### PR TITLE
fix: fix image pull failure

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -222,11 +222,6 @@ func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *
 	disk := template.Properties.Disks[0]
 	disk.InitializeParams.DiskType = fmt.Sprintf("projects/%s/zones/%s/diskTypes/pd-balanced", p.projectID, zone)
 
-	// disable public IPs
-	for _, ni := range template.Properties.NetworkInterfaces {
-		ni.AccessConfigs = nil
-	}
-
 	err := metadata.RemoveGKEBuiltinLabels(template.Properties.Metadata)
 	if err != nil {
 		log.FromContext(context.Background()).Error(err, "failed to remove GKE builtin labels from metadata")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Before it has the following error:
```
-> % k get po
NAME                                   READY   STATUS             RESTARTS   AGE
inflate-74b8667f9c-dzl6d               0/1     ImagePullBackOff   0          112m
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```