### PR TITLE
fix: give longer time before deleting empty nodes

### DIFF
--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -52,7 +52,8 @@ func (c *Controller) Reconcile(ctx context.Context, node *corev1.Node) (reconcil
 	if !ok || readyCond.Status != corev1.ConditionTrue {
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
-	if time.Since(readyCond.LastTransitionTime.Time) < 30*time.Second {
+
+	if time.Since(readyCond.LastTransitionTime.Time) < 3*time.Minute {
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
After launching a GPU node, it may show as ready but still require about a minute to allocate GPU resources. Once initialized, the pods can then be scheduled to it. Therefore, allow more time for the pod scheduling.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #none

#### Special notes for your reviewer:
none

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase the NodeReady stabilization period from 30 seconds to 3 minutes before considering nodes for empty-node deletion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9b849436f1359b9a2af9df45e01a2ed90440c53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->