### PR TITLE
remove hardcoded credentials path

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -22,7 +22,6 @@ import (
 
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
-	"google.golang.org/api/option"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/karpenter/pkg/operator"
 
@@ -43,12 +42,12 @@ type Operator struct {
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
-	computeService, err := compute.NewService(ctx, option.WithCredentialsFile("demo/account.json"))
+	computeService, err := compute.NewService(ctx)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to create compute service")
 		os.Exit(1)
 	}
-	containerService, err := container.NewService(ctx, option.WithCredentialsFile("demo/account.json"))
+	containerService, err := container.NewService(ctx)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to create container service")
 		os.Exit(1)


### PR DESCRIPTION
Removed the hardcoded credentials path while creating the client 


#### What type of PR is this?

Cleanup


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
The current code relies on service account keys stored in demo/account.json. However, a better practice is to leverage Google Cloud's Application Default Credentials (ADC). With ADC, the Google Cloud client libraries automatically detect and use the appropriate credentials without explicitly specifying a key file, enhancing both security and flexibility in different deployment environments

#### Special notes for your reviewer:
Now whenever you run the script all you have to do is export the service key using 
```
export GOOGLE_APPLICATION_CREDENTIALS=<path>
```

#### Does this PR introduce a user-facing change?
Yes 