### PR TITLE
refactor: update NetworkTags to use NetworkTag type and improve validation descriptions

### DIFF
--- a/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -295,17 +295,19 @@ spec:
                   metadata
                 type: object
               networkTags:
-                description: |-
-                  NetworkTags is a list of network tags to apply to the node.
-                  Network tags must be RFC1035 compliant, start with a lowercase letter, and contain only
-                  lowercase letters, digits, and hyphens. They must be between 1 and 63 characters long.
+                description: NetworkTags is a list of network tags to apply to the
+                  node.
                 items:
+                  description: |-
+                    NetworkTag represents a single GCE network tag value.
+                    Network tags must be RFC1035 compliant, start with a lowercase letter, and contain only
+                    lowercase letters, digits, and hyphens.
+                  maxLength: 63
+                  minLength: 1
+                  pattern: ^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$
                   type: string
                 maxItems: 20
                 type: array
-                x-kubernetes-validations:
-                - message: network tag must match ^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$
-                  rule: self.all(x, x.matches('^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$'))
               serviceAccount:
                 description: ServiceAccount is the GCP IAM service account email to
                   assign to the instance

--- a/pkg/apis/v1alpha1/gcenodeclass.go
+++ b/pkg/apis/v1alpha1/gcenodeclass.go
@@ -70,12 +70,9 @@ type GCENodeClassSpec struct {
 	// +optional
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// NetworkTags is a list of network tags to apply to the node.
-	// Network tags must be RFC1035 compliant, start with a lowercase letter, and contain only
-	// lowercase letters, digits, and hyphens. They must be between 1 and 63 characters long.
 	// +kubebuilder:validation:MaxItems=20
-	// +kubebuilder:validation:XValidation:message="network tag must match ^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$",rule="self.all(x, x.matches('^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$'))"
 	// +optional
-	NetworkTags []string `json:"networkTags,omitempty"`
+	NetworkTags []NetworkTag `json:"networkTags,omitempty"`
 }
 
 // ImageSelectorTerm defines selection logic for an image used by Karpenter to launch nodes.
@@ -195,6 +192,14 @@ type DiskCategory string
 // SecondaryBootDiskMode is the mode of the secondary boot disk.
 // +kubebuilder:validation:Enum=MODE_UNSPECIFIED;CONTAINER_IMAGE_CACHE
 type SecondaryBootDiskMode string
+
+// NetworkTag represents a single GCE network tag value.
+// Network tags must be RFC1035 compliant, start with a lowercase letter, and contain only
+// lowercase letters, digits, and hyphens.
+// +kubebuilder:validation:Pattern=`^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$`
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=63
+type NetworkTag string
 
 // GCENodeClass is the Schema for the GCENodeClass API
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1alpha1/zz_generated.deepcopy.go
@@ -160,7 +160,7 @@ func (in *GCENodeClassSpec) DeepCopyInto(out *GCENodeClassSpec) {
 	}
 	if in.NetworkTags != nil {
 		in, out := &in.NetworkTags, &out.NetworkTags
-		*out = make([]string, len(*in))
+		*out = make([]NetworkTag, len(*in))
 		copy(*out, *in)
 	}
 	return

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -21,12 +21,14 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/compute/v1"
+
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
 )
 
 func TestMergeInstanceTagsPreservesTemplateAndAddsNetworkTags(t *testing.T) {
 	base := &compute.Tags{Items: []string{"gke-default", "existing"}, Fingerprint: "fp"}
 
-	merged := mergeInstanceTags(base, []string{"existing", "custom"})
+	merged := mergeInstanceTags(base, []v1alpha1.NetworkTag{"existing", "custom"})
 
 	require.NotNil(t, merged)
 	require.Equal(t, []string{"gke-default", "existing", "existing", "custom"}, merged.Items)
@@ -36,7 +38,7 @@ func TestMergeInstanceTagsPreservesTemplateAndAddsNetworkTags(t *testing.T) {
 }
 
 func TestMergeInstanceTagsHandlesNilTemplate(t *testing.T) {
-	merged := mergeInstanceTags(nil, []string{"tag-one", "tag-two"})
+	merged := mergeInstanceTags(nil, []v1alpha1.NetworkTag{"tag-one", "tag-two"})
 
 	require.NotNil(t, merged)
 	require.Equal(t, []string{"tag-one", "tag-two"}, merged.Items)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
GKE Server Version: v1.33.5-gke.1201000
```bash
# kubectl apply -f charts/karpenter/crds
The CustomResourceDefinition "gcenodeclasses.karpenter.k8s.gcp" is invalid: spec.validation.openAPIV3Schema.properties[spec].properties[networkTags].x-kubernetes-validations[0].rule: Forbidden: estimated rule cost exceeds budget by factor of 5.7x (try simplifying the rule, or adding maxItems, maxProperties, and maxLength where arrays, maps, and strings are declared) 
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```