### PR TITLE
Fix deadlock on instancetype provider List() invokation

### DIFF
--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -73,9 +73,6 @@ func NewDefaultProvider(ctx context.Context, authOptions *auth.Credential) *Defa
 }
 
 func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1alpha1.GCENodeClass) ([]*cloudprovider.InstanceType, error) {
-	p.muCache.Lock()
-	defer p.muCache.Unlock()
-
 	vmTypes, err := p.getInstanceTypes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing instance types: %w", err)


### PR DESCRIPTION
List was locking mutex in the beging of invokation and then called getInstanceTypes which also tried to acquire the lock. Lock acquirition was dropped from List() function cause it doesn't directly interacts with the cache, so it doesn't need it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug