### PR TITLE
fix: update instance capacity with right pod size.

### DIFF
--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -39,6 +39,7 @@ import (
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
+	"sigs.k8s.io/karpenter/pkg/utils/resources"
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/auth"
@@ -151,6 +152,7 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1alpha1.GCENodeC
 			Capacity: corev1.ResourceList{
 				corev1.ResourceCPU:    *resource.NewQuantity(cpu, resource.DecimalSI),
 				corev1.ResourceMemory: *resource.NewQuantity(memory, resource.BinarySI),
+				corev1.ResourcePods:   *resources.Quantity(fmt.Sprint(int(v1alpha1.KubeletMaxPods))),
 			},
 			Overhead:     &overhead,
 			Offerings:    p.createOfferings(ctx, *mt.Name, zoneData),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Karpenter requirement will fail in mocked scheduling, because the pod is always 0 and all instance type are cleared.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: update instance capacity with right pod size.
```