### PR TITLE
fix: update list clusters apicall param

### DIFF
--- a/pkg/providers/gke/gke.go
+++ b/pkg/providers/gke/gke.go
@@ -63,8 +63,7 @@ func (p *DefaultProvider) ResolveClusterZones(ctx context.Context) ([]string, er
 	projectID := options.FromContext(ctx).ProjectID
 	clusterName := options.FromContext(ctx).ClusterName
 	resp, err := p.gkeClient.ListClusters(ctx, &containerpb.ListClustersRequest{
-		ProjectId: projectID,
-		Zone:      "-", // "-" means all zones
+		Parent: fmt.Sprintf("projects/%s/locations/-", projectID),
 	})
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to list clusters")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Updates the params used in the listClusters call as Gcloud has seemingly dropped support for the deprecated arguments 

#### Special notes for your reviewer:
Encountered the auth failure on Friday evening, debugging since then, finally solved it live in my company cluster after this change


```release-note
NONE
```