### PR TITLE
support addind custom kms key for node in nodeclass

### DIFF
--- a/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -75,6 +75,19 @@ spec:
                       - pd-ssd
                       - pd-standard
                       type: string
+                    kmsKeyName:
+                      description: |-
+                        KMSKeyName is the Cloud KMS key to use for disk encryption.
+                        Format: projects/{project}/locations/{region}/keyRings/{keyring}/cryptoKeys/{key}
+                        Optionally, you can specify a version: projects/{project}/locations/{region}/keyRings/{keyring}/cryptoKeys/{key}/cryptoKeyVersions/{version}
+                      pattern: ^projects/[^/]+/locations/[^/]+/keyRings/[^/]+/cryptoKeys/[^/]+(/cryptoKeyVersions/[^/]+)?$
+                      type: string
+                    kmsKeyServiceAccount:
+                      description: |-
+                        KMSKeyServiceAccount is the service account to use for accessing the KMS key.
+                        If not specified, the Compute Engine default service account will be used.
+                      pattern: ^[^@]+@(developer\.gserviceaccount\.com|[^@]+\.iam\.gserviceaccount\.com)$
+                      type: string
                     secondaryBootImage:
                       description: SecondaryBootImage is the secondary boot disk image
                         name (e.g. global/images/DISK_IMAGE_NAME).

--- a/pkg/apis/v1alpha1/gcenodeclass.go
+++ b/pkg/apis/v1alpha1/gcenodeclass.go
@@ -183,6 +183,17 @@ type Disk struct {
 	// SecondaryBootMode is the secondary boot disk mode (e.g. CONTAINER_IMAGE_CACHE).
 	// +optional
 	SecondaryBootMode SecondaryBootDiskMode `json:"secondaryBootMode,omitempty"`
+	// KMSKeyName is the Cloud KMS key to use for disk encryption.
+	// Format: projects/{project}/locations/{region}/keyRings/{keyring}/cryptoKeys/{key}
+	// Optionally, you can specify a version: projects/{project}/locations/{region}/keyRings/{keyring}/cryptoKeys/{key}/cryptoKeyVersions/{version}
+	// +kubebuilder:validation:Pattern=`^projects/[^/]+/locations/[^/]+/keyRings/[^/]+/cryptoKeys/[^/]+(/cryptoKeyVersions/[^/]+)?$`
+	// +optional
+	KMSKeyName string `json:"kmsKeyName,omitempty"`
+	// KMSKeyServiceAccount is the service account to use for accessing the KMS key.
+	// If not specified, the Compute Engine default service account will be used.
+	// +kubebuilder:validation:Pattern=`^[^@]+@(developer\.gserviceaccount\.com|[^@]+\.iam\.gserviceaccount\.com)$`
+	// +optional
+	KMSKeyServiceAccount string `json:"kmsKeyServiceAccount,omitempty"`
 }
 
 // DiskCategory represents a disk category type

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -408,6 +408,14 @@ func (p *DefaultProvider) renderDiskProperties(instanceType *cloudprovider.Insta
 			attachedDisk.InitializeParams.SourceImage = disk.SecondaryBootImage
 		}
 
+		// Add disk encryption key if specified
+		if disk.KMSKeyName != "" {
+			attachedDisk.DiskEncryptionKey = &compute.CustomerEncryptionKey{
+				KmsKeyName:           disk.KMSKeyName,
+				KmsKeyServiceAccount: disk.KMSKeyServiceAccount,
+			}
+		}
+
 		attachedDisks[i] = attachedDisk
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds support for Customer-Managed Encryption Keys (CMEK) for disk encryption in GCENodeClass. Users can now specify Cloud KMS keys to encrypt node disks, providing additional control over encryption key management and access policies.

#### Which issue(s) this PR fixes:

Fixes #171 


#### Does this PR introduce a user-facing change?

```release-note
Add support for Customer-Managed Encryption Keys (CMEK) in GCENodeClass disk configuration. Users can now specify Cloud KMS keys for disk encryption using the new `kmsKeyName` and `kmsKeyServiceAccount` fields.