### PR TITLE
fix: support gke specific zone labels

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -24,9 +24,12 @@ import (
 	computev1 "cloud.google.com/go/compute/apiv1"
 	"cloud.google.com/go/compute/metadata"
 	containerapiv1 "cloud.google.com/go/container/apiv1"
+	"github.com/samber/lo"
 	"google.golang.org/api/compute/v1"
 	container "google.golang.org/api/container/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/operator"
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/auth"
@@ -42,6 +45,7 @@ import (
 )
 
 func init() {
+	karpv1.NormalizedLabels = lo.Assign(karpv1.NormalizedLabels, map[string]string{"topology.gke.io/zone": corev1.LabelTopologyZone})
 }
 
 type Operator struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We should support gke specific zone requirements

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/cloudpilot-ai/karpenter-provider-gcp/issues/113

#### Special notes for your reviewer:
none

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```