### PR TITLE
fix: support e2-medium and other instance-type format like this

### DIFF
--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -114,11 +114,19 @@ func computeRequirements(mt *computepb.MachineType, offerings cloudprovider.Offe
 	}
 
 	// The format looks like: n1-standard-1, the family is n1-standard, the category is n, the instance size is 1
+	// Also, there is something like e2-medium, the family is e2, the category is e, the instance size is medium
 	instanceTypeParts := strings.Split(aws.StringValue(mt.Name), "-")
-	if len(instanceTypeParts) == 3 {
+	if len(instanceTypeParts) >= 2 {
 		requirements.Get(v1alpha1.LabelInstanceCategory).Insert(extractCategory(instanceTypeParts[0]))
-		requirements.Get(v1alpha1.LabelInstanceFamily).Insert(instanceTypeParts[0] + "-" + instanceTypeParts[1])
-		requirements.Get(v1alpha1.LabelInstanceSize).Insert(instanceTypeParts[2])
+		requirements.Get(v1alpha1.LabelInstanceSize).Insert(instanceTypeParts[len(instanceTypeParts)-1])
+
+		if len(instanceTypeParts) == 2 {
+			requirements.Get(v1alpha1.LabelInstanceFamily).Insert(instanceTypeParts[0])
+		}
+		// If there are three parts, also insert the first two joined as family
+		if len(instanceTypeParts) == 3 {
+			requirements.Get(v1alpha1.LabelInstanceFamily).Insert(instanceTypeParts[0] + "-" + instanceTypeParts[1])
+		}
 	}
 
 	return requirements


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Testing result:
```
-> % k get nodeclaim -A
NAME                     TYPE        CAPACITY   ZONE            NODE                               READY   AGE
default-nodepool-6m7kn   e2-medium   spot       us-central1-a   karpenter-default-nodepool-6m7kn   True    7m30s
```

Before we only support something like `n1-standard-2`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```