### PR TITLE
Fix instance leak race condition by resolving existing instances across all zones

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -215,12 +215,15 @@ func (p *DefaultProvider) isInstanceExists(ctx context.Context, zone, instanceNa
 
 func (p *DefaultProvider) findInstanceByNodeClaim(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*compute.Instance, error) {
 	instanceName := fmt.Sprintf("karpenter-%s", nodeClaim.Name)
-	call := p.computeService.Instances.AggregatedList(p.projectID)
-	call.Filter(fmt.Sprintf("name eq %s", instanceName))
+	call := p.computeService.Instances.AggregatedList(p.projectID).Filter(fmt.Sprintf("name eq %s", instanceName))
 
+	regionPrefix := "zones/" + p.region + "-"
 	var instance *compute.Instance
 	err := call.Pages(ctx, func(resp *compute.InstanceAggregatedList) error {
-		for _, items := range resp.Items {
+		for zoneKey, items := range resp.Items {
+			if !strings.HasPrefix(zoneKey, regionPrefix) {
+				continue
+			}
 			for _, i := range items.Instances {
 				instance = i
 				return nil
@@ -252,10 +255,11 @@ func (p *DefaultProvider) adoptExistingInstance(ctx context.Context, existingIns
 		Location:     zone,
 		ProjectID:    p.projectID,
 		ImageID:      resolveInstanceImage(existingInstance),
-		CreationTime: time.Now(),
+		CreationTime: parseCreationTime(existingInstance.CreationTimestamp),
 		CapacityType: capacityType,
 		Labels:       existingInstance.Labels,
-		Status:       InstanceStatusProvisioning,
+		Tags:         existingInstance.Labels,
+		Status:       existingInstance.Status,
 	}
 }
 

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -19,6 +19,7 @@ package instance
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/compute/v1"
@@ -216,6 +217,74 @@ func TestSelectZone_FailsWhenNoZonesMatchRequirement(t *testing.T) {
 
 	_, err := p.selectZone(ctx, nodeClaim, instanceType, karpv1.CapacityTypeOnDemand)
 	require.Error(t, err)
+}
+
+func TestAdoptExistingInstance_PopulatesFieldsFromGCEInstance(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p := &DefaultProvider{projectID: "my-project"}
+
+	gceInstance := &compute.Instance{
+		Name:              "karpenter-test-node",
+		Zone:              "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-west4-a",
+		MachineType:       "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-west4-a/machineTypes/n2-standard-8",
+		Status:            "RUNNING",
+		CreationTimestamp: "2025-10-31T11:09:17.350-07:00",
+		Labels:            map[string]string{"karpenter-sh-nodepool": "my-pool"},
+		Scheduling: &compute.Scheduling{
+			ProvisioningModel: "SPOT",
+		},
+		Disks: []*compute.AttachedDisk{
+			{
+				Boot: true,
+				InitializeParams: &compute.AttachedDiskInitializeParams{
+					SourceImage: "projects/gke-node-images/global/images/gke-cos",
+				},
+			},
+		},
+	}
+
+	result := p.adoptExistingInstance(ctx, gceInstance, karpv1.CapacityTypeSpot)
+
+	require.Equal(t, "karpenter-test-node", result.InstanceID)
+	require.Equal(t, "karpenter-test-node", result.Name)
+	require.Equal(t, "us-west4-a", result.Location, "zone URL should be trimmed to zone name")
+	require.Equal(t, "n2-standard-8", result.Type, "machineType URL should be trimmed to type name")
+	require.Equal(t, "my-project", result.ProjectID)
+	require.Equal(t, "projects/gke-node-images/global/images/gke-cos", result.ImageID)
+	require.Equal(t, karpv1.CapacityTypeSpot, result.CapacityType)
+	require.Equal(t, "RUNNING", result.Status, "status must reflect the actual instance state, not hardcoded PROVISIONING")
+	require.Equal(t, gceInstance.Labels, result.Labels)
+	require.Equal(t, gceInstance.Labels, result.Tags, "Tags must be populated (matches syncInstances behavior)")
+	require.False(t, result.CreationTime.IsZero(), "CreationTime must not be zero")
+
+	// Verify the creation time was parsed from the instance timestamp, not time.Now()
+	expectedTime, err := time.Parse(time.RFC3339, "2025-10-31T11:09:17.350-07:00")
+	require.NoError(t, err)
+	require.Equal(t, expectedTime, result.CreationTime)
+}
+
+func TestAdoptExistingInstance_UsesActualStatusNotProvisioning(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	p := &DefaultProvider{projectID: "my-project"}
+
+	for _, status := range []string{"RUNNING", "STAGING", "PROVISIONING"} {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			gceInstance := &compute.Instance{
+				Name:              "karpenter-test-node",
+				Zone:              "us-west4-a",
+				MachineType:       "n2-standard-8",
+				Status:            status,
+				CreationTimestamp: "2025-10-31T11:09:17Z",
+			}
+			result := p.adoptExistingInstance(ctx, gceInstance, karpv1.CapacityTypeOnDemand)
+			require.Equal(t, status, result.Status)
+		})
+	}
 }
 
 func TestSelectZone_SpotChoosesCheapestWithinTopologyRequirement(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### Description
This PR addresses a race condition in the instance creation logic that could result in leaked VMs in GCE.

#### The Problem:
When Karpenter attempts to provision an on-demand instance, it selects a random zone. If the `Instances.Insert` API call succeeds in GCE, but the response is lost (e.g., network timeout, controller crash, or a transient error), the controller fails to record the provider ID.

On the next reconciliation loop, the controller retries the creation. For on-demand instances, it might select a different random zone. Since it only checks for existence in the newly selected zone, it misses the instance already running in the previously selected zone. This results in the first instance being leaked (orphaned) while a second one is created.

#### The Solution:
I have updated the Create method in `instance.go` to perform a global check before attempting creation.
The controller now checks if an instance with the deterministic name already exists in any zone.
If an existing instance is found, it is immediately adopted and returned, preventing duplicate creation.

#### Does this PR introduce a user-facing change?
```Bug Fixes:
Fixed a race condition that could cause Karpenter to leak GCE instances.
```