### PR TITLE
docs: fix helm chart variable name for cluster location

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -67,7 +67,7 @@ helm repo add karpenter-provider-gcp https://cloudpilot-ai.github.io/karpenter-p
 helm upgrade karpenter charts/karpenter --install \
   --namespace karpenter-system --create-namespace \
   --set "controller.settings.projectID=${PROJECT_ID}" \
-  --set "controller.settings.location=${REGION}" \
+  --set "controller.settings.clusterLocation=${REGION}" \
   --set "controller.settings.clusterName=${CLUSTER_NAME}" \
   --set "credentials.enabled=false" \
   --set "serviceAccount.annotations.iam\.gke\.io/gcp-service-account=karpenter-gsa@${PROJECT_ID}.iam.gserviceaccount.com" \
@@ -151,7 +151,7 @@ helm repo add karpenter-provider-gcp https://cloudpilot-ai.github.io/karpenter-p
 helm upgrade karpenter charts/karpenter --install \
   --namespace karpenter-system --create-namespace \
   --set "controller.settings.projectID=${PROJECT_ID}" \
-  --set "controller.settings.location=${REGION}" \
+  --set "controller.settings.clusterLocation=${REGION}" \
   --set "controller.settings.clusterName=${CLUSTER_NAME}" \
   --wait
 ```


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR corrects the name of the variable used to set the cluster location in the Helm chart installation instructions.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Here's the code where this configuration variable used: [karpenter-provider-gcp/charts/karpenter/templates/deployment.yaml#L55](https://github.com/cloudpilot-ai/karpenter-provider-gcp/blob/8d2289c92980de97481072f56fdcb89160195d3d/charts/karpenter/templates/deployment.yaml#L55).

Behavior before:
```
panic: validating options, missing required flag cluster-location or env var CLUSTER_LOCATION

goroutine 1 [running]:
github.com/samber/lo.must({0x2b0ede0, 0xc0008c2d40}, {0x0, 0x0, 0x0})
	github.com/samber/lo@v1.51.0/errors.go:55 +0x1df
github.com/samber/lo.Must0(...)
	github.com/samber/lo@v1.51.0/errors.go:74
sigs.k8s.io/karpenter/pkg/operator/injection.WithOptionsOrDie({0x3689fe0, 0x53f2040}, {0xc000a36ec0, 0x2, 0x419274?})
	sigs.k8s.io/karpenter@v1.7.0/pkg/operator/injection/injection.go:53 +0x13c
sigs.k8s.io/karpenter/pkg/operator.NewOperator({0x0?, 0x0?, 0x0?})
	sigs.k8s.io/karpenter@v1.7.0/pkg/operator/operator.go:124 +0x6a
main.main()
	github.com/cloudpilot-ai/karpenter-provider-gcp/cmd/controller/main.go:32 +0x29
```

Behavior after:
```
{"level":"INFO","time":"2026-02-22T17:41:55.699Z","logger":"controller","message":"attempting to determine if location is a region or a zone","commit":"161e3ec","ProjectID":"cameronhudson8","Location":"us-central1-a"}
{"level":"INFO","time":"2026-02-22T17:41:55.699Z","logger":"controller","message":"location is a zone, extracting region","commit":"161e3ec","ProjectID":"cameronhudson8","Location":"us-central1-a"}
{"level":"INFO","time":"2026-02-22T17:41:55.705Z","logger":"controller","message":"resolving zones","commit":"161e3ec","ProjectID":"cameronhudson8","Region":"us-central1"}
...
```

#### Does this PR introduce a user-facing change?

```release-note
Corrects the name of the variable used to set the cluster location in the Helm chart installation instructions.
```
