### PR TITLE
Adding option to use specified service account

### DIFF
--- a/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: gcenodeclasses.karpenter.k8s.gcp
 spec:
   group: karpenter.k8s.gcp
@@ -286,7 +286,6 @@ spec:
                   rule: self.all(k, k !='karpenter.k8s.gcp/gcenodeclass')
             required:
             - imageSelectorTerms
-            - serviceAccount
             type: object
           status:
             description: GCENodeClassStatus contains the resolved state of the GCENodeClass

--- a/charts/karpenter/crds/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter/crds/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/charts/karpenter/crds/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter/crds/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh

--- a/pkg/apis/v1alpha1/gcenodeclass.go
+++ b/pkg/apis/v1alpha1/gcenodeclass.go
@@ -31,7 +31,8 @@ import (
 type GCENodeClassSpec struct {
 	// ServiceAccount is the GCP IAM service account email to assign to the instance
 	// +kubebuilder:validation:Pattern=`^[^@]+@(developer\.gserviceaccount\.com|[^@]+\.iam\.gserviceaccount\.com)$`
-	ServiceAccount string `json:"serviceAccount"`
+	// +optional
+	ServiceAccount string `json:"serviceAccount,omitempty"`
 	// Disk defines the boot disk to attach to the provisioned instance.
 	// +optional
 	Disks *Disk `json:"disk,omitempty"`

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -113,6 +113,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		options.FromContext(ctx).ClusterName,
 		options.FromContext(ctx).Region,
 		options.FromContext(ctx).ProjectID,
+		options.FromContext(ctx).NodePoolServiceAccount,
 		computeService,
 		gkeProvider,
 		unavailableOfferingsCache,

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -405,23 +405,12 @@ func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *
 
 	serviceAccount := p.resolveServiceAccount(nodeClass)
 	serviceAccounts := template.Properties.ServiceAccounts
-
-	// If we have a specific service account to use (either from NodeClass or default config)
-	if serviceAccount != "" && len(serviceAccounts) > 0 {
-		// Create a copy and override the service account
-		serviceAccounts = make([]*compute.ServiceAccount, len(template.Properties.ServiceAccounts))
-		copy(serviceAccounts, template.Properties.ServiceAccounts)
-		serviceAccounts[0] = &compute.ServiceAccount{
-			Email: serviceAccount,
+	if serviceAccount != "" {
+		serviceAccounts = []*compute.ServiceAccount{
+			&compute.ServiceAccount{
+				Email: serviceAccount,
+			},
 		}
-		log.FromContext(context.Background()).Info("using service account for instance",
-			"serviceAccount", serviceAccount,
-			"source", lo.Ternary(nodeClass.Spec.ServiceAccount != "", "nodeclass", "default"),
-			"instanceName", instanceName)
-	} else if serviceAccount == "" {
-		log.FromContext(context.Background()).Info("no service account specified, using template default",
-			"instanceName", instanceName,
-			"templateServiceAccount", lo.Ternary(len(serviceAccounts) > 0, serviceAccounts[0].Email, "none"))
 	}
 
 	instance := &compute.Instance{


### PR DESCRIPTION
/kind feature

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds flexible service account configuration support with a priority hierarchy:
1. **NodeClass override**: Use `serviceAccount` field in GCENodeClass spec for per-nodeclass control
2. **Default from configuration**: Use default service account from environment variables/flags
3. **Template fallback**: Use existing service account from instance template if none specified (GCP defaults to <project number>-compute@developer.gserviceaccount.com)

This enables fine-grained control over which GCP service account instances use.

#### Which issue(s) this PR fixes:

Fixes #

#### Does this PR introduce a user-facing change?

```release-note
Use optional `serviceAccount` field to GCENodeClass spec to override the default service account used for instances. Falls back to configured default or template service account (GCP default) if not specified.
```