### PR TITLE
fix(nodeclass): prevent reconciliation loop in termination controller

### DIFF
--- a/pkg/controllers/nodeclass/termination/controller.go
+++ b/pkg/controllers/nodeclass/termination/controller.go
@@ -49,7 +49,8 @@ func NewController(kubeClient client.Client) *Controller {
 }
 
 func (c *Controller) Reconcile(ctx context.Context, nodeClass *v1alpha1.GCENodeClass) (reconcile.Result, error) {
-	if !controllerutil.ContainsFinalizer(nodeClass, v1alpha1.TerminationFinalizer) {
+	// Only reconcile if the resource is being deleted
+	if nodeClass.DeletionTimestamp.IsZero() || !controllerutil.ContainsFinalizer(nodeClass, v1alpha1.TerminationFinalizer) {
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
Add a DeletionTimestamp check to ensure the termination controller only reconciles when the resource is being deleted, preventing unnecessary reconciliation loops and conflict errors with hash/status controllers.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

##### Root Cause
The termination controller in `pkg/controllers/nodeclass/termination/controller.go` is missing a deletion timestamp check. It currently runs finalizer cleanup logic on **every reconciliation**, not just when the resource is being deleted.

##### Verification
Before fix:
```bash
$ kubectl get gcenodeclass main -o jsonpath='{.metadata.resourceVersion}' && sleep 1 && kubectl get gcenodeclass main -o jsonpath='{.metadata.resourceVersion}'
1761472964019887005
1761473003492015005  # Changed in 1 second
```

After fix:
```bash
$ kubectl get gcenodeclass main -o jsonpath='{.metadata.resourceVersion}' && sleep 3 && kubectl get gcenodeclass main -o jsonpath='{.metadata.resourceVersion}'
1761475012233839005
1761475012233839005  # Stable
```

#### Which issue(s) this PR fixes:

Fixes #145

#### Does this PR introduce a user-facing change?

```release-note
NONE
```