### PR TITLE
feat: add subnet range name to GCENodeClass

### DIFF
--- a/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -352,6 +352,15 @@ spec:
                   type: string
                 maxItems: 20
                 type: array
+              subnetRangeName:
+                description: |-
+                  SubnetRangeName is the name of the subnetwork secondary IPv4 range from which
+                  to allocate pod IP addresses. If not specified, the range inherited from the node
+                  pool instance template is used (typically the default pods range).
+                maxLength: 63
+                minLength: 1
+                pattern: ^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$
+                type: string
               serviceAccount:
                 description: ServiceAccount is the GCP IAM service account email to
                   assign to the instance

--- a/pkg/apis/v1alpha1/gcenodeclass.go
+++ b/pkg/apis/v1alpha1/gcenodeclass.go
@@ -49,6 +49,14 @@ type GCENodeClassSpec struct {
 	// +kubebuilder:validation:Enum:={Ubuntu,ContainerOptimizedOS}
 	// +optional
 	ImageFamily *string `json:"imageFamily,omitempty"`
+	// SubnetRangeName is the name of the subnetwork secondary IPv4 range from which
+	// to allocate pod IP addresses. If not specified, the range inherited from the node
+	// pool instance template is used (typically the default pods range).
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$`
+	// +optional
+	SubnetRangeName *string `json:"subnetRangeName,omitempty"`
 	// KubeletConfiguration defines args to be used when configuring kubelet on provisioned nodes.
 	// They are a vswitch of the upstream types, recognizing not all options may be supported.
 	// Wherever possible, the types and names should reflect the upstream kubelet types.

--- a/pkg/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1alpha1/zz_generated.deepcopy.go
@@ -151,6 +151,11 @@ func (in *GCENodeClassSpec) DeepCopyInto(out *GCENodeClassSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SubnetRangeName != nil {
+		in, out := &in.SubnetRangeName, &out.SubnetRangeName
+		*out = new(string)
+		**out = **in
+	}
 	if in.KubeletConfiguration != nil {
 		in, out := &in.KubeletConfiguration, &out.KubeletConfiguration
 		*out = new(KubeletConfiguration)

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -713,9 +713,14 @@ func (p *DefaultProvider) setupNetworkInterfaces(template *compute.InstanceTempl
 	var networkInterfaces []*compute.NetworkInterface
 
 	for _, networkInterface := range template.Properties.NetworkInterfaces {
+		copiedAliasIpRanges := make([]*compute.AliasIpRange, len(networkInterface.AliasIpRanges))
+		for i, r := range networkInterface.AliasIpRanges {
+			copied := *r
+			copiedAliasIpRanges[i] = &copied
+		}
 		tmpNetworkInterface := &compute.NetworkInterface{
 			AccessConfigs:            networkInterface.AccessConfigs,
-			AliasIpRanges:            networkInterface.AliasIpRanges,
+			AliasIpRanges:            copiedAliasIpRanges,
 			Fingerprint:              networkInterface.Fingerprint,
 			InternalIpv6PrefixLength: networkInterface.InternalIpv6PrefixLength,
 			Ipv6AccessConfigs:        networkInterface.Ipv6AccessConfigs,
@@ -732,10 +737,13 @@ func (p *DefaultProvider) setupNetworkInterfaces(template *compute.InstanceTempl
 			ForceSendFields:          networkInterface.ForceSendFields,
 			NullFields:               networkInterface.NullFields,
 		}
-		for aliasIpRangeIndex := range networkInterface.AliasIpRanges {
+		for aliasIpRangeIndex := range copiedAliasIpRanges {
 			// Set the IP CIDR range for the alias IP range based on the calculated targetRange
 			// TODO: Optionally, add validation to ensure the network interface supports this range if needed
 			tmpNetworkInterface.AliasIpRanges[aliasIpRangeIndex].IpCidrRange = fmt.Sprintf("/%d", targetRange)
+			if nodeClass.Spec.SubnetRangeName != nil {
+				tmpNetworkInterface.AliasIpRanges[aliasIpRangeIndex].SubnetworkRangeName = *nodeClass.Spec.SubnetRangeName
+			}
 		}
 		networkInterfaces = append(networkInterfaces, tmpNetworkInterface)
 	}

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -495,3 +495,80 @@ func TestRenderDiskProperties_MultipleDisksSetProvisioningIndependently(t *testi
 	require.Zero(t, disks[1].InitializeParams.ProvisionedThroughput)
 }
 
+func TestSetupNetworkInterfaces(t *testing.T) {
+	t.Parallel()
+
+	makeTemplate := func(rangeName string) *compute.InstanceTemplate {
+		return &compute.InstanceTemplate{
+			Properties: &compute.InstanceProperties{
+				NetworkInterfaces: []*compute.NetworkInterface{
+					{
+						AliasIpRanges: []*compute.AliasIpRange{
+							{SubnetworkRangeName: rangeName, IpCidrRange: "/24"},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	p := &DefaultProvider{}
+
+	t.Run("without SubnetRangeName, SubnetworkRangeName is unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		nodeClass := &v1alpha1.GCENodeClass{}
+		template := makeTemplate("original-pods-range")
+
+		result := p.setupNetworkInterfaces(template, nodeClass)
+
+		require.Len(t, result, 1)
+		require.Len(t, result[0].AliasIpRanges, 1)
+		require.Equal(t, "original-pods-range", result[0].AliasIpRanges[0].SubnetworkRangeName)
+		require.Equal(t, "original-pods-range", template.Properties.NetworkInterfaces[0].AliasIpRanges[0].SubnetworkRangeName, "template must not be mutated")
+	})
+
+	t.Run("with SubnetRangeName, SubnetworkRangeName is overridden", func(t *testing.T) {
+		t.Parallel()
+
+		rangeName := "pods-secondary"
+		nodeClass := &v1alpha1.GCENodeClass{
+			Spec: v1alpha1.GCENodeClassSpec{
+				SubnetRangeName: &rangeName,
+			},
+		}
+		template := makeTemplate("original-pods-range")
+
+		result := p.setupNetworkInterfaces(template, nodeClass)
+
+		require.Len(t, result, 1)
+		require.Len(t, result[0].AliasIpRanges, 1)
+		require.Equal(t, "pods-secondary", result[0].AliasIpRanges[0].SubnetworkRangeName)
+		require.Equal(t, "original-pods-range", template.Properties.NetworkInterfaces[0].AliasIpRanges[0].SubnetworkRangeName, "template must not be mutated")
+	})
+
+	t.Run("CIDR prefix is set from maxPods in both cases", func(t *testing.T) {
+		t.Parallel()
+
+		maxPods := int32(32)
+		nodeClass := &v1alpha1.GCENodeClass{
+			Spec: v1alpha1.GCENodeClassSpec{
+				KubeletConfiguration: &v1alpha1.KubeletConfiguration{MaxPods: &maxPods},
+			},
+		}
+		template := makeTemplate("some-range")
+
+		result := p.setupNetworkInterfaces(template, nodeClass)
+
+		require.Len(t, result, 1)
+		require.Equal(t, "/26", result[0].AliasIpRanges[0].IpCidrRange)
+		require.Equal(t, "/24", template.Properties.NetworkInterfaces[0].AliasIpRanges[0].IpCidrRange, "template must not be mutated")
+
+		rangeName := "pods-secondary"
+		nodeClass.Spec.SubnetRangeName = &rangeName
+		result = p.setupNetworkInterfaces(template, nodeClass)
+
+		require.Len(t, result, 1)
+		require.Equal(t, "/26", result[0].AliasIpRanges[0].IpCidrRange)
+	})
+}


### PR DESCRIPTION
Allow users to specify the subnetwork secondary IPv4 range for pod IP allocation via GCENodeClass. When set, overrides the range inherited from the node pool instance template.

#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

Adds a new optional field `subnetRangeName` to `GCENodeClass` that allows users to override the subnetwork secondary IPv4 range used for pod IP allocation. Without this field, the range is inherited from the node pool instance template,
which may not be suitable for clusters with custom pod CIDR configurations.

#### Which issue(s) this PR fixes:

Fixes #216 

#### Special notes for your reviewer:

The field maps directly to `SubnetworkRangeName` on the GCE `AliasIpRange` for the node's network interface. When not set, behavior is unchanged — the range inherited from the node pool instance template is preserved.

#### Does this PR introduce a user-facing change?

```release-note
Added `subnetRangeName` field to `GCENodeClass` spec, allowing users to specify
the subnetwork secondary IPv4 range for pod IP allocation, overriding the default
inherited from the node pool instance template.