### PR TITLE
fix: enable multi-zone provisioning on zonal GKE clusters

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -50,11 +50,11 @@ spec:
               value: "{{ .Values.controller.healthProbe.port }}"
             - name: PROJECT_ID
               value: {{ .Values.controller.settings.projectID }}
-            - name: LOCATION
-              value: {{ .Values.controller.settings.location }}
-            {{- if .Values.controller.settings.clusterLocation }}
             - name: CLUSTER_LOCATION
               value: {{ .Values.controller.settings.clusterLocation }}
+            {{- if .Values.controller.settings.nodeLocation }}
+            - name: NODE_LOCATION
+              value: {{ .Values.controller.settings.nodeLocation }}
             {{- end }}
             - name: CLUSTER_NAME
               value: {{ .Values.controller.settings.clusterName }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -72,10 +72,10 @@ controller:
     # -- The GCP project ID.
     projectID: ""
     # -- The GCP region for instance type discovery (e.g., us-central1)
-    location: ""
-    # -- The exact GCP cluster location for GKE API calls (e.g., us-central1-a for zonal, us-central1 for regional).
-    # If not set, defaults to 'location' for backward compatibility.
     clusterLocation: ""
+    # -- The exact GCP cluster location for GKE API calls (e.g., us-central1-a for zonal, us-central1 for regional).
+    # If not set, defaults to 'clusterLocation' for backward compatibility.
+    nodeLocation: ""
     # -- The GCP cluster name.
     clusterName: ""
     # -- The VM memory overhead as a percent that will be subtracted from the total memory for all instance types. The value of `0.075` equals to 7.5%.

--- a/pkg/auth/credential.go
+++ b/pkg/auth/credential.go
@@ -21,6 +21,6 @@ import "google.golang.org/api/option"
 type Credential struct {
 	ProjectID         string
 	Region            string
-	ClusterLocation   string
+	NodeLocation      string
 	CredentialOptions option.ClientOption
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -68,7 +68,7 @@ type Operator struct {
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
 	os.Setenv(options.GCPAuth, options.FromContext(ctx).GCPAuth)
 
-	region, err := determineRegion(ctx, options.FromContext(ctx).ProjectID, options.FromContext(ctx).Location)
+	region, err := determineRegion(ctx, options.FromContext(ctx).ProjectID, options.FromContext(ctx).ClusterLocation)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to determine region")
 		os.Exit(1)
@@ -85,9 +85,9 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		os.Exit(1)
 	}
 	auth := auth.Credential{
-		ProjectID:       options.FromContext(ctx).ProjectID,
-		Region:          region,
-		ClusterLocation: options.FromContext(ctx).ClusterLocation,
+		ProjectID:    options.FromContext(ctx).ProjectID,
+		Region:       region,
+		NodeLocation: options.FromContext(ctx).NodeLocation,
 	}
 
 	versionProvider := version.NewDefaultProvider(operator.KubernetesInterface)
@@ -101,8 +101,8 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		region,
 		options.FromContext(ctx).ProjectID,
 		options.FromContext(ctx).NodePoolServiceAccount,
-		options.FromContext(ctx).Location,
 		options.FromContext(ctx).ClusterLocation,
+		options.FromContext(ctx).NodeLocation,
 	)
 	imageProvider := imagefamily.NewDefaultProvider(computeService, nodeTemplateProvider)
 	pricingProvider, err := pricing.NewDefaultProvider(ctx, region)

--- a/pkg/operator/options/option_validation.go
+++ b/pkg/operator/options/option_validation.go
@@ -33,8 +33,8 @@ func (o *Options) validateRequiredFields() error {
 	if o.ClusterName == "" {
 		return fmt.Errorf("missing required flag %s or env var %s", gkeClusterFlagName, gkeClusterNameEnvVarName)
 	}
-	if o.Location == "" {
-		return fmt.Errorf("missing required flag %s or env var %s", locationFlagName, locationEnvVarName)
+	if o.ClusterLocation == "" {
+		return fmt.Errorf("missing required flag %s or env var %s", clusterLocationFlagName, clusterLocationEnvVarName)
 	}
 	return nil
 }

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -30,10 +30,10 @@ import (
 const (
 	projectIDEnvVarName               = "PROJECT_ID"
 	projectIDFlagName                 = "project-id"
-	locationEnvVarName                = "LOCATION"
-	locationFlagName                  = "location"
 	clusterLocationEnvVarName         = "CLUSTER_LOCATION"
 	clusterLocationFlagName           = "cluster-location"
+	nodeLocationEnvVarName            = "NODE_LOCATION"
+	nodeLocationFlagName              = "node-location"
 	gkeClusterNameEnvVarName          = "CLUSTER_NAME"
 	gkeClusterFlagName                = "cluster-name"
 	vmMemoryOverheadPercentEnvVarName = "VM_MEMORY_OVERHEAD_PERCENT"
@@ -52,8 +52,8 @@ type optionsKey struct{}
 
 type Options struct {
 	ProjectID               string
-	Location                string
 	ClusterLocation         string
+	NodeLocation            string
 	ClusterName             string
 	VMMemoryOverheadPercent float64
 	// GCPAuth is the path to the Google Application Credentials JSON file.
@@ -65,8 +65,8 @@ type Options struct {
 
 func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.ProjectID, projectIDFlagName, env.WithDefaultString(projectIDEnvVarName, ""), "GCP project ID where the GKE cluster is running.")
-	fs.StringVar(&o.Location, locationFlagName, env.WithDefaultString(locationEnvVarName, ""), "GCP region for instance type discovery (e.g., us-central1).")
-	fs.StringVar(&o.ClusterLocation, clusterLocationFlagName, env.WithDefaultString(clusterLocationEnvVarName, ""), "Exact GCP location of the GKE cluster for API calls (e.g., us-central1-a for zonal, us-central1 for regional). Defaults to 'location' if not set.")
+	fs.StringVar(&o.ClusterLocation, clusterLocationFlagName, env.WithDefaultString(clusterLocationEnvVarName, ""), "GCP region for instance type discovery (e.g., us-central1).")
+	fs.StringVar(&o.NodeLocation, nodeLocationFlagName, env.WithDefaultString(nodeLocationEnvVarName, ""), "Exact GCP location of the GKE cluster for API calls (e.g., us-central1-a for zonal, us-central1 for regional). Defaults to 'clusterLocation' if not set.")
 	fs.StringVar(&o.ClusterName, gkeClusterFlagName, env.WithDefaultString(gkeClusterNameEnvVarName, ""), "Name of the GKE cluster that provisioned nodes should connect to.")
 	fs.Float64Var(&o.VMMemoryOverheadPercent, vmMemoryOverheadPercentFlagName, utils.WithDefaultFloat64(vmMemoryOverheadPercentEnvVarName, 0.07), "Percentage of memory overhead for VM. If not set, the controller will use the default value 7%.")
 	fs.StringVar(&o.GCPAuth, GCPAuth, env.WithDefaultString(GCPAuth, ""), "Path to the Google Application Credentials JSON file. If not set, the controller will use the default credentials from the environment.")
@@ -81,12 +81,12 @@ func (o *Options) Parse(fs *coreoptions.FlagSet, args ...string) error {
 		}
 		return fmt.Errorf("parsing flags, %w", err)
 	}
-	
-	// Backward compatibility: if ClusterLocation not set, default to Location
-	if o.ClusterLocation == "" {
-		o.ClusterLocation = o.Location
+
+	// Backward compatibility: if NodeLocation not set, default to ClusterLocation
+	if o.NodeLocation == "" {
+		o.NodeLocation = o.ClusterLocation
 	}
-	
+
 	if err := o.Validate(); err != nil {
 		return fmt.Errorf("validating options, %w", err)
 	}

--- a/pkg/providers/gke/gke.go
+++ b/pkg/providers/gke/gke.go
@@ -63,11 +63,11 @@ func (p *DefaultProvider) ResolveClusterZones(ctx context.Context) ([]string, er
 	}
 
 	projectID := options.FromContext(ctx).ProjectID
-	location := options.FromContext(ctx).Location
+	clusterLocation := options.FromContext(ctx).ClusterLocation
 
-	region := location
-	if strings.Count(location, "-") == 2 {
-		parts := strings.Split(location, "-")
+	region := clusterLocation
+	if strings.Count(clusterLocation, "-") == 2 {
+		parts := strings.Split(clusterLocation, "-")
 		region = strings.Join(parts[:2], "-")
 	}
 


### PR DESCRIPTION
Separates LOCATION env var into two distinct variables to support multi-zone provisioning on zonal GKE clusters:

- `CLUSTER_LOCATION` (renamed from `LOCATION`): Region for instance type filtering (e.g., us-central1)
- `NODE_LOCATION` (renamed from `CLUSTER_LOCATION`): Exact cluster location for GKE API (e.g., us-central1-a)

**Changes:**
- pkg/auth/credential.go: Rename field to NodeLocation
- pkg/operator/options/options.go: Update env vars and flags with new naming
- pkg/providers/gke/gke.go: Use compute service to list all zones in region
- pkg/providers/nodepooltemplate/nodepooltemplate.go: Update to use new variable names
- charts/karpenter/values.yaml: Update config with clusterLocation and nodeLocation
- charts/karpenter/templates/deployment.yaml: Pass renamed env vars

**Variable Renaming** (per review feedback from @jwcesign):
- `location` → `clusterLocation` (region for instance discovery)
- `clusterLocation` → `nodeLocation` (exact cluster location)

**Backward Compatibility**: Maintained by defaulting `nodeLocation` to `clusterLocation` if not explicitly set.

**Related**: Bug fix for nil pointer panic split into #183

Fixes #180

**Release Note**:
```release-note
Enable multi-zone node provisioning on zonal GKE clusters
```