### PR TITLE
feat(helm): allow for specification of pull secrets

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "karpenter.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.controller.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -27,6 +27,9 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
+imagePullSecrets: []
+#  - name: my-registry-secret
+
 podDisruptionBudget:
   minAvailable: 1
 


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
This PR extends the Helm chart to allow the configuration of `imagePullSecrets` on the controller's deployment and service account. This enables users to pull the Karpenter image from private
container registries that require authentication.

#### Special notes for your reviewer:
The changes are confined to the Helm chart and add a new `imagePullSecrets` value to the `values.yaml` file, which is then used in the `deployment.yaml`.

```release-note
The Helm chart now supports specifying `imagePullSecrets` for the controller deployment. This allows pulling the Karpenter image from private container registries.