### PR TITLE
feat/nodepool reconciliation

### DIFF
--- a/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -219,6 +219,7 @@ spec:
                       MaxPods is an override for the maximum number of pods that can run on
                       a worker node instance.
                     format: int32
+                    maximum: 256
                     minimum: 0
                     type: integer
                   podsPerCore:
@@ -279,10 +280,11 @@ spec:
                   metadata
                 type: object
               networkTags:
-                description: NetworkTags is a list of network tags to apply to the node.
+                description: |-
+                  NetworkTags is a list of network tags to apply to the node.
+                  Network tags must be RFC1035 compliant, start with a lowercase letter, and contain only
+                  lowercase letters, digits, and hyphens. They must be between 1 and 63 characters long.
                 items:
-                  maxLength: 63
-                  pattern: ^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$
                   type: string
                 maxItems: 64
                 type: array

--- a/charts/karpenter/crds/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter/crds/karpenter.sh_nodeclaims.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: nodeclaims.karpenter.sh
 spec:
   group: karpenter.sh

--- a/charts/karpenter/crds/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter/crds/karpenter.sh_nodepools.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: nodepools.karpenter.sh
 spec:
   group: karpenter.sh

--- a/pkg/apis/v1alpha1/gcenodeclass.go
+++ b/pkg/apis/v1alpha1/gcenodeclass.go
@@ -107,7 +107,8 @@ type KubeletConfiguration struct {
 	ClusterDNS []string `json:"clusterDNS,omitempty"`
 	// MaxPods is an override for the maximum number of pods that can run on
 	// a worker node instance.
-	// +kubebuilder:validation:Minimum:=0
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=256
 	// +optional
 	MaxPods *int32 `json:"maxPods,omitempty"`
 	// PodsPerCore is an override for the number of pods that can run on a worker node

--- a/pkg/apis/v1alpha1/labels.go
+++ b/pkg/apis/v1alpha1/labels.go
@@ -72,6 +72,7 @@ var (
 	ResourceNVIDIAGPU  corev1.ResourceName = "nvidia.com/gpu"
 	ResourceAMDGPU     corev1.ResourceName = "amd.com/gpu"
 	GCEClusterIDTagKey                     = "gce:gce-cluster-id"
+	GKENodePoolLabel                       = "cloud.google.com/gke-nodepool"
 
 	ImageFamilyUbuntu               = "Ubuntu"
 	ImageFamilyContainerOptimizedOS = "ContainerOptimizedOS"

--- a/pkg/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1alpha1/zz_generated.deepcopy.go
@@ -158,6 +158,11 @@ func (in *GCENodeClassSpec) DeepCopyInto(out *GCENodeClassSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.NetworkTags != nil {
+		in, out := &in.NetworkTags, &out.NetworkTags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -71,6 +71,10 @@ func New(kubeClient client.Client,
 
 // Create a NodeClaim given the constraints.
 func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*karpv1.NodeClaim, error) {
+	nodePool, err := c.resolveNodePoolFromNodeClaim(ctx, nodeClaim)
+	if err != nil {
+		return nil, fmt.Errorf("resolving nodepool, %w", err)
+	}
 	nodeClass, err := c.resolveNodeClassFromNodeClaim(ctx, nodeClaim)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -106,7 +110,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim)
 
 	nc := c.instanceToNodeClaim(instance, instanceType)
 	nc.Annotations = lo.Assign(nc.Annotations, map[string]string{
-		v1alpha1.AnnotationGCENodeClassHash:        nodeClass.Hash(),
+		v1alpha1.AnnotationGCENodeClassHash:        nodePool.Annotations[v1alpha1.AnnotationGCENodeClassHash],
 		v1alpha1.AnnotationGCENodeClassHashVersion: v1alpha1.GCENodeClassHashVersion,
 	})
 	return nc, nil
@@ -242,14 +246,14 @@ func (c *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeCla
 	if nodePool.Spec.Template.Spec.NodeClassRef == nil {
 		return "", nil
 	}
-	nodeClass, err := c.resolveNodeClassFromNodePool(ctx, nodePool)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			c.recorder.Publish(cloudproviderevents.NodePoolFailedToResolveNodeClass(nodePool))
-		}
-		return "", client.IgnoreNotFound(fmt.Errorf("resolving node class, %w", err))
+	// if the nodepooltemplate hash annotation is missing, the node is not drifted
+	if _, ok := nodePool.Annotations[v1alpha1.AnnotationGCENodeClassHash]; !ok {
+		return "", nil
 	}
-	return c.isNodeClassDrifted(ctx, nodeClaim, nodePool, nodeClass), nil
+	if nodePool.Annotations[v1alpha1.AnnotationGCENodeClassHash] != nodeClaim.Annotations[v1alpha1.AnnotationGCENodeClassHash] {
+		return "GCENodeClassHashDrifted", nil
+	}
+	return "", nil
 }
 
 func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
@@ -357,6 +361,18 @@ func (c *CloudProvider) resolveNodeClassFromNodeClaim(ctx context.Context, nodeC
 		return nil, err
 	}
 	return nodeClass, nil
+}
+
+func (c *CloudProvider) resolveNodePoolFromNodeClaim(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*karpv1.NodePool, error) {
+	nodePoolName, ok := nodeClaim.Labels[karpv1.NodePoolLabelKey]
+	if !ok {
+		return nil, fmt.Errorf("nodeClaim missing NodePoolLabelKey")
+	}
+	nodePool := &karpv1.NodePool{}
+	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: nodePoolName}, nodePool); err != nil {
+		return nil, err
+	}
+	return nodePool, nil
 }
 
 func (c *CloudProvider) resolveInstanceTypes(ctx context.Context, nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass) ([]*cloudprovider.InstanceType, error) {

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -63,7 +63,7 @@ func NewController(
 	pricingProvider pricing.Provider) []controller.Controller {
 	controllers := []controller.Controller{
 		nodeclassstatus.NewController(kubeClient, imageProvider),
-		nodepooltemplate.NewController(nodePoolTemplateProvider),
+		nodepooltemplate.NewController(kubeClient, nodePoolTemplateProvider),
 		nodeclasstermination.NewController(kubeClient),
 		nodeclasshash.NewController(kubeClient),
 		instancetype.NewController(instanceTypeProvider),

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -131,6 +131,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		computeService,
 		gkeProvider,
 		unavailableOfferingsCache,
+		operator.GetClient(),
 	)
 	instanceTypeProvider := instancetype.NewDefaultProvider(ctx, &auth, pricingProvider, gkeProvider, unavailableOfferingsCache)
 

--- a/pkg/providers/imagefamily/containeroptimizedos.go
+++ b/pkg/providers/imagefamily/containeroptimizedos.go
@@ -33,11 +33,14 @@ type ContainerOptimizedOS struct {
 	nodePoolTemplateProvider nodepooltemplate.Provider
 }
 
-func (c *ContainerOptimizedOS) ResolveImages(ctx context.Context, version string) (Images, error) {
-	sourceImage, err := getSourceImage(ctx, c.nodePoolTemplateProvider, nodepooltemplate.KarpenterDefaultNodePoolTemplate)
+func (c *ContainerOptimizedOS) ResolveImages(ctx context.Context, nodePoolName, version string) (Images, error) {
+	sourceImage, err := getSourceImage(ctx, c.nodePoolTemplateProvider, nodePoolName)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "unable to get sourceImage")
 		return nil, err
+	}
+	if sourceImage == "" {
+		return nil, nil
 	}
 
 	if version == "latest" {

--- a/pkg/providers/imagefamily/helper.go
+++ b/pkg/providers/imagefamily/helper.go
@@ -37,14 +37,13 @@ func resolveSourceImage(selfLink string) (string, error) {
 	return matches[1], nil
 }
 
-func getSourceImage(ctx context.Context, provider nodepooltemplate.Provider, nodePoolTemplateName string) (string, error) {
-	templates, err := provider.GetInstanceTemplates(ctx)
+func getSourceImage(ctx context.Context, provider nodepooltemplate.Provider, nodePoolName string) (string, error) {
+	defaultNodeTemplate, err := provider.GetInstanceTemplate(ctx, nodePoolName)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get default node template: %w", err)
 	}
-	defaultNodeTemplate, ok := templates[nodePoolTemplateName]
-	if !ok {
-		return "", fmt.Errorf("default node template not found")
+	if defaultNodeTemplate == nil {
+		return "", nil
 	}
 
 	systemDisk, ok := lo.Find(defaultNodeTemplate.Properties.Disks, func(item *compute.AttachedDisk) bool {

--- a/pkg/providers/imagefamily/image.go
+++ b/pkg/providers/imagefamily/image.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
 	pkgcache "github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/cache"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/nodepooltemplate"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
 )
 
 type Provider interface {
@@ -134,7 +135,7 @@ func (p *DefaultProvider) resolveImageFromAlias(ctx context.Context, nodeClass *
 
 	images := Images{}
 	familyProvider := p.getImageFamilyProvider(alias.Family)
-	ims, err := familyProvider.ResolveImages(ctx, alias.Version)
+	ims, err := familyProvider.ResolveImages(ctx, utils.ResolveNodePoolName(nodeClass.Name), alias.Version)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/providers/imagefamily/types.go
+++ b/pkg/providers/imagefamily/types.go
@@ -31,7 +31,7 @@ type Images []Image
 
 // ImageFamily can be implemented to override the default logic for generating dynamic launch template parameters
 type ImageFamily interface {
-	ResolveImages(ctx context.Context, version string) (Images, error)
+	ResolveImages(ctx context.Context, nodePoolName, version string) (Images, error)
 }
 
 const (

--- a/pkg/providers/imagefamily/ubuntu.go
+++ b/pkg/providers/imagefamily/ubuntu.go
@@ -32,11 +32,14 @@ type Ubuntu struct {
 	nodePoolTemplateProvider nodepooltemplate.Provider
 }
 
-func (u *Ubuntu) ResolveImages(ctx context.Context, version string) (Images, error) {
-	sourceImage, err := getSourceImage(ctx, u.nodePoolTemplateProvider, nodepooltemplate.KarpenterUbuntuNodePoolTemplate)
+func (u *Ubuntu) ResolveImages(ctx context.Context, nodePoolName, version string) (Images, error) {
+	sourceImage, err := getSourceImage(ctx, u.nodePoolTemplateProvider, nodePoolName)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "Failed to get source image")
 		return Images{}, err
+	}
+	if sourceImage == "" {
+		return nil, nil
 	}
 
 	if version != "latest" {

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
@@ -44,7 +45,6 @@ import (
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/gke"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/imagefamily"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/metadata"
-	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/nodepooltemplate"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
 )
 
@@ -77,10 +77,11 @@ type DefaultProvider struct {
 	projectID             string
 	defaultServiceAccount string
 	computeService        *compute.Service
+	kubeClient            client.Client
 }
 
 func NewProvider(clusterName, region, projectID, defaultServiceAccount string, computeService *compute.Service, gkeProvider gke.Provider,
-	unavailableOfferings *pkgcache.UnavailableOfferings) Provider {
+	unavailableOfferings *pkgcache.UnavailableOfferings, kubeClient client.Client) Provider {
 	return &DefaultProvider{
 		gkeProvider:           gkeProvider,
 		unavailableOfferings:  unavailableOfferings,
@@ -90,6 +91,7 @@ func NewProvider(clusterName, region, projectID, defaultServiceAccount string, c
 		projectID:             projectID,
 		defaultServiceAccount: defaultServiceAccount,
 		computeService:        computeService,
+		kubeClient:            kubeClient,
 	}
 }
 
@@ -147,6 +149,75 @@ func (p *DefaultProvider) isInstanceExists(ctx context.Context, zone, instanceNa
 	return instance, true, nil
 }
 
+func (p *DefaultProvider) launchInstance(ctx context.Context, nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, template *compute.InstanceTemplate, zone, instanceName, capacityType string) (*compute.Instance, error) {
+	instance := p.buildInstance(nodeClaim, nodeClass, instanceType, template, zone, instanceName)
+	op, err := p.computeService.Instances.Insert(p.projectID, zone, instance).Context(ctx).Do()
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to create instance", "instanceType", instanceType.Name, "zone", zone)
+		return nil, err
+	}
+
+	if err := p.waitOperationDone(ctx, instanceType.Name, zone, capacityType, op.Name); err != nil {
+		log.FromContext(ctx).Error(err, "failed to wait for operation to be done", "instanceType", instanceType.Name, "zone", zone)
+		return nil, err
+	}
+
+	nodeClaim.Status.ProviderID = fmt.Sprintf("gce://%s/%s/%s", p.projectID, zone, instanceName)
+	return instance, nil
+}
+
+func (p *DefaultProvider) createInstance(ctx context.Context, nodeClass *v1alpha1.GCENodeClass, nodeClaim *karpv1.NodeClaim, instanceType *cloudprovider.InstanceType, capacityType string) (*Instance, error) {
+	zone, err := p.selectZone(ctx, nodeClaim, instanceType, capacityType)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to select zone for instance type", "instanceType", instanceType.Name)
+		return nil, err
+	}
+
+	nodePoolName := utils.ResolveNodePoolName(nodeClass.Name)
+	if nodePoolName == "" {
+		log.FromContext(ctx).Error(err, "failed to resolve node pool name for image family", "imageFamily", nodeClass.ImageFamily())
+		return nil, fmt.Errorf("failed to resolve node pool name for image family %q", nodeClass.ImageFamily())
+	}
+
+	template, err := p.findTemplateByNodePoolName(ctx, nodePoolName)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to find template for alias", "alias", nodeClass.Spec.ImageSelectorTerms[0].Alias)
+		return nil, err
+	}
+
+	instanceName := fmt.Sprintf("karpenter-%s", nodeClaim.Name)
+	instance, exists, err := p.isInstanceExists(ctx, zone, instanceName)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to check if instance exists", "instanceName", instanceName)
+		return nil, fmt.Errorf("failed to check if instance exists: %w", err)
+	}
+
+	if !exists {
+		instance, err = p.launchInstance(ctx, nodeClaim, nodeClass, instanceType, template, zone, instanceName, capacityType)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	log.FromContext(ctx).Info("Created instance", "instanceName", instance.Name, "instanceType", instanceType.Name,
+		"zone", zone, "projectID", p.projectID, "region", p.region, "providerID", instance.Name, "providerID", instance.Name,
+		"Labels", instance.Labels, "Tags", instance.Tags, "Status", instance.Status)
+
+	return &Instance{
+		InstanceID:   instance.Name,
+		Name:         instance.Name,
+		Type:         instanceType.Name,
+		Location:     zone,
+		ProjectID:    p.projectID,
+		ImageID:      template.Properties.Disks[0].InitializeParams.SourceImage,
+		CreationTime: time.Now(),
+		CapacityType: capacityType,
+		Tags:         template.Properties.Labels,
+		Labels:       instance.Labels,
+		Status:       InstanceStatusProvisioning,
+	}, nil
+}
+
 func (p *DefaultProvider) Create(ctx context.Context, nodeClass *v1alpha1.GCENodeClass, nodeClaim *karpv1.NodeClaim, instanceTypes []*cloudprovider.InstanceType) (*Instance, error) {
 	if len(instanceTypes) == 0 {
 		return nil, fmt.Errorf("no instance types provided")
@@ -158,75 +229,12 @@ func (p *DefaultProvider) Create(ctx context.Context, nodeClass *v1alpha1.GCENod
 	var errs []error
 	// try all instance types, if one is available, use it
 	for _, instanceType := range instanceTypes {
-		zone, err := p.selectZone(ctx, nodeClaim, instanceType, capacityType)
+		instance, err := p.createInstance(ctx, nodeClass, nodeClaim, instanceType, capacityType)
 		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to select zone for instance type", "instanceType", instanceType.Name)
 			errs = append(errs, err)
 			continue
 		}
-
-		nodePoolName := resolveNodePoolName(nodeClass.ImageFamily())
-		if nodePoolName == "" {
-			log.FromContext(ctx).Error(err, "failed to resolve node pool name for image family", "imageFamily", nodeClass.ImageFamily())
-			return nil, fmt.Errorf("failed to resolve node pool name for image family %q", nodeClass.ImageFamily())
-		}
-
-		template, err := p.findTemplateByNodePoolName(ctx, nodePoolName)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to find template for alias", "alias", nodeClass.Spec.ImageSelectorTerms[0].Alias)
-			errs = append(errs, err)
-			continue
-		}
-
-		instanceName := fmt.Sprintf("karpenter-%s", nodeClaim.Name)
-		// We need to check it in the following scenario:
-		// 1. The instance is in the creation process.
-		// 2. The pod is terminated
-		// 3. The new pod will try to create the instance again, but it will fail because the instance is already in the creation process.
-		instance, exists, err := p.isInstanceExists(ctx, zone, instanceName)
-		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to check if instance exists", "instanceName", instanceName)
-			return nil, fmt.Errorf("failed to check if instance exists: %w", err)
-		}
-
-		if !exists {
-			instance = p.buildInstance(nodeClaim, nodeClass, instanceType, template, nodePoolName, zone, instanceName)
-			op, err := p.computeService.Instances.Insert(p.projectID, zone, instance).Context(ctx).Do()
-			if err != nil {
-				log.FromContext(ctx).Error(err, "failed to create instance", "instanceType", instanceType.Name, "zone", zone)
-				errs = append(errs, err)
-				continue
-			}
-
-			if err := p.waitOperationDone(ctx, instanceType.Name, zone, capacityType, op.Name); err != nil {
-				log.FromContext(ctx).Error(err, "failed to wait for operation to be done", "instanceType", instanceType.Name, "zone", zone)
-				errs = append(errs, err)
-				continue
-			}
-		}
-
-		// we could wait for the node to be present in kubernetes api via csr sign up
-		// should be done with watcher, for now implemented as a csr controller
-		log.FromContext(ctx).Info("Created instance", "instanceName", instance.Name, "instanceType", instanceType.Name,
-			"zone", zone, "projectID", p.projectID, "region", p.region, "providerID", instance.Name, "providerID", instance.Name,
-			"Labels", instance.Labels, "Tags", instance.Tags, "Status", instance.Status)
-
-		return &Instance{
-			InstanceID: instance.Name,
-			Name:       instance.Name,
-			// Refer to https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/45#discussion_r2115586327
-			// In this develop period, we are using a static instance type to avoid high cost of creating a new instance type for each node claim.
-			// Type:         instanceType.Name,
-			Type:         instanceType.Name,
-			Location:     zone,
-			ProjectID:    p.projectID,
-			ImageID:      template.Properties.Disks[0].InitializeParams.SourceImage,
-			CreationTime: time.Now(),
-			CapacityType: capacityType,
-			Tags:         template.Properties.Labels,
-			Labels:       instance.Labels,
-			Status:       InstanceStatusProvisioning,
-		}, nil
+		return instance, nil
 	}
 
 	return nil, fmt.Errorf("failed to create instance after trying all instance types: %w", errors.Join(errs...))
@@ -309,17 +317,6 @@ func (p *DefaultProvider) selectZone(ctx context.Context, nodeClaim *karpv1.Node
 	return cheapestZone, nil
 }
 
-func resolveNodePoolName(imageFamily string) string {
-	switch imageFamily {
-	case v1alpha1.ImageFamilyContainerOptimizedOS:
-		return nodepooltemplate.KarpenterDefaultNodePoolTemplate
-	case v1alpha1.ImageFamilyUbuntu:
-		return nodepooltemplate.KarpenterUbuntuNodePoolTemplate
-	}
-
-	return ""
-}
-
 //nolint:gocyclo
 func (p *DefaultProvider) findTemplateByNodePoolName(ctx context.Context, nodePoolName string) (*compute.InstanceTemplate, error) {
 	if nodePoolName == "" {
@@ -396,20 +393,65 @@ func (p *DefaultProvider) renderDiskProperties(instanceType *cloudprovider.Insta
 	return attachedDisks, nil
 }
 
-func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, template *compute.InstanceTemplate, nodePoolName, zone, instanceName string) *compute.Instance {
+func (p *DefaultProvider) configureScheduling(instance *compute.Instance, nodeClaim *karpv1.NodeClaim, instanceType *cloudprovider.InstanceType) {
+	capacityType := p.getCapacityType(nodeClaim, []*cloudprovider.InstanceType{instanceType})
+	if instance.Scheduling == nil {
+		instance.Scheduling = &compute.Scheduling{}
+	}
+	if capacityType == karpv1.CapacityTypeSpot {
+		instance.Scheduling.ProvisioningModel = "SPOT"
+		instance.Scheduling.Preemptible = true
+		instance.Scheduling.AutomaticRestart = ptr.To(false)
+		instance.Scheduling.OnHostMaintenance = "TERMINATE"
+	}
+}
+
+func (p *DefaultProvider) configureLabelsAndTags(instance *compute.Instance, nodeClass *v1alpha1.GCENodeClass, nodeClaim *karpv1.NodeClaim, instanceType *cloudprovider.InstanceType) {
+	instance.Labels[utils.SanitizeGCELabelValue(utils.LabelNodePoolKey)] = nodeClaim.Labels[karpv1.NodePoolLabelKey]
+	instance.Labels[utils.SanitizeGCELabelValue(utils.LabelGCENodeClassKey)] = nodeClass.Name
+	instance.Labels[utils.SanitizeGCELabelValue(utils.LabelClusterNameKey)] = p.clusterName
+	lo.ForEach(lo.Entries(instanceType.Requirements.Labels()), func(entry lo.Entry[string, string], _ int) {
+		instance.Labels[entry.Key] = entry.Value
+	})
+
+	if instance.Tags == nil {
+		instance.Tags = &compute.Tags{}
+	}
+	instance.Tags.Items = append(instance.Tags.Items, nodeClass.Spec.NetworkTags...)
+
+	// User-defined tags on the GCENodeClass are added to the instance labels.
+}
+
+func (p *DefaultProvider) configureMetadata(ctx context.Context, templateMetadata *compute.Metadata, nodeClass *v1alpha1.GCENodeClass, nodeClaim *karpv1.NodeClaim, instanceType *cloudprovider.InstanceType) error {
+	if err := metadata.SetMaxPodsPerNode(templateMetadata, nodeClass); err != nil {
+		log.FromContext(ctx).Error(err, "failed to set max pods per node in metadata")
+		return err
+	}
+	if err := metadata.RenderKubeletConfigMetadata(templateMetadata, instanceType); err != nil {
+		log.FromContext(ctx).Error(err, "failed to render kubelet config metadata")
+		return err
+	}
+	if err := metadata.PatchUnregisteredTaints(templateMetadata); err != nil {
+		log.FromContext(ctx).Error(err, "failed to append unregistered taint to kube-env")
+		return err
+	}
+	metadata.AppendNodeClaimLabel(nodeClaim, nodeClass, templateMetadata)
+	metadata.AppendRegisteredLabel(templateMetadata)
+	return nil
+}
+
+func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, template *compute.InstanceTemplate, zone, instanceName string) *compute.Instance {
 	attachedDisks, err := p.renderDiskProperties(instanceType, nodeClass, zone)
 	if err != nil {
 		log.FromContext(context.Background()).Error(err, "failed to render disk properties")
 		return nil
 	}
 
-	// Setup metadata
-	if err := p.setupInstanceMetadata(template.Properties.Metadata, nodeClass, instanceType, nodeClaim, nodePoolName); err != nil {
-		log.FromContext(context.Background()).Error(err, "failed to setup instance metadata")
+	if err := p.configureMetadata(context.Background(), template.Properties.Metadata, nodeClass, nodeClaim, instanceType); err != nil {
+		log.FromContext(context.Background()).Error(err, "failed to configure metadata")
 		return nil
 	}
 
-	// Setup service accounts
 	serviceAccounts := p.setupServiceAccounts(nodeClass, template.Properties.ServiceAccounts)
 
 	// Create instance
@@ -420,42 +462,15 @@ func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *
 		NetworkInterfaces: template.Properties.NetworkInterfaces,
 		ServiceAccounts:   serviceAccounts,
 		Metadata:          template.Properties.Metadata,
-		Labels:            p.initializeInstanceLabels(nodeClass),
+		Labels:            nodeClass.Labels,
 		Scheduling:        template.Properties.Scheduling,
 		Tags:              mergeInstanceTags(template.Properties.Tags, nodeClass.Spec.NetworkTags),
 	}
 
-	// Configure capacity provision
-	p.configureInstanceCapacityProvision(instance, nodeClaim, instanceType)
-
-	// Setup karpenter built-in labels
-	p.setupInstanceLabels(instance, nodeClaim, nodeClass, instanceType)
+	p.configureScheduling(instance, nodeClaim, instanceType)
+	p.configureLabelsAndTags(instance, nodeClass, nodeClaim, instanceType)
 
 	return instance
-}
-
-// setupInstanceMetadata configures all metadata-related settings for the instance
-func (p *DefaultProvider) setupInstanceMetadata(instanceMetadata *compute.Metadata, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, nodeClaim *karpv1.NodeClaim, nodePoolName string) error {
-	if err := metadata.RemoveGKEBuiltinLabels(instanceMetadata, nodePoolName); err != nil {
-		return fmt.Errorf("failed to remove GKE builtin labels from metadata: %w", err)
-	}
-
-	if err := metadata.SetMaxPodsPerNode(instanceMetadata, nodeClass); err != nil {
-		return fmt.Errorf("failed to set max pods per node in metadata: %w", err)
-	}
-
-	if err := metadata.RenderKubeletConfigMetadata(instanceMetadata, instanceType); err != nil {
-		return fmt.Errorf("failed to render kubelet config metadata: %w", err)
-	}
-
-	if err := metadata.PatchUnregisteredTaints(instanceMetadata); err != nil {
-		return fmt.Errorf("failed to append unregistered taint to kube-env: %w", err)
-	}
-
-	metadata.AppendNodeClaimLabel(nodeClaim, nodeClass, instanceMetadata)
-	metadata.AppendRegisteredLabel(instanceMetadata)
-
-	return nil
 }
 
 // setupServiceAccounts configures service accounts for the instance
@@ -479,43 +494,6 @@ func (p *DefaultProvider) setupServiceAccounts(nodeClass *v1alpha1.GCENodeClass,
 			},
 		},
 	}
-}
-
-// initializeInstanceLabels initializes the instance labels map
-func (p *DefaultProvider) initializeInstanceLabels(nodeClass *v1alpha1.GCENodeClass) map[string]string {
-	labels := make(map[string]string)
-	for k, v := range nodeClass.Spec.Labels {
-		labels[k] = v
-	}
-	return labels
-}
-
-// configureInstanceCapacityProvision configures capacity provision settings for the instance
-func (p *DefaultProvider) configureInstanceCapacityProvision(instance *compute.Instance, nodeClaim *karpv1.NodeClaim, instanceType *cloudprovider.InstanceType) {
-	capacityType := p.getCapacityType(nodeClaim, []*cloudprovider.InstanceType{instanceType})
-	if instance.Scheduling == nil {
-		instance.Scheduling = &compute.Scheduling{}
-	}
-
-	if capacityType == karpv1.CapacityTypeSpot {
-		instance.Scheduling.ProvisioningModel = "SPOT"
-		instance.Scheduling.Preemptible = true
-		instance.Scheduling.AutomaticRestart = ptr.To(false)
-		instance.Scheduling.OnHostMaintenance = "TERMINATE"
-	}
-}
-
-// setupInstanceLabels configures all labels for the instance
-func (p *DefaultProvider) setupInstanceLabels(instance *compute.Instance, nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType) {
-	// Set common Karpenter labels
-	instance.Labels[utils.SanitizeGCELabelValue(utils.LabelNodePoolKey)] = nodeClaim.Labels[karpv1.NodePoolLabelKey]
-	instance.Labels[utils.SanitizeGCELabelValue(utils.LabelGCENodeClassKey)] = nodeClass.Name
-	instance.Labels[utils.SanitizeGCELabelValue(utils.LabelClusterNameKey)] = p.clusterName
-
-	// Add instance type requirement labels
-	lo.ForEach(lo.Entries(instanceType.Requirements.Labels()), func(entry lo.Entry[string, string], _ int) {
-		instance.Labels[entry.Key] = entry.Value
-	})
 }
 
 func mergeInstanceTags(templateTags *compute.Tags, networkTags []string) *compute.Tags {

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -163,7 +163,7 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1alpha1.GCENodeC
 			continue
 		}
 
-		addInstanceType := NewInstanceType(ctx, mt, p.authOptions.Region, offerings)
+		addInstanceType := NewInstanceType(ctx, mt, nodeClass, p.authOptions.Region, offerings)
 		instanceTypes = append(instanceTypes, addInstanceType)
 	}
 	p.instanceTypesCache.SetDefault(listKey, instanceTypes)

--- a/pkg/providers/metadata/metadata.go
+++ b/pkg/providers/metadata/metadata.go
@@ -26,7 +26,6 @@ import (
 
 const (
 	ClusterNameLabel     = "cluster-name"
-	GKENodePoolLabel     = "cloud.google.com/gke-nodepool"
 	UnregisteredTaintArg = "--register-with-taints=karpenter.sh/unregistered=true:NoExecute"
 	KubeletConfigLabel   = "kubelet-config"
 )

--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -94,26 +94,15 @@ func RenderKubeletConfigMetadata(metaData *compute.Metadata, instanceType *cloud
 	return nil
 }
 
-func RemoveGKEBuiltinLabels(metadata *compute.Metadata, nodePoolName string) error {
-	nodePoolLabelEntry := fmt.Sprintf("%s=%s", GKENodePoolLabel, nodePoolName)
-	// Remove nodePoolLabelEntry from `kube-labels` and `kube-env`
-	for _, item := range metadata.Items {
-		if item.Key != "kube-labels" && item.Key != "kube-env" {
-			continue
-		}
-
-		item.Value = swag.String(strings.ReplaceAll(swag.StringValue(item.Value), nodePoolLabelEntry, ""))
-	}
-	return nil
-}
-
 func SetMaxPodsPerNode(metadata *compute.Metadata, nodeClass *v1alpha1.GCENodeClass) error {
-	if nodeClass.Spec.KubeletConfiguration == nil || nodeClass.Spec.KubeletConfiguration.MaxPods == nil {
-		return nil
+	maxPodsVal := v1alpha1.KubeletMaxPods
+	if nodeClass.Spec.KubeletConfiguration != nil && nodeClass.Spec.KubeletConfiguration.MaxPods != nil {
+		maxPodsVal = int(*nodeClass.Spec.KubeletConfiguration.MaxPods)
 	}
+
 	keys := []string{"kube-labels", "kube-env"}
-	maxPodsPerNode := fmt.Sprintf("max-pods-per-node=%d", *nodeClass.Spec.KubeletConfiguration.MaxPods)
-	maxPods := fmt.Sprintf("max-pods=%d", *nodeClass.Spec.KubeletConfiguration.MaxPods)
+	maxPodsPerNode := fmt.Sprintf("max-pods-per-node=%d", maxPodsVal)
+	maxPods := fmt.Sprintf("max-pods=%d", maxPodsVal)
 
 	for _, key := range keys {
 		targetEntry, index, ok := lo.FindIndexOf(metadata.Items, func(item *compute.MetadataItems) bool {

--- a/pkg/providers/nodepooltemplate/nodepooltemplate.go
+++ b/pkg/providers/nodepooltemplate/nodepooltemplate.go
@@ -24,19 +24,26 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/samber/lo"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/googleapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/version"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
 )
 
 type Provider interface {
-	Create(ctx context.Context) error
-	GetInstanceTemplates(ctx context.Context) (map[string]*compute.InstanceTemplate, error)
+	Create(ctx context.Context, nodeClass *v1alpha1.GCENodeClass, nodePool *v1.NodePool) error
+	Delete(ctx context.Context, nodeClass *v1alpha1.GCENodeClass) error
+	GetInstanceTemplate(ctx context.Context, nodePoolName string) (*compute.InstanceTemplate, error)
 }
 
 type DefaultProvider struct {
@@ -57,10 +64,8 @@ type ClusterInfo struct {
 }
 
 const (
-	KarpenterDefaultNodePoolTemplate          = "karpenter-default"
 	KarpenterDefaultNodePoolTemplateImageType = "COS_CONTAINERD"
 
-	KarpenterUbuntuNodePoolTemplate          = "karpenter-ubuntu"
 	KarpenterUbuntuNodePoolTemplateImageType = "UBUNTU_CONTAINERD"
 )
 
@@ -84,7 +89,7 @@ func NewDefaultProvider(ctx context.Context, kubeClient client.Client, computeSe
 			ProjectID: projectID,
 			Location:  location,
 			Region:    region,
-			Name:      clusterName,
+			Name:      strings.TrimSuffix(clusterName, "."),
 			Zones:     zones,
 		},
 	}
@@ -118,102 +123,208 @@ func resolveZones(ctx context.Context, computeService *compute.Service, projectI
 	return zones, nil
 }
 
-// creating both default nodepool templates could be run concurrently
-func (p *DefaultProvider) Create(ctx context.Context) error {
-	if err := p.ensureKarpenterNodePoolTemplate(ctx, KarpenterDefaultNodePoolTemplateImageType, KarpenterDefaultNodePoolTemplate, p.defaultServiceAccount); err != nil {
+func (p *DefaultProvider) Create(ctx context.Context, nodeClass *v1alpha1.GCENodeClass, nodePool *v1.NodePool) error {
+	nodePoolName := utils.ResolveNodePoolName(nodeClass.Name)
+	imageType, err := p.resolveImageType(nodeClass.ImageFamily())
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to resolve image type", "nodeClass", nodeClass.Name)
 		return err
 	}
 
-	if err := p.ensureKarpenterNodePoolTemplate(ctx, KarpenterUbuntuNodePoolTemplateImageType, KarpenterUbuntuNodePoolTemplate, p.defaultServiceAccount); err != nil {
-		return err
+	var maxPods int64 = v1alpha1.KubeletMaxPods
+	if nodeClass.Spec.KubeletConfiguration != nil && nodeClass.Spec.KubeletConfiguration.MaxPods != nil {
+		maxPods = int64(*nodeClass.Spec.KubeletConfiguration.MaxPods)
 	}
 
+	if err := p.ensureNodePoolTemplate(ctx, imageType, nodePoolName, p.defaultServiceAccount, maxPods, nodePool); err != nil {
+		log.FromContext(ctx).Error(err, "failed to ensure node pool template", "nodeClass", nodeClass.Name)
+		return err
+	}
 	return nil
 }
 
-func (p *DefaultProvider) ensureKarpenterNodePoolTemplate(ctx context.Context, imageType, nodePoolName, serviceAccount string) error {
+func (p *DefaultProvider) Delete(ctx context.Context, nodeClass *v1alpha1.GCENodeClass) error {
+	nodePoolName := utils.ResolveNodePoolName(nodeClass.Name)
 	logger := log.FromContext(ctx)
-
-	// adding simple validation, because previous code was failing
-	// here and no reasonable log was printed out
-	if p.ClusterInfo.Name == "" {
-		return fmt.Errorf("clusterName is required but was empty")
-	}
-	if len(p.ClusterInfo.Zones) == 0 {
-		return fmt.Errorf("no zones provided for node pool %s", nodePoolName)
-	}
-
-	logger.Info("ensuring node pool template exists",
-		"projectID", p.ClusterInfo.ProjectID,
-		"region", p.ClusterInfo.Region,
-		"name", p.ClusterInfo.Name,
-		"nodePoolName", nodePoolName,
-		"zones", p.ClusterInfo.Zones)
+	logger.Info("deleting node pool template", "name", nodePoolName)
 
 	nodePoolSelfLink := fmt.Sprintf("projects/%s/locations/%s/clusters/%s/nodePools/%s",
-		p.ClusterInfo.ProjectID, p.ClusterInfo.Location, p.ClusterInfo.Name, nodePoolName)
+		p.ClusterInfo.ProjectID, p.ClusterInfo.Region, p.ClusterInfo.Name, nodePoolName)
 
-	_, err := p.containerService.Projects.Locations.Clusters.NodePools.Get(nodePoolSelfLink).Context(ctx).Do()
-	if err == nil {
-		logger.Info("template node pool already exists", "name", nodePoolName)
+	op, err := p.containerService.Projects.Locations.Clusters.NodePools.Delete(nodePoolSelfLink).Context(ctx).Do()
+	if err != nil {
+		if err := p.waitForOperation(ctx, op); err != nil {
+			return err
+		}
+		logger.Info("node pool template deleted", "name", nodePoolName)
 		return nil
 	}
 
 	var gcpErr *googleapi.Error
-	if errors.As(err, &gcpErr) && gcpErr.Code != http.StatusNotFound {
-		logger.Error(err, "Failed to get node pool", "name", nodePoolName, "nodePoolSelfLink", nodePoolSelfLink)
+	if errors.As(err, &gcpErr) {
+		if gcpErr.Code == http.StatusNotFound {
+			logger.Info("node pool template already deleted", "name", nodePoolName)
+			return nil
+		}
+		if gcpErr.Code == http.StatusBadRequest && strings.Contains(gcpErr.Message, "CLUSTER_ALREADY_HAS_OPERATION") {
+			logger.Info("cluster has a conflicting operation in progress, requeueing delete", "name", nodePoolName)
+			return fmt.Errorf("cluster has a conflicting operation in progress")
+		}
+	}
+	logger.Error(err, "failed to delete node pool template", "name", nodePoolName)
+	return err
+}
+
+func (p *DefaultProvider) resolveImageType(imageFamily string) (string, error) {
+	switch imageFamily {
+	case v1alpha1.ImageFamilyContainerOptimizedOS:
+		return KarpenterDefaultNodePoolTemplateImageType, nil
+	case v1alpha1.ImageFamilyUbuntu:
+		return KarpenterUbuntuNodePoolTemplateImageType, nil
+	default:
+		return "", fmt.Errorf("unsupported image family %q", imageFamily)
+	}
+}
+
+func (p *DefaultProvider) ensureNodePoolTemplate(ctx context.Context, imageType, nodePoolName, serviceAccount string, maxPods int64, nodePool *v1.NodePool) error {
+	logger := log.FromContext(ctx)
+	nodePoolSelfLink := fmt.Sprintf("projects/%s/locations/%s/clusters/%s/nodePools/%s",
+		p.ClusterInfo.ProjectID, p.ClusterInfo.Region, p.ClusterInfo.Name, nodePoolName)
+
+	existing, err := p.containerService.Projects.Locations.Clusters.NodePools.Get(nodePoolSelfLink).Context(ctx).Do()
+	if err != nil {
+		var gcpErr *googleapi.Error
+		if errors.As(err, &gcpErr) && gcpErr.Code == http.StatusNotFound {
+			return p.createNodePoolTemplate(ctx, imageType, nodePoolName, serviceAccount, maxPods, nodePool)
+		}
+		logger.Error(err, "failed to get node pool", "name", nodePoolName)
 		return err
 	}
 
-	// Prepare request
-	nodePoolOpts := &container.CreateNodePoolRequest{
+	// Node pool exists, check if it needs an update.
+	if existing.MaxPodsConstraint.MaxPodsPerNode != maxPods ||
+		existing.Config.Labels == nil ||
+		existing.Config.Labels[v1alpha1.GKENodePoolLabel] != nodePoolName {
+		logger.Info("node pool template is outdated, recreating", "name", nodePoolName)
+		if err := p.Delete(ctx, &v1alpha1.GCENodeClass{ObjectMeta: metav1.ObjectMeta{Name: strings.TrimPrefix(nodePoolName, "karpenter-")}}); err != nil {
+			return err
+		}
+		return p.createNodePoolTemplate(ctx, imageType, nodePoolName, serviceAccount, maxPods, nodePool)
+	}
+
+	return nil
+}
+
+func (p *DefaultProvider) buildNodePool(cluster *container.Cluster, imageType, nodePoolName, serviceAccount string, maxPods int64, nodePool *v1.NodePool) (*container.CreateNodePoolRequest, error) {
+	var nodepoolZones *v1.NodeSelectorRequirementWithMinValues
+	for i := range nodePool.Spec.Template.Spec.Requirements {
+		if nodePool.Spec.Template.Spec.Requirements[i].Key == "topology.kubernetes.io/zone" {
+			nodepoolZones = &nodePool.Spec.Template.Spec.Requirements[i]
+			break
+		}
+	}
+
+	if nodepoolZones == nil {
+		return nil, fmt.Errorf("no zones specified in nodepool %s", nodePool.Name)
+	}
+	zones := lo.Intersect(p.ClusterInfo.Zones, nodepoolZones.Values)
+	if len(zones) == 0 {
+		return nil, fmt.Errorf("no zones provided for node pool %s (intersection of cluster zones and nodepool zones is empty)", nodePoolName)
+	}
+
+	return &container.CreateNodePoolRequest{
 		NodePool: &container.NodePool{
 			Name:             nodePoolName,
 			Autoscaling:      &container.NodePoolAutoscaling{Enabled: false},
 			InitialNodeCount: 0,
-			Locations:        p.ClusterInfo.Zones,
+			Locations:        zones,
 			Config: &container.NodeConfig{
 				ImageType:      imageType,
 				ServiceAccount: serviceAccount,
+				Labels:         map[string]string{v1alpha1.GKENodePoolLabel: nodePoolName},
+			},
+			MaxPodsConstraint: &container.MaxPodsConstraint{MaxPodsPerNode: maxPods},
+			NetworkConfig: &container.NodeNetworkConfig{
+				PodRange: cluster.IpAllocationPolicy.ClusterSecondaryRangeName,
 			},
 		},
-	}
+	}, nil
+}
 
-	logger.Info("creating node pool", "name", nodePoolName)
-	clusterSelfLink := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", p.ClusterInfo.ProjectID, p.ClusterInfo.Location, p.ClusterInfo.Name)
-	_, err = p.containerService.Projects.Locations.Clusters.NodePools.Create(clusterSelfLink, nodePoolOpts).Context(ctx).Do()
+func (p *DefaultProvider) createNodePoolTemplate(ctx context.Context, imageType, nodePoolName, serviceAccount string, maxPods int64, nodePool *v1.NodePool) error {
+	logger := log.FromContext(ctx)
+	logger.Info("creating node pool template", "name", nodePoolName)
+
+	clusterSelfLink := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", p.ClusterInfo.ProjectID, p.ClusterInfo.Region, p.ClusterInfo.Name)
+	cluster, err := p.containerService.Projects.Locations.Clusters.Get(clusterSelfLink).Context(ctx).Do()
 	if err != nil {
-		if errors.As(err, &gcpErr) && gcpErr.Code == http.StatusConflict {
-			logger.Info("node pool already created concurrently", "name", nodePoolName)
-			return nil
-		}
-		logger.Error(err, "failed to create node pool", "name", nodePoolName)
+		logger.Error(err, "failed to get cluster info for nodepool creation")
 		return err
 	}
 
-	logger.Info("node pool created successfully", "name", nodePoolName)
+	nodePoolOpts, err := p.buildNodePool(cluster, imageType, nodePoolName, serviceAccount, maxPods, nodePool)
+	if err != nil {
+		return err
+	}
+
+	op, err := p.containerService.Projects.Locations.Clusters.NodePools.Create(clusterSelfLink, nodePoolOpts).Context(ctx).Do()
+	if err != nil {
+		var gcpErr *googleapi.Error
+		if errors.As(err, &gcpErr) {
+			if gcpErr.Code == http.StatusConflict {
+				logger.Info("node pool template already created concurrently", "name", nodePoolName)
+				return nil
+			}
+			if gcpErr.Code == http.StatusBadRequest && strings.Contains(gcpErr.Message, "CLUSTER_ALREADY_HAS_OPERATION") {
+				logger.Info("cluster has a conflicting operation in progress, requeueing", "name", nodePoolName)
+				return fmt.Errorf("cluster has a conflicting operation in progress")
+			}
+		}
+		logger.Error(err, "failed to create node pool template", "name", nodePoolName)
+		return err
+	}
+	if err := p.waitForOperation(ctx, op); err != nil {
+		return err
+	}
+	logger.Info("node pool template created", "name", nodePoolName)
 	return nil
 }
 
-func (p *DefaultProvider) GetInstanceTemplates(ctx context.Context) (map[string]*compute.InstanceTemplate, error) {
-	ret := map[string]*compute.InstanceTemplate{}
-	defaultTemplate, err := p.getInstanceTemplate(ctx, KarpenterDefaultNodePoolTemplate)
-	if err != nil {
-		return nil, err
+func (p *DefaultProvider) waitForOperation(ctx context.Context, op *container.Operation) error {
+	logger := log.FromContext(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+			var err error
+			u, err := url.Parse(op.SelfLink)
+			if err != nil {
+				return fmt.Errorf("parsing operation selfLink %q, %w", op.SelfLink, err)
+			}
+			opName := strings.TrimPrefix(u.Path, "/v1/")
+			op, err = p.containerService.Projects.Locations.Operations.Get(opName).Context(ctx).Do()
+			if err != nil {
+				return fmt.Errorf("polling operation status, %w", err)
+			}
+			if op.Status == "DONE" {
+				if op.Error != nil {
+					return fmt.Errorf("operation failed: %v", op.Error)
+				}
+				logger.Info("gke operation finished", "operation", op.Name, "type", op.OperationType)
+				return nil
+			}
+			logger.Info("waiting for gke operation", "operation", op.Name, "type", op.OperationType, "status", op.Status)
+		}
 	}
-	if defaultTemplate != nil {
-		ret[KarpenterDefaultNodePoolTemplate] = defaultTemplate
-	}
+}
 
-	ubuntuTemplate, err := p.getInstanceTemplate(ctx, KarpenterUbuntuNodePoolTemplate)
+func (p *DefaultProvider) GetInstanceTemplate(ctx context.Context, nodePoolName string) (*compute.InstanceTemplate, error) {
+	defaultTemplate, err := p.getInstanceTemplate(ctx, nodePoolName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting instance template for node pool %s: %w", nodePoolName, err)
 	}
-	if ubuntuTemplate != nil {
-		ret[KarpenterUbuntuNodePoolTemplate] = ubuntuTemplate
-	}
-
-	return ret, nil
+	return defaultTemplate, nil
 }
 
 func (p *DefaultProvider) getNodePool(ctx context.Context, nodePoolName string) (*container.NodePool, error) {
@@ -221,6 +332,11 @@ func (p *DefaultProvider) getNodePool(ctx context.Context, nodePoolName string) 
 		p.ClusterInfo.ProjectID, p.ClusterInfo.Location, p.ClusterInfo.Name, nodePoolName)
 	nodePool, err := p.containerService.Projects.Locations.Clusters.NodePools.Get(nodePoolSelfLink).Context(ctx).Do()
 	if err != nil {
+		var gerr *googleapi.Error
+		if errors.As(err, &gerr) && gerr.Code == http.StatusNotFound {
+			log.FromContext(ctx).Info("node pool not found", "name", nodePoolName)
+			return nil, nil // Not found is not an error
+		}
 		log.FromContext(ctx).Error(err, "error getting node pool")
 		return nil, err
 	}
@@ -230,32 +346,27 @@ func (p *DefaultProvider) getNodePool(ctx context.Context, nodePoolName string) 
 func (p *DefaultProvider) getInstanceTemplate(ctx context.Context, nodePoolName string) (*compute.InstanceTemplate, error) {
 	logger := log.FromContext(ctx)
 
-	if p.ClusterInfo.ProjectID == "" || p.ClusterInfo.Name == "" || p.ClusterInfo.Region == "" {
-		return nil, fmt.Errorf("ClusterInfo not initialized")
-	}
-
-	nodePool, err := p.getNodePool(ctx, nodePoolName)
-	if err != nil {
+	if err := p.validateClusterInfo(); err != nil {
 		return nil, err
 	}
 
-	if nodePool.Status != "RUNNING" {
-		return nil, nil
+	nodePool, err := p.getNodePool(ctx, nodePoolName)
+	if err != nil || nodePool == nil || nodePool.Status != "RUNNING" {
+		return nil, err
 	}
 
 	if len(nodePool.InstanceGroupUrls) == 0 {
 		return nil, fmt.Errorf("no instance group URLs found for node pool: %s", nodePoolName)
 	}
 
-	zone, managerName, err := resolveInstanceGroupZoneAndManagerName(nodePool.InstanceGroupUrls[0])
+	location, managerName, isRegional, err := resolveInstanceGroupZoneAndManagerName(nodePool.InstanceGroupUrls[0])
 	if err != nil {
 		logger.Error(err, "error resolving instance group URL")
 		return nil, err
 	}
 
-	ig, err := p.computeService.InstanceGroupManagers.Get(p.ClusterInfo.ProjectID, zone, managerName).Do()
+	ig, err := p.getInstanceGroupManager(location, managerName, isRegional)
 	if err != nil {
-		logger.Error(err, "error getting instance group manager")
 		return nil, err
 	}
 
@@ -264,12 +375,36 @@ func (p *DefaultProvider) getInstanceTemplate(ctx context.Context, nodePoolName 
 		return nil, err
 	}
 
+	return p.getRegionalInstanceTemplate(ctx, templateName)
+}
+
+func (p *DefaultProvider) validateClusterInfo() error {
+	if p.ClusterInfo.ProjectID == "" || p.ClusterInfo.Name == "" || p.ClusterInfo.Region == "" {
+		return fmt.Errorf("ClusterInfo not initialized")
+	}
+	return nil
+}
+
+func (p *DefaultProvider) getInstanceGroupManager(location, managerName string, isRegional bool) (*compute.InstanceGroupManager, error) {
+	if isRegional {
+		ig, err := p.computeService.RegionInstanceGroupManagers.Get(p.ClusterInfo.ProjectID, location, managerName).Do()
+		if err != nil {
+			return nil, fmt.Errorf("getting instance group manager: %w", err)
+		}
+		return ig, nil
+	}
+	ig, err := p.computeService.InstanceGroupManagers.Get(p.ClusterInfo.ProjectID, location, managerName).Do()
+	if err != nil {
+		return nil, fmt.Errorf("getting instance group manager: %w", err)
+	}
+	return ig, nil
+}
+
+func (p *DefaultProvider) getRegionalInstanceTemplate(ctx context.Context, templateName string) (*compute.InstanceTemplate, error) {
 	template, err := p.computeService.RegionInstanceTemplates.Get(p.ClusterInfo.ProjectID, p.ClusterInfo.Region, templateName).Context(ctx).Do()
 	if err != nil {
-		logger.Error(err, "error getting instance template")
-		return nil, err
+		return nil, fmt.Errorf("getting instance template: %w", err)
 	}
-
 	return template, nil
 }
 
@@ -291,22 +426,20 @@ func resolveInstanceTemplateName(instanceTemplateURL string) (string, error) {
 	return "", fmt.Errorf("invalid instance template URL: %s", instanceTemplateURL)
 }
 
-func resolveInstanceGroupZoneAndManagerName(instanceGroupURL string) (string, string, error) {
+func resolveInstanceGroupZoneAndManagerName(instanceGroupURL string) (string, string, bool, error) {
 	parsedURL, err := url.Parse(instanceGroupURL)
 	if err != nil {
-		return "", "", err
+		return "", "", false, err
 	}
 
 	parts := strings.Split(strings.Trim(parsedURL.Path, "/"), "/")
-
-	// Ensure the path has enough components to extract zone and instance group manager name
-	if len(parts) < 8 || parts[4] != "zones" || parts[6] != "instanceGroupManagers" {
-		return "", "", fmt.Errorf("invalid instance group URL: %s", instanceGroupURL)
+	for i, p := range parts {
+		if p == "instanceGroupManagers" && i > 1 && i+1 < len(parts) {
+			locationType := parts[i-2]
+			if locationType == "zones" || locationType == "regions" {
+				return parts[i-1], parts[i+1], locationType == "regions", nil
+			}
+		}
 	}
-
-	// Extract zone and instance group manager name
-	zone := parts[5]
-	instanceGroupManagerName := parts[7]
-
-	return zone, instanceGroupManagerName, nil
+	return "", "", false, fmt.Errorf("invalid instance group URL: %s", instanceGroupURL)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"os"
 	"regexp"
@@ -167,4 +168,8 @@ func ResolveNodePoolFromNodeClaim(ctx context.Context, kubeClient client.Client,
 	}
 	// There will be no nodePool referenced inside the nodeClaim in case of standalone nodeClaims
 	return nil, nil
+}
+
+func ResolveNodePoolName(nodeClassName string) string {
+	return fmt.Sprintf("karpenter-%s", strings.ToLower(nodeClassName))
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

This PR addresses an issue where nodes provisioned by Karpenter can experience IP address exhaustion when a custom `maxPods` value in the `GCENodeClass` is higher than the GKE cluster's default `max-pods-per-node` setting.

The key changes in this PR are:
- **Nodepool Reconciliation:** Implements a more robust reconciliation logic for nodepools to ensure that configuration changes are correctly propagated.
- **Consistent Naming:** Resolves the nodepool name consistently when accessing the template, preventing mismatches.
- **GKE Node Labeling:** Ensures that all nodes provisioned in GKE are correctly labeled with the `gke-nodepool` label, improving compatibility and discovery.
- **Instance Configuration:** Removes an unused `nodePoolName` parameter from the instance creation logic to reduce complexity.

By consolidating these fixes and features, this PR ensures that the node's allocated pod CIDR block aligns with its advertised pod capacity, preventing pods from failing due to IP exhaustion.

#### Which issue(s) this PR fixes:
Fixes #120

#### Special notes for your reviewer:

This PR merges several recent commits related to node pool management and instance configuration into a single, focused commit. The changes are designed to enhance the reliability and accuracy of node provisioning in GKE.

Special thanks to @sthomson-wyn for helping pinpoint the issue I could not see  

#### Does this PR introduce a user-facing change?
```release-note
- **Fix:** Resolves an IP exhaustion issue for nodes created with a custom `maxPods` value that exceeds the cluster's default.
- **Feature:** Improves nodepool reconciliation logic and ensures GKE nodes are consistently labeled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements NodePool reconciliation with hash annotations, refactors instance/image/instancetype flows to derive from per-nodepool templates, updates drift logic, and aligns kubelet maxPods with GKE settings (plus CRD/validation tweaks).
> 
> - **Controllers**:
>   - **NodePoolTemplate Controller**: Rewritten to reconcile `NodePool`/`GCENodeClass`, add finalizer, create/delete GKE nodepools, compute/annotate `gcenodeclass-hash`, and watch `GCENodeClass` changes.
>   - Wire controller with `kubeClient`.
> - **Nodepool Template Provider (`pkg/providers/nodepooltemplate`)**:
>   - New API: `Create(ctx, nodeClass, nodePool)`, `Delete(...)`, `GetInstanceTemplate(ctx, nodePoolName)`.
>   - Create GKE nodepools per `GCENodeClass`/`NodePool` with image type, labels (`cloud.google.com/gke-nodepool`), `MaxPodsConstraint`, and operation wait; support regional IGMs; improved URL parsing and zone resolution.
> - **CloudProvider**:
>   - Use `NodePool` annotation `gcenodeclass-hash` for created `NodeClaim`; drift detection compares nodepool vs nodeclaim hash; helper to resolve `NodePool` from `NodeClaim`.
> - **Instance Provider**:
>   - Refactor creation into helpers; select zone, find template by resolved nodepool name, configure scheduling/labels/tags/metadata, and set `ProviderID`.
> - **Image Family**:
>   - `ResolveImages(ctx, nodePoolName, version)`; fetch source image via `GetInstanceTemplate`; handle empty template.
> - **InstanceTypes**:
>   - `NewInstanceType(..., nodeClass, ...)`; capacity `pods` respects `GCENodeClass.KubeletConfiguration.MaxPods`.
> - **Metadata**:
>   - Always set max pods in metadata from `GCENodeClass` (fallback to default); remove GKE builtin label stripping; move `gke-nodepool` label key to API constants.
> - **CRDs/API**:
>   - Add `Maximum=256` for `kubeletConfiguration.maxPods`; expand `networkTags` docs/validation; bump `controller-gen` version for `nodeclaims`/`nodepools`.
> - **Utils**:
>   - Add `ResolveNodePoolName()` for consistent nodepool naming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6a46a416d2c316829c3eb94b1443ebd67d98122. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->