### PR TITLE
Add more control over gcp credentials in helm chart

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -50,8 +50,10 @@ spec:
               value: {{ .Values.controller.settings.region }}
             - name: CLUSTER_NAME
               value: {{ .Values.controller.settings.clusterName }}
+            {{- if .Values.credentials.enabled }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: "/var/secrets/google/key.json"
+              value: "/var/secrets/google/{{ .Values.credentials.secretKey }}"
+            {{- end }}
             - name: KUBERNETES_MIN_VERSION
               value: "1.26.0"
             {{- with .Values.logLevel }}
@@ -98,6 +100,9 @@ spec:
               value: "{{ .Values.controller.metrics.port }}"
             - name: KARPENTER_SERVICE
               value: {{ include "karpenter.fullname" . }}
+            {{- with .Values.controller.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.controller.healthProbe.port }}
@@ -120,9 +125,11 @@ spec:
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
           volumeMounts:
+          {{- if .Values.credentials.enabled }}
             - mountPath: "/var/secrets/google"
               readOnly: true
               name: gcp-secret
+          {{- end }}
       {{- with .Values.controller.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
@@ -131,10 +138,12 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.credentials.enabled }}
       volumes:
         - name: gcp-secret
           secret:
-            secretName: {{ include "karpenter.fullname" . }}-gcp-credentials
+            secretName: {{ .Values.credentials.secretName | default (printf "%s-gcp-credentials" (include "karpenter.fullname" .)) }}
             items:
-              - key: key.json
-                path: "key.json"
+              - key: {{ .Values.credentials.secretKey }}
+                path: {{ .Values.credentials.secretKey }}
+      {{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -84,7 +84,7 @@ credentials:
   # -- Enable or disable the use of GCP credentials secret
   # Set to true if you want to use a Kubernetes secret for GCP authentication
   # Set to false to rely on other authentication methods (e.g., Workload Identity, instance metadata)
-  enabled: false
+  enabled: true
   # -- Name of the existing secret containing GCP credentials
   # If not specified, defaults to "<release-name>-gcp-credentials"
   # This secret should contain a service account key file

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -79,3 +79,15 @@ controller:
     # will be batched separately.
     batchIdleDuration: 1s
 
+# -- GCP credentials configuration
+credentials:
+  # -- Enable or disable the use of GCP credentials secret
+  # Set to true if you want to use a Kubernetes secret for GCP authentication
+  # Set to false to rely on other authentication methods (e.g., Workload Identity, instance metadata)
+  enabled: false
+  # -- Name of the existing secret containing GCP credentials
+  # If not specified, defaults to "<release-name>-gcp-credentials"
+  # This secret should contain a service account key file
+  secretName: ""
+  # -- Key within the secret that contains the service account JSON
+  secretKey: "key.json"


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

Adds optional GCP credentials configuration to the Helm chart, allowing users to:
- Disable credential secrets entirely (for Workload Identity setups)
- Specify custom secret names and keys
- Control when credential volumes are mounted

This provides flexibility for different GCP authentication methods while keeping deployments clean when credentials aren't needed.

#### Which issue(s) this PR fixes:

Fixes #96

#### Special notes for your reviewer:

The changes maintain backward compatibility and only mount credential volumes when explicitly enabled via `credentials.enabled: true`.

#### Does this PR introduce a user-facing change?

```release-note
Add optional GCP credentials configuration to Helm chart with `credentials.enabled`, `credentials.secretName`, and `credentials.secretKey` values for flexible authentication setup.
```