### PR TITLE
fix: add missing namespace to Deployment and ServiceAccount in Helm chart

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "karpenter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}

--- a/charts/karpenter/templates/serviceaccount.yaml
+++ b/charts/karpenter/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "karpenter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION

#### What type of PR is this?
 /kind bug

#### What this PR does / why we need it:
Adds the missing `namespace: {{ .Release.Namespace }}` field to the `Deployment` and `ServiceAccount` templates in the Helm chart.
When deploying the Karpenter Helm chart using tools like Tanka with a default namespace other than `karpenter`, the `Deployment` and `ServiceAccount` resources are created in the wrong namespace, while other resources (Service, PodDisruptionBudget, Role, RoleBinding) are correctly created in the target namespace.

#### Which issue(s) this PR fixes:
Fixes #190

#### Does this PR introduce a user-facing change?
```release-note
Fixed Helm chart Deployment and ServiceAccount templates to include namespace field, ensuring correct namespace placement.
```