### PR TITLE
fix: zone normalization, spot price fallback, and image discovery

### DIFF
--- a/pkg/providers/imagefamily/ubuntu.go
+++ b/pkg/providers/imagefamily/ubuntu.go
@@ -47,7 +47,7 @@ func (u *Ubuntu) ResolveImages(ctx context.Context, version string) (Images, err
 }
 
 var (
-	ubuntuArm64Pattern     = `(projects\/ubuntu-os-gke-cloud\/global\/images\/ubuntu-gke-\d+-\d+-\d+)-v(\d+)`
+	ubuntuArm64Pattern     = `(projects\/ubuntu-os-gke-cloud\/global\/images\/ubuntu-gke-.*?)(?:-amd64)?-v(\d+)`
 	ubuntuArm64Replacement = `$1-arm64-$2`
 	ubuntuArm64Re          = regexp.MustCompile(ubuntuArm64Pattern)
 )


### PR DESCRIPTION
This PR fixes several critical issues in the GCP provider:

- **Zone Normalization**: Extracts the short zone name from GCE resource paths to ensure correct matching with cluster zones.
- **Spot Price Fallback**: Adds a 40% on-demand price fallback if the external pricing CSV is unavailable.
- **Improved Ubuntu Regex**: Updates the regex to correctly identify modern GKE Ubuntu images.

Fixes #178

**Release Note**
```release-note
fixes zone normalization, spot price fallback, and improved image discovery for GCP provider
```