### PR TITLE
fix: improve error handling in waitOperationDone function

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -125,7 +125,11 @@ func (p *DefaultProvider) waitOperationDone(ctx context.Context,
 					p.unavailableOfferings.MarkUnavailable(ctx, capacityError.Message, instanceType, zone, capacityType)
 					return cloudprovider.NewInsufficientCapacityError(fmt.Errorf("zone resource pool exhausted: %s", capacityError.Message))
 				}
-				return fmt.Errorf("operation failed: %v", op.Error.Errors)
+
+				errorMsgs := lo.Map(op.Error.Errors, func(e *compute.OperationErrorErrors, _ int) string {
+					return e.Message
+				})
+				return fmt.Errorf("operation failed: %s", strings.Join(errorMsgs, "; "))
 			}
 			return nil
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
improve error handling in waitOperationDone function

origin log looks like
```
{"level":"ERROR","time":"2025-09-25T10:36:02.924Z","logger":"controller","message":"failed to wait for operation to be done","commit":"6611ba7","controller":"nodeclaim.lifecycle","controllerGroup":"karpenter.sh","controllerKind":"NodeClaim","NodeClaim":{"name":"nodepool-72rgn"},"namespace":"","name":"nodepool-72rgn","reconcileID":"f1877ef0-74da-4afb-9291-0ee831a77ef4","instanceType":"e2-standard-4","zone":"us-west8-a","error":"operation failed: [0xc0092aeb00]"}
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```