### PR TITLE
fix: on-demand instance selection to respect zone constraints.

### DIFF
--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -17,11 +17,16 @@ limitations under the License.
 package instance
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
+	corev1 "k8s.io/api/core/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
 	pkgcache "github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/cache"
@@ -122,4 +127,142 @@ func TestInsufficientCapacityBackoffTTLForOtherReasons(t *testing.T) {
 	ttl := insufficientCapacityBackoffTTL("ZONE_RESOURCE_POOL_EXHAUSTED")
 
 	require.Equal(t, pkgcache.UnavailableOfferingsTTL, ttl)
+}
+
+type fakeGKEProvider struct {
+	zones []string
+}
+
+func (f *fakeGKEProvider) ResolveClusterZones(context.Context) ([]string, error) {
+	return f.zones, nil
+}
+
+func TestSelectZone_OnDemandHonorsTopologyRequirement(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	p := &DefaultProvider{
+		gkeProvider: &fakeGKEProvider{
+			zones: []string{"europe-west4-a", "europe-west4-b", "europe-west4-c"},
+		},
+	}
+
+	nodeClaim := &karpv1.NodeClaim{
+		Spec: karpv1.NodeClaimSpec{
+			Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+				{
+					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+						Key:      corev1.LabelTopologyZone,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"europe-west4-b"},
+					},
+				},
+			},
+		},
+	}
+
+	instanceType := &cloudprovider.InstanceType{
+		Offerings: cloudprovider.Offerings{
+			{
+				Available: true,
+				Requirements: scheduling.NewRequirements(
+					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "europe-west4-b"),
+				),
+			},
+		},
+	}
+
+	zone, err := p.selectZone(ctx, nodeClaim, instanceType, karpv1.CapacityTypeOnDemand)
+	require.NoError(t, err)
+	require.Equal(t, "europe-west4-b", zone)
+}
+
+func TestSelectZone_FailsWhenNoZonesMatchRequirement(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	p := &DefaultProvider{
+		gkeProvider: &fakeGKEProvider{
+			zones: []string{"europe-west4-a", "europe-west4-c"},
+		},
+	}
+
+	nodeClaim := &karpv1.NodeClaim{
+		Spec: karpv1.NodeClaimSpec{
+			Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+				{
+					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+						Key:      corev1.LabelTopologyZone,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"europe-west4-b"},
+					},
+				},
+			},
+		},
+	}
+
+	instanceType := &cloudprovider.InstanceType{
+		Offerings: cloudprovider.Offerings{
+			{
+				Available: true,
+				Requirements: scheduling.NewRequirements(
+					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "europe-west4-a"),
+				),
+			},
+		},
+	}
+
+	_, err := p.selectZone(ctx, nodeClaim, instanceType, karpv1.CapacityTypeOnDemand)
+	require.Error(t, err)
+}
+
+func TestSelectZone_SpotChoosesCheapestWithinTopologyRequirement(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	p := &DefaultProvider{
+		gkeProvider: &fakeGKEProvider{
+			zones: []string{"europe-west4-a", "europe-west4-b"},
+		},
+	}
+
+	nodeClaim := &karpv1.NodeClaim{
+		Spec: karpv1.NodeClaimSpec{
+			Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+				{
+					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+						Key:      corev1.LabelTopologyZone,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"europe-west4-a", "europe-west4-b"},
+					},
+				},
+			},
+		},
+	}
+
+	instanceType := &cloudprovider.InstanceType{
+		Offerings: cloudprovider.Offerings{
+			{
+				Available: true,
+				Price:     1.0,
+				Requirements: scheduling.NewRequirements(
+					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "europe-west4-a"),
+				),
+			},
+			{
+				Available: true,
+				Price:     0.5,
+				Requirements: scheduling.NewRequirements(
+					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "europe-west4-b"),
+				),
+			},
+		},
+	}
+
+	zone, err := p.selectZone(ctx, nodeClaim, instanceType, karpv1.CapacityTypeSpot)
+	require.NoError(t, err)
+	require.Equal(t, "europe-west4-b", zone)
 }


### PR DESCRIPTION
This PR closes https://github.com/cloudpilot-ai/karpenter-provider-gcp/issues/189

Current logic for on-demand picks randomly from available zones without looking at requirements, this fix aims to address this for both spot and on-demand instances

Additionally adds some tests to verify logic 