### PR TITLE
feat: render ephemeral-storage in kubeconfig

### DIFF
--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -61,6 +61,7 @@ func RenderKubeletConfigMetadata(metaData *compute.Metadata, instanceType *cloud
 	}
 	cpuMilliCore := fmt.Sprintf("%dm", instanceType.Overhead.KubeReserved.Cpu().MilliValue())
 	memoryMB := fmt.Sprintf("%dMi", instanceType.Overhead.KubeReserved.Memory().Value()/(1024*1024))
+	ephemeralStorage := instanceType.Overhead.KubeReserved.StorageEphemeral().String()
 
 	configStr := swag.StringValue(targetEntry.Value)
 	if configStr == "" {
@@ -80,6 +81,7 @@ func RenderKubeletConfigMetadata(metaData *compute.Metadata, instanceType *cloud
 	}
 	kubeReserved["cpu"] = cpuMilliCore
 	kubeReserved["memory"] = memoryMB
+	kubeReserved["ephemeral-storage"] = ephemeralStorage
 	config["kubeReserved"] = kubeReserved
 
 	// Marshal back to YAML


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Ephemeral storage correctly set when launching a new node.

#### Which issue(s) this PR fixes:



#### Special notes for your reviewer:

Discussed in Slack: https://cloudpilotaicommunity.slack.com/archives/C093V65481H/p1759983580490859

#### Does this PR introduce a user-facing change?
```release-note
Set the ephemeral-storage field of the kubeReserved object in the kubelet config.
```