### PR TITLE
fix: Register GKE readiness-gate labels as well-known for DaemonSet scheduling simulation

### DIFF
--- a/pkg/apis/v1alpha1/labels.go
+++ b/pkg/apis/v1alpha1/labels.go
@@ -45,6 +45,12 @@ func init() {
 		LabelInstanceGPUMemory,
 		LabelTopologyZoneID,
 		corev1.LabelWindowsBuild,
+		LabelGKEReadinessCalicoReady,
+		LabelGKEReadinessKubeProxyReady,
+		LabelGKEReadinessMetadataServerEnabled,
+		LabelGKEReadinessMasqAgentReady,
+		LabelGKEReadinessNetdReady,
+		LabelGKEReadinessNodeLocalDNSReady,
 	)
 }
 
@@ -77,6 +83,19 @@ var (
 	ImageFamilyUbuntu               = "Ubuntu"
 	ImageFamilyContainerOptimizedOS = "ContainerOptimizedOS"
 	ImageFamilyCustom               = "Custom"
+
+	// GKE readiness-gate labels are applied by the GKE control plane after node
+	// registration. System DaemonSets use these as nodeSelector to gate scheduling
+	// until the node is ready for each subsystem. Registering them as well-known
+	// allows Karpenter's DaemonSet overhead simulation (isDaemonPodCompatible) to
+	// include these DaemonSets when sizing instance types, preventing undersizing
+	// and node churn. See https://github.com/cloudpilot-ai/karpenter-provider-gcp/issues/202
+	LabelGKEReadinessCalicoReady            = "projectcalico.org/ds-ready"
+	LabelGKEReadinessKubeProxyReady         = "node.kubernetes.io/kube-proxy-ds-ready"
+	LabelGKEReadinessMetadataServerEnabled  = "iam.gke.io/gke-metadata-server-enabled"
+	LabelGKEReadinessMasqAgentReady         = "node.kubernetes.io/masq-agent-ds-ready"
+	LabelGKEReadinessNetdReady              = "cloud.google.com/gke-netd-ready"
+	LabelGKEReadinessNodeLocalDNSReady      = "addon.gke.io/node-local-dns-ds-ready"
 
 	LabelNodeClass                           = apis.Group + "/gcenodeclass"
 	LabelTopologyZoneID                      = "topology.k8s.gcp/zone-id"


### PR DESCRIPTION
#### What type of PR is this?

Bug fix

#### What this PR does / why we need it:

GKE system DaemonSets (calico-node, kube-proxy, gke-metadata-server, ip-masq-agent, netd, node-local-dns) use readiness-gate `nodeSelector` labels applied by the GKE control plane after node registration. These labels are absent from the virtual node during `getDaemonOverhead()` → `isDaemonPodCompatible()`, so these DaemonSets are excluded from the overhead calculation.

This underestimates CPU overhead by ~408m on typical GKE clusters. On clusters where a small instance type is selected (e.g. e2-medium with 940m allocatable), this causes an infinite provision → insufficient-cpu → empty-node-delete cycle.

The fix registers 6 GKE readiness-gate labels as `WellKnownLabels` in `pkg/apis/v1alpha1/labels.go`:

- `projectcalico.org/ds-ready` — calico-node (Dataplane V1)
- `node.kubernetes.io/kube-proxy-ds-ready` — kube-proxy (non-DPv2)
- `iam.gke.io/gke-metadata-server-enabled` — gke-metadata-server (Workload Identity)
- `node.kubernetes.io/masq-agent-ds-ready` — ip-masq-agent
- `cloud.google.com/gke-netd-ready` — netd
- `addon.gke.io/node-local-dns-ds-ready` — node-local-dns

Core Karpenter's `isDaemonPodCompatible()` calls `Requirements.Compatible()` with `AllowUndefinedWellKnownLabels`. When a DaemonSet pod requires a label in `WellKnownLabels`, the check passes even if the `NodeClaimTemplate` doesn't define it. This correctly includes GKE system DaemonSets in `getDaemonOverhead()`.

Different cluster configurations are handled automatically — if a DaemonSet doesn't exist on a cluster (e.g. no calico-node on Dataplane V2), it's never evaluated.

#### Which issue(s) this PR fixes:

Fixes #202

#### Special notes for your reviewer:

As noted in the issue, this is also a class of issue that affects all Karpenter providers (ref: kubernetes-sigs/karpenter#919). The `WellKnownLabels` approach is the mechanism upstream Karpenter core designed for exactly this — cloud providers register platform-specific labels so `isDaemonPodCompatible()` doesn't reject DaemonSets with unknown nodeSelector keys.

#### Does this PR introduce a user-facing change?

```release-note
Register GKE readiness-gate labels as well-known for DaemonSet scheduling simulation to ensure accurate daemon overhead calculation and prevent undersized instance selection.
```
