### PR TITLE
fix: update Makefile variable for cluster location and add instance shape label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ run: ## Run Karpenter controller binary against your local cluster
 		DISABLE_LEADER_ELECTION=true \
 		CLUSTER_NAME=${CLUSTER_NAME} \
 		PROJECT_ID=${PROJECT_ID} \
-		LOCATION=${REGION} \
+		CLUSTER_LOCATION=${REGION} \
 		INTERRUPTION_QUEUE=${CLUSTER_NAME} \
 		FEATURE_GATES="SpotToSpotConsolidation=true,NodeOverlay=true" \
 		go run ./cmd/controller/main.go

--- a/pkg/apis/v1alpha1/labels.go
+++ b/pkg/apis/v1alpha1/labels.go
@@ -33,6 +33,7 @@ func init() {
 	karpv1.WellKnownLabels = karpv1.WellKnownLabels.Insert(
 		LabelInstanceCategory,
 		LabelInstanceFamily,
+		LabelInstanceShape,
 		LabelInstanceGeneration,
 		LabelInstanceSize,
 		LabelInstanceCPU,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes one bug that caused every NodeClaim to fail immediately with "_insufficient capacity, all requested instance types were unavailable during launch_" when running the controller locally.

#### Which issue(s) this PR fixes:
Part of #189

#### Special notes for your reviewer:
The bug was discovered while testing locally with `make run` against an existing cluster. It consistently failed, every NodeClaim was created and immediately deleted. The **LabelInstanceShape** omission from **WellKnownLabels** was the root cause.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```