### PR TITLE
feature: support manage operations on GCE instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ go.work.sum
 .vscode/
 .DS_Store
 demo
+
+_go

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,9 @@ download: ## Run "go mod download"
 codegen: ## Auto generate files based on GCP APIs
 	./hack/codegen.sh
 
+crds: ## Apply CRDs
+	kubectl apply -f charts/karpenter/crds/
+
 .PHONY: help presubmit run ut-test coverage update verify image apply delete toolchain tidy download
 
 define newline

--- a/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: gcenodeclasses.karpenter.k8s.gcp
 spec:
   group: karpenter.k8s.gcp
@@ -46,9 +46,26 @@ spec:
               GCENodeClassSpec is the top level specification for the GCP Karpenter Provider.
               This will contain the configuration necessary to launch instances in GCP.
             properties:
+              disk:
+                description: Disk defines the boot disk to attach to the instance.
+                properties:
+                  sizeGiB:
+                    description: SizeGiB is the size of the boot disk
+                    format: int32
+                    minimum: 10
+                    type: integer
+                  type:
+                    description: Type of the disk (e.g., pd-standard, pd-balanced,
+                      pd-ssd)
+                    type: string
+                required:
+                - sizeGiB
+                - type
+                type: object
               imageSelectorTerms:
-                description: ImageSelectorTerms is a list of or image selector terms.
-                  The terms are ORed.
+                description: |-
+                  ImageSelectorTerms is a list of or image selector terms. The terms are ORed.
+                  Remove or adjust mutual exclusivity rules since there's only one field
                 items:
                   description: |-
                     ImageSelectorTerm defines selection logic for an image used by Karpenter to launch nodes.
@@ -56,10 +73,8 @@ spec:
                   properties:
                     alias:
                       description: |-
-                        Alias specifies which ACK image to select.
-                        Each alias consists of a family and an image version, specified as "family@version".
+                        Alias specifies which GKE image to select.
                         Valid families include: ContainerOptimizedOS,Ubuntu
-                        Setting the version to latest will result in drift when a new Image is released. This is **not** recommended for production environments.
                       maxLength: 30
                       type: string
                       x-kubernetes-validations:
@@ -69,25 +84,14 @@ spec:
                       - message: 'family is not supported, must be one of the following:
                           ''ContainerOptimizedOS,Ubuntu'''
                         rule: self.find('^[^@]+') in ['ContainerOptimizedOS', 'Ubuntu']
-                    id:
-                      description: ID is the image id in ECS
-                      type: string
                   type: object
                 maxItems: 30
                 minItems: 1
                 type: array
                 x-kubernetes-validations:
-                - message: expected at least one, got none, ['id', 'alias']
-                  rule: self.all(x, has(x.id) || has(x.alias))
-                - message: '''id'' is mutually exclusive, cannot be set with a combination
-                    of other fields in imageSelectorTerms'
-                  rule: '!self.exists(x, has(x.id) && (has(x.alias)))'
-                - message: '''alias'' is mutually exclusive, cannot be set with a
-                    combination of other fields in imageSelectorTerms'
-                  rule: '!self.exists(x, has(x.alias) && (has(x.id)))'
-                - message: '''alias'' is mutually exclusive, cannot be set with a
-                    combination of other imageSelectorTerms'
-                  rule: '!(self.exists(x, has(x.alias)) && self.size() != 1)'
+                - message: '''alias'' is improperly formatted, must match the format
+                    ''family'''
+                  rule: self.all(x, has(x.alias))
               kubeletConfiguration:
                 description: |-
                   KubeletConfiguration defines args to be used when configuring kubelet on provisioned nodes.
@@ -211,6 +215,34 @@ spec:
                     evictionSoft
                   rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e,
                     (e in self.evictionSoft)):true
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains key/value pairs to set as instance
+                  metadata
+                type: object
+              serviceAccount:
+                description: ServiceAccount is the GCP IAM service account email to
+                  assign to the instance
+                pattern: ^[^@]+@[^@]+\.iam\.gserviceaccount\.com$
+                type: string
+              subnetworkSelectorTerms:
+                description: SubnetworkSelectorTerms is a list of subnetwork selector
+                  terms. The terms are ORed.
+                items:
+                  properties:
+                    name:
+                      description: Name of the subnetwork (optional)
+                      type: string
+                    tags:
+                      additionalProperties:
+                        type: string
+                      description: Tags is a map of labels used to select subnetworks
+                      type: object
+                  type: object
+                maxItems: 30
+                minItems: 1
+                type: array
               tags:
                 additionalProperties:
                   type: string
@@ -232,6 +264,8 @@ spec:
                   rule: self.all(k, k !='karpenter.k8s.gcp/gcenodeclass')
             required:
             - imageSelectorTerms
+            - serviceAccount
+            - subnetworkSelectorTerms
             type: object
           status:
             description: GCENodeClassStatus contains the resolved state of the GCENodeClass

--- a/charts/karpenter/crds/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter/crds/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/charts/karpenter/crds/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter/crds/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -35,6 +35,7 @@ func main() {
 		op.GetClient(),
 		op.EventRecorder,
 		op.InstanceTypeProvider,
+		op.InstanceProvider,
 	)
 
 	lo.Must0(op.AddHealthzCheck("cloud-provider", gcpCloudProvider.LivenessProbe))
@@ -54,6 +55,7 @@ func main() {
 		WithControllers(ctx, controllers.NewController(
 			ctx,
 			op.GetClient(),
+			op.KubernetesInterface,
 			op.ImagesProvider,
 			op.NodePoolTemplateProvider,
 			op.InstanceTypeProvider,

--- a/examples/nodeclaim/default-nodeclaim.yaml
+++ b/examples/nodeclaim/default-nodeclaim.yaml
@@ -1,0 +1,24 @@
+apiVersion: karpenter.sh/v1
+kind: NodeClaim
+metadata:
+  name: example-nodeclaim
+  labels:
+    karpenter.sh/nodepool: default-nodepool
+spec:
+  nodeClassRef:
+    name: default-example
+    kind: GCENodeClass
+    group: karpenter.k8s.gcp
+  requirements:
+    - key: "karpenter.sh/capacity-type"
+      operator: In
+      values: ["on-demand"]
+    - key: "kubernetes.io/arch"
+      operator: In
+      values: ["amd64"]
+    - key: "topology.kubernetes.io/zone"
+      operator: In
+      values: ["us-central1-c", "us-central1-a", "us-central1-f", "us-central1-b"]
+    - key: "node.kubernetes.io/instance-type"
+      operator: In
+      values: ["e2-standard-2"]

--- a/examples/nodeclass/default-gcenodeclass.yaml
+++ b/examples/nodeclass/default-gcenodeclass.yaml
@@ -3,6 +3,9 @@ kind: GCENodeClass
 metadata:
   name: default-example
 spec:
+  serviceAccount: <fill-me>
+  subnetworkSelectorTerms:
+    - name: karpenter-provider-gcp
   imageSelectorTerms:
     - alias: ContainerOptimizedOS
   tags:

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.20.0
 	sigs.k8s.io/karpenter v1.2.0
 )
@@ -85,7 +86,6 @@ require (
 	k8s.io/csi-translation-lib v0.32.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,6 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
-github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/samber/lo v1.49.1 h1:4BIFyVfuQSEpluc7Fua+j1NolZHiEHEpaSEKdsH0tew=
 github.com/samber/lo v1.49.1/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
@@ -172,8 +170,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -16,22 +16,30 @@ package cloudprovider
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/awslabs/operatorpkg/status"
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/events"
+	"sigs.k8s.io/karpenter/pkg/utils/resources"
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
+	cloudproviderevents "github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/cloudprovider/events"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instance"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instancetype"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
 )
 
 const CloudProviderName = "gcp"
@@ -43,32 +51,144 @@ type CloudProvider struct {
 	recorder   events.Recorder
 
 	instanceTypeProvider instancetype.Provider
+	instanceProvider     instance.Provider
 }
 
 func New(kubeClient client.Client,
 	recorder events.Recorder,
 	instanceTypeProvider instancetype.Provider,
+	instanceProvider instance.Provider,
 ) *CloudProvider {
 	return &CloudProvider{
 		kubeClient:           kubeClient,
 		recorder:             recorder,
 		instanceTypeProvider: instanceTypeProvider,
+		instanceProvider:     instanceProvider,
 	}
 }
 
 // Create a NodeClaim given the constraints.
 func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*karpv1.NodeClaim, error) {
-	return nil, fmt.Errorf("not implemented")
+	log.FromContext(ctx).Info("creating nodes", "nodeClaim", nodeClaim)
+	nodeClass, err := c.resolveNodeClassFromNodeClaim(ctx, nodeClaim)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			c.recorder.Publish(cloudproviderevents.NodeClaimFailedToResolveNodeClass(nodeClaim))
+		}
+		return nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("resolving node class, %w", err))
+	}
+
+	nodeClassReady := nodeClass.StatusConditions().Get(status.ConditionReady)
+	if nodeClassReady.IsFalse() {
+		return nil, cloudprovider.NewNodeClassNotReadyError(stderrors.New(nodeClassReady.Message))
+	}
+	if nodeClassReady.IsUnknown() {
+		return nil, cloudprovider.NewCreateError(fmt.Errorf("resolving NodeClass readiness, NodeClass is in Ready=Unknown, %s", nodeClassReady.Message), "NodeClassReadinessUnknown", "NodeClass is in Ready=Unknown")
+	}
+
+	instanceTypes, err := c.resolveInstanceTypes(ctx, nodeClass)
+	if err != nil {
+		return nil, cloudprovider.NewCreateError(fmt.Errorf("resolving instance types, %w", err), "InstanceTypeResolutionFailed", "Error resolving instance types")
+	}
+	if len(instanceTypes) == 0 {
+		return nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("all requested instance types were unavailable during launch"))
+	}
+
+	instance, err := c.instanceProvider.Create(ctx, nodeClass, nodeClaim, instanceTypes)
+	if err != nil {
+		return nil, fmt.Errorf("creating instance, %w", err)
+	}
+
+	instanceType, _ := lo.Find(instanceTypes, func(i *cloudprovider.InstanceType) bool {
+		return i.Name == instance.Type
+	})
+
+	nc := c.instanceToNodeClaim(instance, instanceType)
+	nc.Annotations = lo.Assign(nc.Annotations, map[string]string{
+		v1alpha1.AnnotationGCENodeClassHash:        nodeClass.Hash(),
+		v1alpha1.AnnotationGCENodeClassHashVersion: v1alpha1.GCENodeClassHashVersion,
+	})
+	return nc, nil
 }
 
 func (c *CloudProvider) List(ctx context.Context) ([]*karpv1.NodeClaim, error) {
-	return nil, fmt.Errorf("not implemented")
+	log.FromContext(ctx).Info("listing instances from instance provider")
+	instances, err := c.instanceProvider.List(ctx)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to list instances")
+		return nil, fmt.Errorf("listing instances, %w", err)
+	}
 
+	var nodeClaims []*karpv1.NodeClaim
+	for i := range instances {
+		log.FromContext(ctx).Info("resolving instance type")
+		instanceType, err := c.resolveInstanceTypeFromInstance(ctx, instances[i])
+		if err != nil {
+			log.FromContext(ctx).Error(err, "failed to resolve instance type")
+			return nil, fmt.Errorf("resolving instance type, %w", err)
+		}
+
+		nodeClaim := c.instanceToNodeClaim(instances[i], instanceType)
+		log.FromContext(ctx).Info("converted instance to nodeclaim", "nodeClaimName", nodeClaim.Name)
+		nodeClaims = append(nodeClaims, nodeClaim)
+	}
+
+	log.FromContext(ctx).Info("listed all nodeclaims", "count", len(nodeClaims))
+	return nodeClaims, nil
+}
+
+func (c *CloudProvider) resolveInstanceTypeFromInstance(ctx context.Context, instance *instance.Instance) (*cloudprovider.InstanceType, error) {
+	nodePool, err := c.resolveNodePoolFromInstance(ctx, instance)
+	if err != nil {
+		return nil, client.IgnoreNotFound(fmt.Errorf("resolving nodepool, %w", err))
+	}
+
+	instanceTypes, err := c.GetInstanceTypes(ctx, nodePool)
+	if err != nil {
+		return nil, client.IgnoreNotFound(fmt.Errorf("getting instance types, %w", err))
+	}
+
+	instanceType, _ := lo.Find(instanceTypes, func(i *cloudprovider.InstanceType) bool {
+		return i.Name == instance.Type
+	})
+
+	if instanceType == nil {
+		return nil, fmt.Errorf("instance type %s not found in offerings", instance.Type)
+	}
+	return instanceType, nil
+}
+
+func (c *CloudProvider) resolveNodePoolFromInstance(ctx context.Context, instance *instance.Instance) (*karpv1.NodePool, error) {
+	sanitizedKey := utils.SanitizeGCELabelValue(utils.LabelNodePoolKey)
+	nodePoolName := instance.Labels[sanitizedKey]
+	if nodePoolName == "" {
+		return nil, fmt.Errorf("missing nodepool label")
+	}
+
+	var nodePool karpv1.NodePool
+	if err := c.kubeClient.Get(ctx, client.ObjectKey{Name: nodePoolName}, &nodePool); err != nil {
+		return nil, err
+	}
+
+	return &nodePool, nil
 }
 
 func (c *CloudProvider) Get(ctx context.Context, providerID string) (*karpv1.NodeClaim, error) {
-	return nil, fmt.Errorf("not implemented")
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("providerID", providerID))
 
+	instance, err := c.instanceProvider.Get(ctx, providerID)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "getting instance")
+		return nil, fmt.Errorf("getting instance, %w", err)
+	}
+
+	instanceType, err := c.resolveInstanceTypeFromInstance(ctx, instance)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "resolving instance type")
+		return nil, fmt.Errorf("resolving instance type, %w", err)
+	}
+
+	return c.instanceToNodeClaim(instance, instanceType), nil
 }
 
 func (c *CloudProvider) LivenessProbe(req *http.Request) error {
@@ -77,13 +197,12 @@ func (c *CloudProvider) LivenessProbe(req *http.Request) error {
 
 // GetInstanceTypes returns all available InstanceTypes
 func (c *CloudProvider) GetInstanceTypes(ctx context.Context, nodePool *karpv1.NodePool) ([]*cloudprovider.InstanceType, error) {
-	logger := log.FromContext(ctx)
 	nodeClass, err := c.resolveNodeClassFromNodePool(ctx, nodePool)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// If we can't resolve the NodeClass, then it's impossible for us to resolve the instance types
 			// c.recorder.Publish(cloudproviderevents.NodePoolFailedToResolveNodeClass(nodePool))
-			logger.Error(fmt.Errorf("failed to resolve node class"), "nodePool", nodePool)
+			log.FromContext(ctx).Error(fmt.Errorf("failed to resolve node class"), "nodePool", nodePool)
 			return nil, nil
 		}
 		return nil, fmt.Errorf("resolving node class, %w", err)
@@ -110,7 +229,9 @@ func (c *CloudProvider) resolveNodeClassFromNodePool(ctx context.Context, nodePo
 }
 
 func (c *CloudProvider) Delete(ctx context.Context, nodeClaim *karpv1.NodeClaim) error {
-	return fmt.Errorf("not implemented")
+	providerID := nodeClaim.Status.ProviderID
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("id", providerID))
+	return c.instanceProvider.Delete(ctx, providerID)
 }
 
 func (c *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeClaim) (cloudprovider.DriftReason, error) {
@@ -167,4 +288,61 @@ func (c *CloudProvider) Name() string {
 
 func (c *CloudProvider) GetSupportedNodeClasses() []status.Object {
 	return []status.Object{&v1alpha1.GCENodeClass{}}
+}
+
+func (c *CloudProvider) instanceToNodeClaim(i *instance.Instance, instanceType *cloudprovider.InstanceType) *karpv1.NodeClaim {
+	nodeClaim := &karpv1.NodeClaim{}
+	labels := map[string]string{}
+	annotations := map[string]string{}
+
+	if instanceType != nil {
+		labels = utils.GetAllSingleValuedRequirementLabels(instanceType)
+
+		resourceFilter := func(name corev1.ResourceName, value resource.Quantity) bool {
+			return !resources.IsZero(value)
+		}
+
+		nodeClaim.Status.Capacity = lo.PickBy(instanceType.Capacity, resourceFilter)
+		nodeClaim.Status.Allocatable = lo.PickBy(instanceType.Allocatable(), resourceFilter)
+	}
+
+	// Set core labels
+	labels[corev1.LabelTopologyZone] = i.Location
+	labels[karpv1.CapacityTypeLabelKey] = i.CapacityType
+
+	// Add node pool label if present
+	if v, ok := i.Labels[karpv1.NodePoolLabelKey]; ok {
+		labels[karpv1.NodePoolLabelKey] = v
+	}
+
+	nodeClaim.Labels = labels
+	nodeClaim.Annotations = annotations
+	nodeClaim.CreationTimestamp = metav1.Time{Time: i.CreationTime}
+
+	// Handle instance deletion status (e.g., TERMINATED or STOPPING in GCP)
+	if i.Status == instance.InstanceStatusTerminated || i.Status == instance.InstanceStatusStopping {
+		nodeClaim.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	}
+
+	// ProviderID format for GCE: gce://project/zone/instance-name
+	nodeClaim.Status.ProviderID = fmt.Sprintf("gce://%s/%s/%s", i.ProjectID, i.Location, i.Name)
+	nodeClaim.Status.ImageID = i.ImageID
+
+	return nodeClaim
+}
+
+func (c *CloudProvider) resolveNodeClassFromNodeClaim(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*v1alpha1.GCENodeClass, error) {
+	ref := nodeClaim.Spec.NodeClassRef
+	if ref == nil {
+		return nil, fmt.Errorf("nodeClaim missing NodeClassRef")
+	}
+	nodeClass := &v1alpha1.GCENodeClass{}
+	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: ref.Name}, nodeClass); err != nil {
+		return nil, err
+	}
+	return nodeClass, nil
+}
+
+func (c *CloudProvider) resolveInstanceTypes(ctx context.Context, nodeClass *v1alpha1.GCENodeClass) ([]*cloudprovider.InstanceType, error) {
+	return c.instanceTypeProvider.List(ctx, nodeClass)
 }

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -20,8 +20,10 @@ import (
 	"context"
 
 	"github.com/awslabs/operatorpkg/controller"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/csr"
 	nodeclassstatus "github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/nodeclass/status"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/nodepooltemplate"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/providers/instancetype"
@@ -32,13 +34,19 @@ import (
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/pricing"
 )
 
-func NewController(ctx context.Context, kubeClient client.Client, imageProvider imagefamily.Provider,
-	nodePoolTemplateProvider providernodepooltemplate.Provider, instanceTypeProvider providerinstancetype.Provider,
+func NewController(
+	ctx context.Context,
+	kubeClient client.Client,
+	kubernetesInterface kubernetes.Interface,
+	imageProvider imagefamily.Provider,
+	nodePoolTemplateProvider providernodepooltemplate.Provider,
+	instanceTypeProvider providerinstancetype.Provider,
 	pricingProvider pricing.Provider) []controller.Controller {
 	controllers := []controller.Controller{
 		nodeclassstatus.NewController(kubeClient, imageProvider),
 		nodepooltemplate.NewController(nodePoolTemplateProvider),
 		instancetype.NewController(instanceTypeProvider),
+		csr.NewController(kubernetesInterface),
 		controllerspricing.NewController(pricingProvider),
 	}
 

--- a/pkg/controllers/csr/csr.go
+++ b/pkg/controllers/csr/csr.go
@@ -1,0 +1,92 @@
+package csr
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	"github.com/awslabs/operatorpkg/singleton"
+	certv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const KubeletClientSignerName = "kubernetes.io/kube-apiserver-client-kubelet"
+
+type Controller struct {
+	client     client.Client
+	kubeClient kubernetes.Interface
+}
+
+func NewController(kubeClient kubernetes.Interface) *Controller {
+	return &Controller{
+		kubeClient: kubeClient,
+	}
+}
+
+func (c *Controller) Reconcile(ctx context.Context) (reconcile.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("reconciling CertificateSigningRequests")
+
+	var csrList certv1.CertificateSigningRequestList
+	if err := c.client.List(ctx, &csrList); err != nil {
+		logger.Error(err, "unable to list CSRs")
+		return reconcile.Result{}, err
+	}
+
+	for _, csr := range csrList.Items {
+		if isApprovedOrDenied(&csr) {
+			continue
+		}
+
+		if csr.Spec.SignerName != KubeletClientSignerName {
+			continue
+		}
+
+		if !reflect.DeepEqual(csr.Spec.Usages, []certv1.KeyUsage{
+			certv1.UsageDigitalSignature,
+			certv1.UsageKeyEncipherment,
+			certv1.UsageClientAuth,
+		}) {
+			continue
+		}
+
+		logger.Info("approving bootstrap CSR", "name", csr.Name, "username", csr.Spec.Username)
+
+		csr.Status.Conditions = append(csr.Status.Conditions, certv1.CertificateSigningRequestCondition{
+			Type:           certv1.CertificateApproved,
+			Status:         "True",
+			Reason:         "KarpenterAutoApprover",
+			Message:        "Automatically approved by Karpenter CSR controller",
+			LastUpdateTime: metav1.Now(),
+		})
+
+		if _, err := c.kubeClient.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, csr.Name, &csr, metav1.UpdateOptions{}); err != nil {
+			logger.Error(err, "failed to approve CSR", "name", csr.Name)
+			continue
+		}
+	}
+	return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+}
+
+func isApprovedOrDenied(csr *certv1.CertificateSigningRequest) bool {
+	for _, cond := range csr.Status.Conditions {
+		if cond.Type == certv1.CertificateApproved || cond.Type == certv1.CertificateDenied {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Controller) Register(ctx context.Context, m manager.Manager) error {
+	c.client = m.GetClient()
+	return controllerruntime.NewControllerManagedBy(m).
+		Named("csr").
+		WatchesRawSource(singleton.Source()).
+		Complete(singleton.AsReconciler(c))
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/auth"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/operator/options"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/imagefamily"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instance"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instancetype"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/nodepooltemplate"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/pricing"
@@ -44,6 +45,7 @@ type Operator struct {
 	NodePoolTemplateProvider nodepooltemplate.Provider
 	PricingProvider          pricing.Provider
 	InstanceTypeProvider     instancetype.Provider
+	InstanceProvider         instance.Provider
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
@@ -81,11 +83,18 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	}
 	instanceTypeProvider := instancetype.NewDefaultProvider(ctx, &auth)
 
+	instanceProvider := instance.NewProvider(
+		options.FromContext(ctx).Region,
+		options.FromContext(ctx).ProjectID,
+		computeService,
+	)
+
 	return ctx, &Operator{
 		Operator:                 operator,
 		ImagesProvider:           imageProvider,
 		NodePoolTemplateProvider: nodeTemplateProvider,
 		PricingProvider:          pricingProvider,
 		InstanceTypeProvider:     instanceTypeProvider,
+		InstanceProvider:         instanceProvider,
 	}
 }

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -18,11 +18,21 @@ package instance
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
 
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/nodepooltemplate"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
 )
 
 type Provider interface {
@@ -34,36 +44,326 @@ type Provider interface {
 }
 
 type DefaultProvider struct {
-	region string
+	region         string
+	projectID      string
+	computeService *compute.Service
 }
 
-func NewProvider(region string) *DefaultProvider {
+func NewProvider(region, projectID string, computeService *compute.Service) *DefaultProvider {
 	return &DefaultProvider{
-		region: region,
+		region:         region,
+		projectID:      projectID,
+		computeService: computeService,
 	}
 }
 
 func (p *DefaultProvider) Create(ctx context.Context, nodeClass *v1alpha1.GCENodeClass, nodeClaim *karpv1.NodeClaim, instanceTypes []*cloudprovider.InstanceType) (*Instance, error) {
-	// TODO: Implement me
-	return nil, nil
+	if len(instanceTypes) == 0 {
+		return nil, fmt.Errorf("no instance types provided")
+	}
+
+	// all code below must be adjusted with correct logic!
+	// lets always create e2-standard-2 in us-central1-c at least for now
+	instanceType, err := p.selectInstanceType(instanceTypes)
+	if err != nil {
+		return nil, err
+	}
+
+	zone, err := p.selectZone(nodeClaim)
+	if err != nil {
+		return nil, err
+	}
+
+	template, err := p.findTemplateForAlias(ctx, nodeClass.Spec.ImageSelectorTerms[0].Alias)
+	if err != nil {
+		return nil, err
+	}
+
+	instance := p.buildInstance(nodeClaim, nodeClass, instanceType, template, zone)
+
+	op, err := p.computeService.Instances.Insert(p.projectID, zone, instance).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("creating instance: %w", err)
+	}
+
+	// we could wait for the node to be present in kubernetes api via csr sign up
+	// should be done with watcher, for now implemented as a csr controller
+	log.FromContext(ctx).Info("Created instance", "instanceName", op.Name)
+
+	return &Instance{
+		InstanceID:   instance.Name,
+		Name:         instance.Name,
+		Type:         instanceType.Name,
+		Location:     zone,
+		ProjectID:    p.projectID,
+		ImageID:      template.Properties.Disks[0].InitializeParams.SourceImage,
+		CreationTime: time.Now(),
+		CapacityType: karpv1.CapacityTypeOnDemand,
+		Tags:         template.Properties.Labels,
+		Labels:       instance.Labels,
+		Status:       InstanceStatusProvisioning,
+	}, nil
+}
+
+// lets always create e2-standard-2 for now
+func (p *DefaultProvider) selectInstanceType(instanceTypes []*cloudprovider.InstanceType) (*cloudprovider.InstanceType, error) {
+	for _, it := range instanceTypes {
+		if it.Name == "e2-standard-2" {
+			return it, nil
+		}
+	}
+	return nil, fmt.Errorf("instance type e2-standard-2 not found")
+}
+
+// zone should be based on the offering, for now lets return static zone from requirements
+func (p *DefaultProvider) selectZone(nodeClaim *karpv1.NodeClaim) (string, error) {
+	for _, req := range nodeClaim.Spec.Requirements {
+		if req.Key == "topology.kubernetes.io/zone" && len(req.Values) > 0 {
+			return req.Values[0], nil // always select us-central1-c for now
+		}
+	}
+	return "", fmt.Errorf("no zone specified in nodeClaim requirements")
+}
+
+func (p *DefaultProvider) findTemplateForAlias(ctx context.Context, alias string) (*compute.InstanceTemplate, error) {
+	if alias == "" {
+		return nil, fmt.Errorf("alias not specified in ImageSelectorTerm")
+	}
+
+	var expectedLabelValue string
+	switch alias {
+	case "ContainerOptimizedOS":
+		expectedLabelValue = nodepooltemplate.KarpenterDefaultNodePoolTemplate
+	case "Ubuntu":
+		expectedLabelValue = nodepooltemplate.KarpenterUbuntuNodePoolTemplate
+	default:
+		return nil, fmt.Errorf("unsupported image alias %q", alias)
+	}
+
+	instanceTemplates, err := p.computeService.RegionInstanceTemplates.List(p.projectID, p.region).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("cannot list all instance templates for alias %q: %w", alias, err)
+	}
+
+	for _, t := range instanceTemplates.Items {
+		if t.Properties != nil && t.Properties.Labels != nil {
+			if val, ok := t.Properties.Labels["goog-k8s-node-pool-name"]; ok && val == expectedLabelValue {
+				return t, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no instance template found with label goog-k8s-node-pool-name=%s for alias %q", expectedLabelValue, alias)
+}
+
+func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, template *compute.InstanceTemplate, zone string) *compute.Instance {
+	disk := template.Properties.Disks[0]
+	disk.InitializeParams.DiskType = fmt.Sprintf("projects/%s/zones/%s/diskTypes/pd-balanced", p.projectID, zone)
+
+	// disable public IPs
+	for _, ni := range template.Properties.NetworkInterfaces {
+		ni.AccessConfigs = nil
+	}
+
+	instance := &compute.Instance{
+		Name:              fmt.Sprintf("karpenter-%s", nodeClaim.Name),
+		MachineType:       fmt.Sprintf("zones/%s/machineTypes/%s", zone, instanceType.Name),
+		Disks:             []*compute.AttachedDisk{disk},
+		NetworkInterfaces: template.Properties.NetworkInterfaces,
+		ServiceAccounts:   template.Properties.ServiceAccounts,
+		Metadata:          template.Properties.Metadata,
+		Labels:            map[string]string{},
+		Scheduling:        template.Properties.Scheduling,
+		Tags:              template.Properties.Tags,
+	}
+
+	// apply scheduling config for Spot capacity, for now lets do on demand only
+	capacityType := karpv1.CapacityTypeOnDemand
+	if instance.Scheduling == nil {
+		instance.Scheduling = &compute.Scheduling{}
+	}
+	if capacityType == karpv1.CapacityTypeSpot {
+		instance.Scheduling.ProvisioningModel = "SPOT"
+		instance.Scheduling.Preemptible = true
+		instance.Scheduling.AutomaticRestart = ptr.To(false)
+		instance.Scheduling.OnHostMaintenance = "TERMINATE"
+	}
+
+	// set common Karpenter labels
+	instance.Labels[utils.SanitizeGCELabelValue(utils.LabelNodePoolKey)] = nodeClaim.Labels[karpv1.NodePoolLabelKey]
+	instance.Labels[utils.SanitizeGCELabelValue(utils.LabelGCENodeClassKey)] = nodeClass.Name
+
+	return instance
 }
 
 func (p *DefaultProvider) Get(ctx context.Context, providerID string) (*Instance, error) {
-	// TODO: Implement me
-	return nil, nil
+	project, zone, instanceName, err := parseGCEProviderID(providerID)
+	if err != nil {
+		return nil, fmt.Errorf("parsing provider ID: %w", err)
+	}
+
+	log := log.FromContext(ctx)
+	log.Info("Fetching instance", "project", project, "zone", zone, "instance", instanceName)
+
+	resp, err := p.computeService.Instances.Get(project, zone, instanceName).Context(ctx).Do()
+	if err != nil {
+		if isInstanceNotFoundError(err) {
+			return nil, cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("instance not found: %w", err))
+		}
+		return nil, fmt.Errorf("getting instance: %w", err)
+	}
+
+	// Translate Compute API response into internal Instance struct
+	instance := &Instance{
+		InstanceID:   resp.Name,
+		Name:         resp.Name,
+		Type:         resp.MachineType[strings.LastIndex(resp.MachineType, "/")+1:], // extract type from full URI
+		Location:     zone,
+		ProjectID:    project,
+		ImageID:      getBootImageID(resp),
+		CreationTime: parseCreationTime(resp.CreationTimestamp),
+		CapacityType: resolveCapacityType(resp.Scheduling),
+		Labels:       resp.Labels,
+		Tags:         resp.Labels,           // GCP doesn't have separate tags like AWS; labels suffice
+		Status:       InstanceStatusRunning, // consider deriving from resp.Status if needed
+	}
+
+	return instance, nil
+}
+
+func parseCreationTime(ts string) time.Time {
+	parsed, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return time.Now() // fallback
+	}
+	return parsed
+}
+
+func getBootImageID(inst *compute.Instance) string {
+	if len(inst.Disks) > 0 && inst.Disks[0].InitializeParams != nil {
+		return inst.Disks[0].InitializeParams.SourceImage
+	}
+	return ""
+}
+
+func resolveCapacityType(sched *compute.Scheduling) string {
+	if sched != nil && sched.ProvisioningModel == "SPOT" {
+		return karpv1.CapacityTypeSpot
+	}
+	return karpv1.CapacityTypeOnDemand
 }
 
 func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
-	// TODO: Implement me
-	return nil, nil
+	var instances []*Instance
+	filter := fmt.Sprintf(
+		"(labels.%s:* AND labels.%s:*)",
+		utils.SanitizeGCELabelValue(utils.LabelNodePoolKey),
+		utils.SanitizeGCELabelValue(utils.LabelGCENodeClassKey))
+
+	zones, err := p.getZonesInRegion(ctx)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "getting zones in region")
+		return nil, fmt.Errorf("listing zones, %w", err)
+	}
+
+	for _, zone := range zones {
+		req := p.computeService.Instances.List(p.projectID, zone).Filter(filter).Context(ctx)
+
+		err := req.Pages(ctx, func(page *compute.InstanceList) error {
+			if len(page.Items) == 0 {
+				log.FromContext(ctx).Info("No instances found in zone", "zone", zone)
+				return nil // empty page, continue
+			}
+
+			for _, inst := range page.Items {
+				instances = append(instances, &Instance{
+					InstanceID:   inst.Name,
+					Name:         inst.Name,
+					Type:         inst.MachineType[strings.LastIndex(inst.MachineType, "/")+1:], // just for matching "e2-standard-2"
+					Location:     zone,
+					ProjectID:    p.projectID,
+					ImageID:      getBootImageID(inst),
+					CreationTime: parseCreationTime(inst.CreationTimestamp),
+					CapacityType: resolveCapacityType(inst.Scheduling),
+					Labels:       inst.Labels,
+					Tags:         inst.Labels,
+					Status:       InstanceStatusRunning, // consider mapping from inst.Status
+				})
+			}
+			return nil
+		})
+
+		if err != nil {
+			log.FromContext(ctx).Error(err, "error listing instances in zone", "zone", zone)
+			return nil, fmt.Errorf("listing instances in zone %s: %w", zone, err)
+		}
+	}
+
+	log.FromContext(ctx).Info("finished listing GCP instances", "total", len(instances))
+	return instances, nil
+}
+
+func (p *DefaultProvider) getZonesInRegion(ctx context.Context) ([]string, error) {
+	region, err := p.computeService.Regions.Get(p.projectID, p.region).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	var zones []string
+	for _, zoneURL := range region.Zones {
+		parts := strings.Split(zoneURL, "/")
+		zones = append(zones, parts[len(parts)-1])
+	}
+	return zones, nil
 }
 
 func (p *DefaultProvider) Delete(ctx context.Context, providerID string) error {
-	// TODO: Implement me
+	project, zone, instance, err := parseGCEProviderID(providerID)
+	if err != nil {
+		return fmt.Errorf("parsing provider ID: %w", err)
+	}
+
+	log.FromContext(ctx).Info("Deleting instance", "project", project, "zone", zone, "instance", instance)
+
+	op, err := p.computeService.Instances.Delete(project, zone, instance).Context(ctx).Do()
+	if err != nil {
+		if isInstanceNotFoundError(err) {
+			log.FromContext(ctx).Info("Instance already deleted or not found", "instance", instance)
+			return cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("instance not found: %w", err))
+		}
+		return fmt.Errorf("deleting instance: %w", err)
+	}
+
+	log.FromContext(ctx).Info("Delete operation started", "operation", op.Name)
 	return nil
 }
 
 func (p *DefaultProvider) CreateTags(ctx context.Context, providerID string, tags map[string]string) error {
 	// TODO: Implement me
 	return nil
+}
+
+func parseGCEProviderID(providerID string) (project, zone, instance string, err error) {
+	const prefix = "gce://"
+	if !strings.HasPrefix(providerID, prefix) {
+		err = fmt.Errorf("unexpected providerID format: %s", providerID)
+		return
+	}
+
+	parts := strings.Split(strings.TrimPrefix(providerID, prefix), "/")
+	if len(parts) != 3 {
+		err = fmt.Errorf("invalid GCE providerID, expected format gce://project/zone/instance")
+		return
+	}
+
+	project, zone, instance = parts[0], parts[1], parts[2]
+	return
+}
+
+func isInstanceNotFoundError(err error) bool {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		return apiErr.Code == 404
+	}
+	return false
 }

--- a/pkg/providers/instance/types.go
+++ b/pkg/providers/instance/types.go
@@ -34,15 +34,17 @@ const (
 )
 
 type Instance struct {
-	CreationTime     time.Time         `json:"creationTime"`
-	Status           string            `json:"status"`
-	ID               string            `json:"id"`
-	ImageID          string            `json:"imageId"`
-	Type             string            `json:"type"`
-	Region           string            `json:"region"`
-	Zone             string            `json:"zone"`
-	CapacityType     string            `json:"capacityType"`
-	SecurityGroupIDs []string          `json:"securityGroupIds"`
-	VSwitchID        string            `json:"vSwitchId"`
-	Tags             map[string]string `json:"tags"`
+	CapacityReservationID string            `json:"capacityReservationId"`
+	CapacityType          string            `json:"capacityType"`
+	CreationTime          time.Time         `json:"creationTime"`
+	ImageID               string            `json:"imageId"`
+	InstanceID            string            `json:"instanceId"`
+	InstanceTemplate      string            `json:"instanceTemplate"`
+	Labels                map[string]string `json:"labels"`
+	Location              string            `json:"location"`
+	Name                  string            `json:"name"`
+	ProjectID             string            `json:"projectId"`
+	Status                string            `json:"status"`
+	Tags                  map[string]string `json:"tags"`
+	Type                  string            `json:"type"`
 }

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -134,9 +134,6 @@ func (p *DefaultProvider) UpdateInstanceTypes(ctx context.Context) error {
 }
 
 func (p *DefaultProvider) getInstanceTypes(ctx context.Context) ([]*computepb.MachineType, error) {
-	p.muCache.Lock()
-	defer p.muCache.Unlock()
-
 	if cached, ok := p.cache.Get(InstanceTypesCacheKey); ok {
 		return cached.([]*computepb.MachineType), nil
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,48 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"regexp"
+	"strings"
+
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+)
+
+const (
+	LabelNodePoolKey     string = "karpenter.sh/nodepool"
+	LabelGCENodeClassKey string = "karpenter.k8s.gcp/gcenodeclass"
+)
+
+func GetAllSingleValuedRequirementLabels(instanceType *cloudprovider.InstanceType) map[string]string {
+	labels := map[string]string{}
+	if instanceType == nil {
+		return labels
+	}
+	for key, req := range instanceType.Requirements {
+		if req.Len() == 1 {
+			labels[key] = req.Values()[0]
+		}
+	}
+	return labels
+}
+
+func SanitizeGCELabelValue(s string) string {
+	re := regexp.MustCompile("[^a-zA-Z0-9]+")
+	sanitized := re.ReplaceAllString(s, "-")
+
+	sanitized = strings.Trim(sanitized, "-")
+	return strings.ToLower(sanitized)
+}


### PR DESCRIPTION
This adds full support for creating, listing, getting and deleting GCP instances through the Karpenter CloudProvider. It also includes label sanitization, proper instance filtering, and a basic CSR auto-approver. Example manifests and CRDs were updated to reflect the new fields.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR supports the instance CRUD operator in provider, and those are the basic API to support karpenter auto management.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7 

Reference PR #28 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```