### PR TITLE
Added documentation for using workload identity

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -32,6 +32,9 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
 gcloud projects add-iam-policy-binding $PROJECT_ID \
     --member="serviceAccount:$GSA_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
     --role="roles/container.admin"
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+    --member="serviceAccount:$GSA_NAME@$PROJECT_ID.iam.gserviceaccount.com" \
+    --role="roles/iam.serviceAccountUser"
 
 # Allow Kubernetes Service Account to impersonate Google Service Account
 gcloud iam service-accounts add-iam-policy-binding $GSA_NAME@$PROJECT_ID.iam.gserviceaccount.com \


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds documentation for GKE Workload Identity authentication in the Helm chart. This provides a more secure alternative to service account keys by allowing the Kubernetes service account to impersonate a Google service account without storing credentials as secrets.

#### Which issue(s) this PR fixes:

Fixes #96

#### Special notes for your reviewer:

- Added workload identity setup instructions to README

#### Does this PR introduce a user-facing change?
None