### PR TITLE
fix: simplify NodePoolTemplate provider by using ClusterInfo struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ KARPENTER_VERSION ?= $(shell git tag --sort=committerdate | tail -1 | cut -d"v" 
 KO_DOCKER_REPO ?= ko.local
 KOCACHE ?= ~/.ko
 
+# GCP Cluster Context
+PROJECT_ID ?= karpenter-provider-gcp
+CLUSTER_NAME ?= karpenter-provider-gcp
+CLUSTER_LOCATION ?= us-central1
+
 # Common Directories
 MOD_DIRS = $(shell find . -path "./website" -prune -o -name go.mod -type f -print | xargs dirname)
 KARPENTER_CORE_DIR = $(shell go list -m -f '{{ .Dir }}' sigs.k8s.io/karpenter)
@@ -35,6 +40,8 @@ run: ## Run Karpenter controller binary against your local cluster
 		KUBERNETES_MIN_VERSION="v1.26.0" \
 		DISABLE_LEADER_ELECTION=true \
 		CLUSTER_NAME=${CLUSTER_NAME} \
+		PROJECT_ID=${PROJECT_ID} \
+		CLUSTER_LOCATION=${CLUSTER_LOCATION} \
 		INTERRUPTION_QUEUE=${CLUSTER_NAME} \
 		FEATURE_GATES="SpotToSpotConsolidation=true" \
 		go run ./cmd/controller/main.go

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-CLUSTER_NAME ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].name}' | rev | cut -d"/" -f1 | rev | cut -d"." -f1)
-
 ## Inject the app version into operator.Version
 LDFLAGS ?= -ldflags=-X=sigs.k8s.io/karpenter/pkg/operator.Version=$(shell git describe --tags --always | cut -d"v" -f2)
 
@@ -18,7 +16,7 @@ KOCACHE ?= ~/.ko
 # GCP Cluster Context
 PROJECT_ID ?= karpenter-provider-gcp
 CLUSTER_NAME ?= karpenter-provider-gcp
-CLUSTER_LOCATION ?= us-central1
+REGION ?= us-central1
 
 # Common Directories
 MOD_DIRS = $(shell find . -path "./website" -prune -o -name go.mod -type f -print | xargs dirname)
@@ -41,7 +39,7 @@ run: ## Run Karpenter controller binary against your local cluster
 		DISABLE_LEADER_ELECTION=true \
 		CLUSTER_NAME=${CLUSTER_NAME} \
 		PROJECT_ID=${PROJECT_ID} \
-		CLUSTER_LOCATION=${CLUSTER_LOCATION} \
+		REGION=${REGION} \
 		INTERRUPTION_QUEUE=${CLUSTER_NAME} \
 		FEATURE_GATES="SpotToSpotConsolidation=true" \
 		go run ./cmd/controller/main.go

--- a/examples/crds/default-gcenodeclass.yaml
+++ b/examples/crds/default-gcenodeclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: karpenter.k8s.gcp/v1alpha1
+kind: GCENodeClass
+metadata:
+  name: default-example
+spec:
+  imageSelectorTerms:
+    - alias: ContainerOptimizedOS
+  tags:
+    env: dev

--- a/examples/crds/ubuntu-gcenodeclass.yaml
+++ b/examples/crds/ubuntu-gcenodeclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: karpenter.k8s.gcp/v1alpha1
+kind: GCENodeClass
+metadata:
+  name: default-ubuntu
+spec:
+  imageSelectorTerms:
+    - alias: Ubuntu
+  tags:
+    env: dev

--- a/examples/deploy/terraform/main.tf
+++ b/examples/deploy/terraform/main.tf
@@ -1,0 +1,82 @@
+variable "common_name" {
+  type = string
+  default = "karpenter-provider-gcp"
+}
+
+variable "google_region" {
+  type = string
+  default = "us-central1"
+}
+
+variable "project_id" {
+  type = string
+  default = "karpenter-provider-gcp"
+}
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "6.28.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+}
+
+resource "google_compute_network" "default" {
+  name = var.common_name
+
+  auto_create_subnetworks  = false
+  enable_ula_internal_ipv6 = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name = var.common_name
+
+  ip_cidr_range = "10.0.0.0/24"
+  region        = var.google_region
+
+  network = google_compute_network.default.id
+  secondary_ip_range {
+    range_name    = "services-range"
+    ip_cidr_range = "10.10.0.0/22"
+  }
+
+  secondary_ip_range {
+    range_name    = "pod-ranges"
+    ip_cidr_range = "10.100.0.0/20"
+  }
+}
+
+resource "google_container_cluster" "default" {
+  name = var.common_name
+
+  location                 = var.google_region
+
+  network    = google_compute_network.default.id
+  subnetwork = google_compute_subnetwork.default.id
+
+  monitoring_config {
+    enable_components = []
+    managed_prometheus {
+        enabled = false
+    }
+  }
+
+  logging_config {
+    enable_components = []
+  }
+
+  ip_allocation_policy {
+    services_secondary_range_name = google_compute_subnetwork.default.secondary_ip_range[0].range_name
+    cluster_secondary_range_name  = google_compute_subnetwork.default.secondary_ip_range[1].range_name
+  }
+
+  deletion_protection = false
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/karpenter/pkg/operator"
 
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/operator/options"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/imagefamily"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/nodepooltemplate"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/version"
@@ -54,8 +55,16 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	}
 
 	versionProvider := version.NewDefaultProvider(operator.KubernetesInterface)
-	nodeTemplateProvider := nodepooltemplate.NewDefaultProvider(operator.GetClient(),
-		computeService, containerService, versionProvider)
+	nodeTemplateProvider := nodepooltemplate.NewDefaultProvider(
+		ctx,
+		operator.GetClient(),
+		computeService,
+		containerService,
+		versionProvider,
+		options.FromContext(ctx).ClusterName,
+		options.FromContext(ctx).Region,
+		options.FromContext(ctx).ProjectID,
+	)
 	imageProvider := imagefamily.NewDefaultProvider(versionProvider, nodeTemplateProvider)
 
 	return ctx, &Operator{

--- a/pkg/operator/options/option_validation.go
+++ b/pkg/operator/options/option_validation.go
@@ -1,0 +1,40 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"fmt"
+
+	"go.uber.org/multierr"
+)
+
+func (o *Options) Validate() error {
+	return multierr.Combine(
+		o.validateRequiredFields(),
+	)
+}
+
+func (o *Options) validateRequiredFields() error {
+	if o.ProjectID == "" {
+		return fmt.Errorf("missing required flag %s or env var %s", projectIDFlagName, projectIDEnvVarName)
+	}
+	if o.ClusterName == "" {
+		return fmt.Errorf("missing required flag %s or env var %s", gkeClusterFlagName, gkeClusterNameEnvVarName)
+	}
+	if o.Region == "" {
+		return fmt.Errorf("missing required flag %s or env var %s", regionFlagName, regionEnvVarName)
+	}
+	return nil
+}

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -1,0 +1,82 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
+	"sigs.k8s.io/karpenter/pkg/utils/env"
+)
+
+const (
+	projectIDEnvVarName      = "PROJECT_ID"
+	projectIDFlagName        = "project-id"
+	regionEnvVarName         = "REGION"
+	regionFlagName           = "region"
+	gkeClusterNameEnvVarName = "CLUSTER_NAME"
+	gkeClusterFlagName       = "cluster-name"
+)
+
+func init() {
+	coreoptions.Injectables = append(coreoptions.Injectables, &Options{})
+}
+
+type optionsKey struct{}
+
+type Options struct {
+	ProjectID   string
+	Region      string
+	ClusterName string
+}
+
+func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
+	fs.StringVar(&o.ProjectID, projectIDFlagName, env.WithDefaultString(projectIDEnvVarName, ""), "GCP project ID where the GKE cluster is running.")
+	fs.StringVar(&o.Region, regionFlagName, env.WithDefaultString(regionEnvVarName, ""), "GCP region of the GKE cluster. If not set, the controller will attempt to infer it.")
+	fs.StringVar(&o.ClusterName, gkeClusterFlagName, env.WithDefaultString(gkeClusterNameEnvVarName, ""), "Name of the GKE cluster that provisioned nodes should connect to.")
+}
+
+func (o *Options) Parse(fs *coreoptions.FlagSet, args ...string) error {
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		return fmt.Errorf("parsing flags, %w", err)
+	}
+	if err := o.Validate(); err != nil {
+		return fmt.Errorf("validating options, %w", err)
+	}
+	return nil
+}
+
+func (o *Options) ToContext(ctx context.Context) context.Context {
+	return ToContext(ctx, o)
+}
+
+func ToContext(ctx context.Context, opts *Options) context.Context {
+	return context.WithValue(ctx, optionsKey{}, opts)
+}
+
+func FromContext(ctx context.Context) *Options {
+	retval := ctx.Value(optionsKey{})
+	if retval == nil {
+		return nil
+	}
+	return retval.(*Options)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

fix

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR removes the dependency on existing NodePools by switching to direct GCP API calls for retrieving cluster and node pool information. This change enables more flexible and resilient bootstrapping workflows by eliminating the requirement for a default (empty) NodePool to exist in advance.

Additionally, this resolves a bug where templated NodePools would not run if a matching node template already existed. Reconciliation now works as expected in these scenarios.

Key updates:

- Introduced a ClusterInfo struct to encapsulate project, region, cluster name, and zones.
- These values are now configured via environment variables for easier setup.
- Refactored functions to accept ClusterInfo instead of individual parameters, improving code clarity and maintainability.
- Improved logging and error messages to enhance visibility and make debugging easier.
- Added example CRDs and Terraform files to assist with testing and setup.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

none

#### Special notes for your reviewer:

none

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

none 