### PR TITLE
Fix max pods per node consistency

### DIFF
--- a/pkg/apis/v1alpha1/gcenodeclass.go
+++ b/pkg/apis/v1alpha1/gcenodeclass.go
@@ -279,3 +279,10 @@ func imageVersionFromAlias(alias string) string {
 	}
 	return components[1]
 }
+
+func (in *GCENodeClass) GetMaxPods() int32 {
+	if in.Spec.KubeletConfiguration != nil && in.Spec.KubeletConfiguration.MaxPods != nil {
+		return *in.Spec.KubeletConfiguration.MaxPods
+	}
+	return KubeletMaxPods
+}

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -440,12 +440,8 @@ func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *
 
 // nolint:gocyclo
 func (p *DefaultProvider) setupNetworkInterfaces(template *compute.InstanceTemplate, nodeClass *v1alpha1.GCENodeClass) []*compute.NetworkInterface {
-	if nodeClass.Spec.KubeletConfiguration == nil || nodeClass.Spec.KubeletConfiguration.MaxPods == nil {
-		return template.Properties.NetworkInterfaces
-	}
-
 	// referring to: https://cloud.google.com/kubernetes-engine/docs/how-to/flexible-pod-cidr
-	maxPods := *nodeClass.Spec.KubeletConfiguration.MaxPods
+	maxPods := nodeClass.GetMaxPods()
 	targetRange := int32(maxNodeCIDR)
 	if maxPods <= 8 {
 		targetRange = 28

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -163,7 +163,7 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1alpha1.GCENodeC
 			continue
 		}
 
-		addInstanceType := NewInstanceType(ctx, mt, p.authOptions.Region, offerings)
+		addInstanceType := NewInstanceType(ctx, nodeClass, mt, p.authOptions.Region, offerings)
 		instanceTypes = append(instanceTypes, addInstanceType)
 	}
 	p.instanceTypesCache.SetDefault(listKey, instanceTypes)

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -35,7 +35,7 @@ import (
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
 )
 
-func NewInstanceType(ctx context.Context, mt *computepb.MachineType,
+func NewInstanceType(ctx context.Context, nodeClass *v1alpha1.GCENodeClass, mt *computepb.MachineType,
 	region string, offerings cloudprovider.Offerings) *cloudprovider.InstanceType {
 	if offerings == nil {
 		return nil
@@ -57,7 +57,7 @@ func NewInstanceType(ctx context.Context, mt *computepb.MachineType,
 		Name:         aws.StringValue(mt.Name),
 		Requirements: computeRequirements(mt, offerings, region),
 		Offerings:    offerings,
-		Capacity:     computeCapacity(ctx, mt),
+		Capacity:     computeCapacity(ctx, nodeClass, mt),
 		Overhead:     &overhead,
 	}
 
@@ -163,11 +163,11 @@ func extractArch(instanceTypePrefix string) string {
 	return "amd64"
 }
 
-func computeCapacity(ctx context.Context, mt *computepb.MachineType) corev1.ResourceList {
+func computeCapacity(ctx context.Context, nodeClass *v1alpha1.GCENodeClass, mt *computepb.MachineType) corev1.ResourceList {
 	resourceList := corev1.ResourceList{
 		corev1.ResourceCPU:    *cpu(mt),
 		corev1.ResourceMemory: *memory(ctx, mt),
-		corev1.ResourcePods:   *resource.NewQuantity(int64(v1alpha1.KubeletMaxPods), resource.DecimalSI),
+		corev1.ResourcePods:   *resource.NewQuantity(int64(nodeClass.GetMaxPods()), resource.DecimalSI),
 	}
 	return resourceList
 }

--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -108,12 +108,10 @@ func RemoveGKEBuiltinLabels(metadata *compute.Metadata, nodePoolName string) err
 }
 
 func SetMaxPodsPerNode(metadata *compute.Metadata, nodeClass *v1alpha1.GCENodeClass) error {
-	if nodeClass.Spec.KubeletConfiguration == nil || nodeClass.Spec.KubeletConfiguration.MaxPods == nil {
-		return nil
-	}
+	maxPods := nodeClass.GetMaxPods()
 	keys := []string{"kube-labels", "kube-env"}
-	maxPodsPerNode := fmt.Sprintf("max-pods-per-node=%d", *nodeClass.Spec.KubeletConfiguration.MaxPods)
-	maxPods := fmt.Sprintf("max-pods=%d", *nodeClass.Spec.KubeletConfiguration.MaxPods)
+	maxPodsPerNode := fmt.Sprintf("max-pods-per-node=%d", maxPods)
+	maxPodsStr := fmt.Sprintf("max-pods=%d", maxPods)
 
 	for _, key := range keys {
 		targetEntry, index, ok := lo.FindIndexOf(metadata.Items, func(item *compute.MetadataItems) bool {
@@ -123,7 +121,7 @@ func SetMaxPodsPerNode(metadata *compute.Metadata, nodeClass *v1alpha1.GCENodeCl
 			return fmt.Errorf("%s metadata not found", key)
 		}
 		targetEntry.Value = swag.String(maxPodsPerNodeRegex.ReplaceAllString(*targetEntry.Value, maxPodsPerNode))
-		targetEntry.Value = swag.String(maxPodsRegex.ReplaceAllString(*targetEntry.Value, maxPods))
+		targetEntry.Value = swag.String(maxPodsRegex.ReplaceAllString(*targetEntry.Value, maxPodsStr))
 
 		metadata.Items[index] = targetEntry
 	}


### PR DESCRIPTION
- centralize retrieving max pods per node
- set pod capacity in node claim based on max pods configuration
- default 110 pods per node

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes consistency error

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #133 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
This sets the default max pods per node to the kubelet default of 110, rather than using the cluster's default configuration
```release-note

```