### PR TITLE
feat: Allow custom disk configurations

### DIFF
--- a/pkg/apis/v1alpha1/gcenodeclass_defaults.go
+++ b/pkg/apis/v1alpha1/gcenodeclass_defaults.go
@@ -21,3 +21,4 @@ import (
 )
 
 func (in *GCENodeClass) SetDefaults(_ context.Context) {}
+

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -358,6 +358,15 @@ func (p *DefaultProvider) renderDiskProperties(instanceType *cloudprovider.Insta
 	disk := template.Properties.Disks[0]
 	disk.InitializeParams.DiskType = fmt.Sprintf("projects/%s/zones/%s/diskTypes/pd-balanced", p.projectID, zone)
 
+	if nodeClass.Spec.Disks != nil {
+		if len(nodeClass.Spec.Disks.Categories) > 0 {
+			disk.InitializeParams.DiskType = fmt.Sprintf("projects/%s/zones/%s/diskTypes/%s", p.projectID, zone, nodeClass.Spec.Disks.Categories[0])
+		}
+		if nodeClass.Spec.Disks.SizeGiB != 0 {
+			disk.InitializeParams.DiskSizeGb = int64(nodeClass.Spec.Disks.SizeGiB)
+		}
+	}
+
 	requirements := instanceType.Requirements
 	if requirements.Get(corev1.LabelArchStable).Has(imagefamily.OSArchARM64Requirement) {
 		disk.InitializeParams.Architecture = imagefamily.OSArchitectureARM


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Previously, the disk size and type were hardcoded, ignoring any user-defined values in the GCENodeClass. This change reads the `disk` property from the `GCENodeClassSpec` and applies the specified `sizeGiB` and `categories` to the created instances.

This allows users to define custom disk configurations for their node classes, for example:

```yaml
disk:
  sizeGiB: 256
  categories:
  - "pd-ssd"
```

#### Which issue(s) this PR fixes:

Fixes: #109

#### Special notes for your reviewer:

Tested the updated controller in our enviroemnt and the intended change working

Before:
<img width="986" height="157" alt="disktype-issue-before" src="https://github.com/user-attachments/assets/bd434e8a-7d22-47b3-b86c-88c40a6f71f9" />

After:
<img width="917" height="146" alt="disktype-issue-after" src="https://github.com/user-attachments/assets/a5a93831-3b79-4cfd-b509-0fdd8d53b8e5" />
