### PR TITLE
fix: nil pointer panic in resolveInstanceImage

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -246,6 +246,9 @@ func resolveInstanceImage(instance *compute.Instance) string {
 	if !ok {
 		return ""
 	}
+	if image.InitializeParams == nil {
+		return ""
+	}
 	return image.InitializeParams.SourceImage
 }
 


### PR DESCRIPTION
Fixes nil pointer panic when reading existing instances in regional/zonal clusters.

**Problem**: When Karpenter reads existing instances (especially in regional clusters), `InitializeParams` can be nil since it's only populated during instance creation, not when reading existing instances.

**Solution**: Add nil check before accessing `InitializeParams.SourceImage`.

**Error Fixed**:
```
runtime error: invalid memory address or nil pointer dereference
at instance.go:249
```

**Stack Trace**:
```
github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instance.resolveInstanceImage(...)
github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instance/instance.go:249
```

**Testing**: Prevents crash when:
- Karpenter reconciles existing instances
- Reading instance metadata for already-running nodes  
- High GCP API load returns incomplete data

**Related**: Reported in #181 feedback

**Release Note**:
```release-note
fix nil pointer panic when resolving instance images for existing instances
```