### PR TITLE
fix: choose node template for current cluster in case of mixed cluster csr.

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -93,6 +93,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	}
 
 	instanceProvider := instance.NewProvider(
+		options.FromContext(ctx).ClusterName,
 		options.FromContext(ctx).Region,
 		options.FromContext(ctx).ProjectID,
 		computeService,

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -147,6 +147,7 @@ func (p *DefaultProvider) selectZone(nodeClaim *karpv1.NodeClaim) (string, error
 	return "", fmt.Errorf("no zone specified in nodeClaim requirements")
 }
 
+//nolint:gocyclo
 func (p *DefaultProvider) findTemplateForAlias(ctx context.Context, alias string) (*compute.InstanceTemplate, error) {
 	if alias == "" {
 		return nil, fmt.Errorf("alias not specified in ImageSelectorTerm")
@@ -169,7 +170,8 @@ func (p *DefaultProvider) findTemplateForAlias(ctx context.Context, alias string
 
 	for _, t := range instanceTemplates.Items {
 		if t.Properties != nil && t.Properties.Labels != nil {
-			// Need to check instanceTemplates in current cluster
+			// instanceTemplates are shared across clusters, so we need to check if the template belongs to the current cluster
+			// This is done by checking the metadata for the cluster name label.
 			if t.Properties.Metadata != nil {
 				metadataClusterNamemetadata, err := metadata.GetClusterName(t.Properties.Metadata)
 				if err != nil {

--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2025 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-openapi/swag"
+	"github.com/samber/lo"
+	"google.golang.org/api/compute/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func GetClusterName(metadata *compute.Metadata) (string, error) {
+	// Get cluster name
+	clusterNameEntry := lo.Filter(metadata.Items, func(item *compute.MetadataItems, _ int) bool {
+		return item.Key == ClusterNameLabel
+	})
+	if len(clusterNameEntry) != 1 {
+		return "", errors.New("cluster name label not found")
+	}
+	clusterName := swag.StringValue(clusterNameEntry[0].Value)
+	if clusterName == "" {
+		return "", errors.New("cluster name label is empty")
+	}
+	log.FromContext(context.Background()).Info("retrieved cluster name from metadata", "clusterName", clusterName)
+	return clusterName, nil
+}
+
+func RemoveGKEBuiltinLabels(metadata *compute.Metadata) error {
+	// Get cluster name
+	clusterNameEntry := lo.Filter(metadata.Items, func(item *compute.MetadataItems, _ int) bool {
+		return item.Key == ClusterNameLabel
+	})
+	if len(clusterNameEntry) != 1 {
+		return errors.New("cluster name label not found")
+	}
+	clusterName := swag.StringValue(clusterNameEntry[0].Value)
+	nodePoolLabelEntry := fmt.Sprintf("%s=%s", GKENodePoolLabel, clusterName)
+
+	// Remove nodePoolLabelEntry from `kube-labels` and `kube-env`
+	for _, item := range metadata.Items {
+		if item.Key == "kube-labels" {
+			item.Value = swag.String(strings.ReplaceAll(swag.StringValue(item.Value), nodePoolLabelEntry, ""))
+		}
+		if item.Key == "kube-env" {
+			item.Value = swag.String(strings.ReplaceAll(swag.StringValue(item.Value), nodePoolLabelEntry, ""))
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Current `Create` function will choose first node template, and this template is shared in current workspace. Template with wrong metadata will cause init error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: choose node template for current cluster in case of mixed cluster csr.
```

cc @patrostkowski 