### PR TITLE
fix(crd): correct schema for systemDisk category validation

### DIFF
--- a/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -64,6 +64,7 @@ spec:
                     description: The category of the system disk (e.g., pd-standard,
                       pd-balanced, pd-ssd, pd-extreme).
                     items:
+                      description: DiskCategory represents a disk category type
                       enum:
                       - hyperdisk-balanced
                       - hyperdisk-balanced-high-availability
@@ -76,6 +77,7 @@ spec:
                       - pd-ssd
                       - pd-standard
                       type: string
+                    maxItems: 10
                     type: array
                   sizeGiB:
                     description: 'SizeGiB is the size of the system disk. Unit: GiB'

--- a/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -63,18 +63,18 @@ spec:
                   categories:
                     description: The category of the system disk (e.g., pd-standard,
                       pd-balanced, pd-ssd, pd-extreme).
-                    enum:
-                    - hyperdisk-balanced
-                    - hyperdisk-balanced-high-availability
-                    - hyperdisk-extreme
-                    - hyperdisk-ml
-                    - hyperdisk-throughput
-                    - local-ssd
-                    - pd-balanced
-                    - pd-extreme
-                    - pd-ssd
-                    - pd-standard
                     items:
+                      enum:
+                      - hyperdisk-balanced
+                      - hyperdisk-balanced-high-availability
+                      - hyperdisk-extreme
+                      - hyperdisk-ml
+                      - hyperdisk-throughput
+                      - local-ssd
+                      - pd-balanced
+                      - pd-extreme
+                      - pd-ssd
+                      - pd-standard
                       type: string
                     type: array
                   sizeGiB:

--- a/pkg/apis/v1alpha1/gcenodeclass.go
+++ b/pkg/apis/v1alpha1/gcenodeclass.go
@@ -162,13 +162,17 @@ type Disk struct {
 	// +optional
 	SizeGiB int32 `json:"sizeGiB"`
 	// The category of the system disk (e.g., pd-standard, pd-balanced, pd-ssd, pd-extreme).
-	// +kubebuilder:validation:Enum=hyperdisk-balanced;hyperdisk-balanced-high-availability;hyperdisk-extreme;hyperdisk-ml;hyperdisk-throughput;local-ssd;pd-balanced;pd-extreme;pd-ssd;pd-standard
+	// +kubebuilder:validation:MaxItems=10
 	// +optional
-	Categories []string `json:"categories,omitempty"`
+	Categories []DiskCategory `json:"categories,omitempty"`
 	// Indicates that this is a boot disk
 	// +optional
 	Boot bool `json:"boot"`
 }
+
+// DiskCategory represents a disk category type
+// +kubebuilder:validation:Enum=hyperdisk-balanced;hyperdisk-balanced-high-availability;hyperdisk-extreme;hyperdisk-ml;hyperdisk-throughput;local-ssd;pd-balanced;pd-extreme;pd-ssd;pd-standard
+type DiskCategory string
 
 // GCENodeClass is the Schema for the GCENodeClass API
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1alpha1/zz_generated.deepcopy.go
@@ -49,7 +49,7 @@ func (in *Disk) DeepCopyInto(out *Disk) {
 	*out = *in
 	if in.Categories != nil {
 		in, out := &in.Categories, &out.Categories
-		*out = make([]string, len(*in))
+		*out = make([]DiskCategory, len(*in))
 		copy(*out, *in)
 	}
 	return


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

The enum for `systemDisk.categories` was incorrectly placed at the array level instead of the item level. This prevented the validation from being correctly applied to the items within the array.

#### Which issue(s) this PR fixes:
This PR fixes a bug in the GCENodeClass CRD where the validation for spec.systemDisk.categories was not being applied correctly.

The enum constraint was mistakenly applied to the categories array field itself, rather than to the individual string items within the array. This meant that no actual validation was occurring for the disk types provided by the user.

This change moves the enum to the items property, which is the correct location for validating elements of an array according to the OpenAPI v3 schema specification. This ensures that any value supplied in the categories array must be one of the officially supported GCP disk types.
