### PR TITLE
chore: add env auth for gcp metadata.

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -57,6 +57,8 @@ type Operator struct {
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
+	os.Setenv(options.GCPAuth, options.FromContext(ctx).GCPAuth)
+
 	computeService, err := compute.NewService(ctx)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to create compute service")

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -33,6 +33,7 @@ const (
 	gkeClusterNameEnvVarName = "CLUSTER_NAME"
 	gkeClusterFlagName       = "cluster-name"
 	gkeEnableInterruption    = "INTERRUPTION"
+	GCPAuth                  = "GOOGLE_APPLICATION_CREDENTIALS"
 )
 
 func init() {
@@ -42,9 +43,12 @@ func init() {
 type optionsKey struct{}
 
 type Options struct {
-	ProjectID    string
-	Region       string
-	ClusterName  string
+	ProjectID   string
+	Region      string
+	ClusterName string
+	// GCPAuth is the path to the Google Application Credentials JSON file.
+	// https://cloud.google.com/docs/authentication/application-default-credentials
+	GCPAuth      string
 	Interruption bool
 }
 
@@ -52,6 +56,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.ProjectID, projectIDFlagName, env.WithDefaultString(projectIDEnvVarName, ""), "GCP project ID where the GKE cluster is running.")
 	fs.StringVar(&o.Region, regionFlagName, env.WithDefaultString(regionEnvVarName, ""), "GCP region of the GKE cluster. If not set, the controller will attempt to infer it.")
 	fs.StringVar(&o.ClusterName, gkeClusterFlagName, env.WithDefaultString(gkeClusterNameEnvVarName, ""), "Name of the GKE cluster that provisioned nodes should connect to.")
+	fs.StringVar(&o.GCPAuth, GCPAuth, env.WithDefaultString(GCPAuth, ""), "Path to the Google Application Credentials JSON file. If not set, the controller will use the default credentials from the environment.")
 	fs.BoolVar(&o.Interruption, gkeEnableInterruption, env.WithDefaultBool(gkeEnableInterruption, true), "Enable interruption handling.")
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add config env for google application credential and read metadata with auth json file.

> Refer: https://cloud.google.com/docs/authentication/application-default-credentials

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
chore: add env auth for gcp metadata.
```