### PR TITLE
fix: include disk config in instance type cache key

### DIFF
--- a/pkg/providers/instancetype/fakeproviders_test.go
+++ b/pkg/providers/instancetype/fakeproviders_test.go
@@ -41,11 +41,11 @@ func (f *fakeGKEProvider) ResolveClusterZones(_ context.Context) ([]string, erro
 // making GCP API calls.
 type fakePricingProvider struct{}
 
-func (f *fakePricingProvider) LivenessProbe(_ *http.Request) error      { return nil }
-func (f *fakePricingProvider) InstanceTypes() []string                  { return nil }
-func (f *fakePricingProvider) OnDemandPrice(_ string) (float64, bool)   { return 1.0, true }
-func (f *fakePricingProvider) SpotPrice(_, _ string) (float64, bool)    { return 0.5, true }
-func (f *fakePricingProvider) UpdatePrices(_ context.Context) error     { return nil }
+func (f *fakePricingProvider) LivenessProbe(_ *http.Request) error    { return nil }
+func (f *fakePricingProvider) InstanceTypes() []string                { return nil }
+func (f *fakePricingProvider) OnDemandPrice(_ string) (float64, bool) { return 1.0, true }
+func (f *fakePricingProvider) SpotPrice(_, _ string) (float64, bool)  { return 0.5, true }
+func (f *fakePricingProvider) UpdatePrices(_ context.Context) error   { return nil }
 
 // newTestProvider builds a DefaultProvider wired with fakes and pre-populated
 // with one machine type so that List can return results without network calls.
@@ -56,9 +56,9 @@ func newTestProvider() *DefaultProvider {
 		MemoryMb:  aws.Int32(16384),
 	}
 	return &DefaultProvider{
-		authOptions:     &auth.Credential{Region: "us-central1"},
-		pricingProvider: &fakePricingProvider{},
-		gkeProvider:     &fakeGKEProvider{},
+		authOptions:       &auth.Credential{Region: "us-central1"},
+		pricingProvider:   &fakePricingProvider{},
+		gkeProvider:       &fakeGKEProvider{},
 		instanceTypesInfo: []*computepb.MachineType{mt},
 		instanceTypesOfferings: map[string]sets.Set[string]{
 			"n2-standard-4": sets.New("us-central1-a"),

--- a/pkg/providers/instancetype/fakeproviders_test.go
+++ b/pkg/providers/instancetype/fakeproviders_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancetype
+
+import (
+	"context"
+	"net/http"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/patrickmn/go-cache"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/karpenter/pkg/utils/pretty"
+
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/auth"
+	pkgcache "github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/cache"
+)
+
+// fakeGKEProvider returns a fixed zone list without making GCP API calls.
+type fakeGKEProvider struct{}
+
+func (f *fakeGKEProvider) ResolveClusterZones(_ context.Context) ([]string, error) {
+	return []string{"us-central1-a"}, nil
+}
+
+// fakePricingProvider returns a fixed price for every instance type without
+// making GCP API calls.
+type fakePricingProvider struct{}
+
+func (f *fakePricingProvider) LivenessProbe(_ *http.Request) error      { return nil }
+func (f *fakePricingProvider) InstanceTypes() []string                  { return nil }
+func (f *fakePricingProvider) OnDemandPrice(_ string) (float64, bool)   { return 1.0, true }
+func (f *fakePricingProvider) SpotPrice(_, _ string) (float64, bool)    { return 0.5, true }
+func (f *fakePricingProvider) UpdatePrices(_ context.Context) error     { return nil }
+
+// newTestProvider builds a DefaultProvider wired with fakes and pre-populated
+// with one machine type so that List can return results without network calls.
+func newTestProvider() *DefaultProvider {
+	mt := &computepb.MachineType{
+		Name:      aws.String("n2-standard-4"),
+		GuestCpus: aws.Int32(4),
+		MemoryMb:  aws.Int32(16384),
+	}
+	return &DefaultProvider{
+		authOptions:     &auth.Credential{Region: "us-central1"},
+		pricingProvider: &fakePricingProvider{},
+		gkeProvider:     &fakeGKEProvider{},
+		instanceTypesInfo: []*computepb.MachineType{mt},
+		instanceTypesOfferings: map[string]sets.Set[string]{
+			"n2-standard-4": sets.New("us-central1-a"),
+		},
+		unavailableOfferings: pkgcache.NewUnavailableOfferings(),
+		instanceTypesCache:   cache.New(InstanceTypesCacheTTL, pkgcache.DefaultCleanupInterval),
+		cm:                   pretty.NewChangeMonitor(),
+	}
+}

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -136,7 +136,8 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1alpha1.GCENodeC
 
 	zonesHash, _ := hashstructure.Hash(zones, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	kcHash, _ := hashstructure.Hash(nodeClass.Spec.KubeletConfiguration, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
-	listKey := fmt.Sprintf("%d-%d-%d-%d", p.instanceTypesSeqNum, p.unavailableOfferings.SeqNum, zonesHash, kcHash)
+	disksHash, _ := hashstructure.Hash(nodeClass.Spec.Disks, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+	listKey := fmt.Sprintf("%d-%d-%d-%d-%d", p.instanceTypesSeqNum, p.unavailableOfferings.SeqNum, zonesHash, kcHash, disksHash)
 	item, ok := p.instanceTypesCache.Get(listKey)
 	if ok && len(item.([]*cloudprovider.InstanceType)) > 0 {
 		return item.([]*cloudprovider.InstanceType), nil

--- a/pkg/providers/instancetype/types_test.go
+++ b/pkg/providers/instancetype/types_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package instancetype
 
 import (
+	"context"
 	"testing"
 
 	"cloud.google.com/go/compute/apiv1/computepb"
@@ -28,7 +29,57 @@ import (
 	"sigs.k8s.io/karpenter/pkg/scheduling"
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/operator/options"
 )
+
+// TestListEphemeralStorageCacheIsolation verifies that two GCENodeClass objects
+// with different boot disk sizes but the same KubeletConfiguration receive
+// independently computed ephemeral-storage overhead values from List().
+//
+// Without the disksHash in the cache key both calls share one entry, so the
+// 30 GiB class would silently inherit the 200 GiB reservation (76 Gi) and the
+// kubelet would refuse to start because 76 Gi > actual disk capacity (~25 Gi).
+func TestListEphemeralStorageCacheIsolation(t *testing.T) {
+	ctx := options.ToContext(context.Background(), &options.Options{VMMemoryOverheadPercent: 0.07})
+	p := newTestProvider()
+
+	nodeClass200 := &v1alpha1.GCENodeClass{
+		Spec: v1alpha1.GCENodeClassSpec{
+			Disks: []v1alpha1.Disk{
+				{Boot: true, SizeGiB: 200, Category: "hyperdisk-balanced"},
+			},
+		},
+	}
+	nodeClass30 := &v1alpha1.GCENodeClass{
+		Spec: v1alpha1.GCENodeClassSpec{
+			Disks: []v1alpha1.Disk{
+				{Boot: true, SizeGiB: 30, Category: "hyperdisk-balanced"},
+			},
+		},
+	}
+
+	// First call: 200 GiB disk – populates the cache.
+	its200, err := p.List(ctx, nodeClass200)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, its200)
+	ephemeral200 := its200[0].Overhead.KubeReserved.StorageEphemeral()
+
+	// Second call: 30 GiB disk – must NOT reuse the 200 GiB cache entry.
+	its30, err := p.List(ctx, nodeClass30)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, its30)
+	ephemeral30 := its30[0].Overhead.KubeReserved.StorageEphemeral()
+
+	// With the fix (disksHash in key): each NodeClass gets its own cache entry and overhead.
+	// Without the fix: both calls share one key – the second call returns stale 76 Gi
+	// for a 30 GiB disk, causing kubelet to fail with "reservation > capacity".
+	assert.Equal(t, int64(76)*1024*1024*1024, ephemeral200.Value(),
+		"200 GiB disk should produce 76 Gi kubeReserved ephemeral-storage")
+	assert.Equal(t, int64(15)*1024*1024*1024, ephemeral30.Value(),
+		"30 GiB disk should produce 15 Gi kubeReserved ephemeral-storage, not the cached 76 Gi")
+	assert.Equal(t, 2, p.instanceTypesCache.ItemCount(),
+		"each distinct disk config must produce a separate cache entry")
+}
 
 func TestCalculateDiskConfiguration(t *testing.T) {
 	tests := []struct {

--- a/pkg/providers/instancetype/types_test.go
+++ b/pkg/providers/instancetype/types_test.go
@@ -70,9 +70,6 @@ func TestListEphemeralStorageCacheIsolation(t *testing.T) {
 	assert.NotEmpty(t, its30)
 	ephemeral30 := its30[0].Overhead.KubeReserved.StorageEphemeral()
 
-	// With the fix (disksHash in key): each NodeClass gets its own cache entry and overhead.
-	// Without the fix: both calls share one key – the second call returns stale 76 Gi
-	// for a 30 GiB disk, causing kubelet to fail with "reservation > capacity".
 	assert.Equal(t, int64(76)*1024*1024*1024, ephemeral200.Value(),
 		"200 GiB disk should produce 76 Gi kubeReserved ephemeral-storage")
 	assert.Equal(t, int64(15)*1024*1024*1024, ephemeral30.Value(),
@@ -83,14 +80,14 @@ func TestListEphemeralStorageCacheIsolation(t *testing.T) {
 
 func TestCalculateDiskConfiguration(t *testing.T) {
 	tests := []struct {
-		name              string
-		nodeClass         *v1alpha1.GCENodeClass
-		expectedBootGiB   int64
-		expectedSSDGiB    int64
-		expectedSSDCount  int64
+		name             string
+		nodeClass        *v1alpha1.GCENodeClass
+		expectedBootGiB  int64
+		expectedSSDGiB   int64
+		expectedSSDCount int64
 	}{
 		{
-			name:             "30GiB boot disk from nodeClass (issue #220)",
+			name: "30GiB boot disk from nodeClass (issue #220)",
 			nodeClass: &v1alpha1.GCENodeClass{
 				Spec: v1alpha1.GCENodeClassSpec{
 					Disks: []v1alpha1.Disk{

--- a/pkg/providers/instancetype/types_test.go
+++ b/pkg/providers/instancetype/types_test.go
@@ -30,6 +30,46 @@ import (
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
 )
 
+func TestCalculateDiskConfiguration(t *testing.T) {
+	tests := []struct {
+		name              string
+		nodeClass         *v1alpha1.GCENodeClass
+		expectedBootGiB   int64
+		expectedSSDGiB    int64
+		expectedSSDCount  int64
+	}{
+		{
+			name:             "30GiB boot disk from nodeClass (issue #220)",
+			nodeClass: &v1alpha1.GCENodeClass{
+				Spec: v1alpha1.GCENodeClassSpec{
+					Disks: []v1alpha1.Disk{
+						{Boot: true, SizeGiB: 30, Category: "hyperdisk-balanced"},
+					},
+				},
+			},
+			expectedBootGiB:  30,
+			expectedSSDGiB:   0,
+			expectedSSDCount: 0,
+		},
+		{
+			name:             "default 100GiB when no disks specified",
+			nodeClass:        &v1alpha1.GCENodeClass{},
+			expectedBootGiB:  100,
+			expectedSSDGiB:   0,
+			expectedSSDCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bootGiB, ssdGiB, ssdCount := calculateDiskConfiguration(tt.nodeClass, &computepb.MachineType{})
+			assert.Equal(t, tt.expectedBootGiB, bootGiB, "boot disk GiB mismatch")
+			assert.Equal(t, tt.expectedSSDGiB, ssdGiB, "total SSD GiB mismatch")
+			assert.Equal(t, tt.expectedSSDCount, ssdCount, "SSD count mismatch")
+		})
+	}
+}
+
 func TestComputeRequirements(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -175,8 +175,8 @@ func ResolveReservedEphemeralStorage(bootDiskGiB, totalSSDGiB, localSSDCount int
 	// - 50% of boot disk capacity
 	// - 35% of boot disk capacity + 6 GiB
 	// - 100 GiB
-	option1 := int64(float64(bootDiskGiB) * 0.50)
-	option2 := int64(float64(bootDiskGiB)*0.35) + 6
+	option1 := int64(math.Round(float64(bootDiskGiB) * 0.50))
+	option2 := int64(math.Round(float64(bootDiskGiB)*0.35 + 6))
 	option3 := int64(100)
 
 	systemReservation = option1

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -142,7 +142,7 @@ func TestResolveReservedEphemeralStorage(t *testing.T) {
 			totalSSDGiB:      0,
 			localSSDCount:    0,
 			expectedEviction: 3,  // 10% of 30GB
-			expectedSystem:   15, // min(15, 10+6, 100) = min(15, 16, 100) = 15
+			expectedSystem:   15, // 50%×30=15 < round(35%×30+6)=17 → 15 wins
 		},
 		{
 			name:             "100GB boot disk only",

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -137,6 +137,14 @@ func TestResolveReservedEphemeralStorage(t *testing.T) {
 	}{
 		// Boot disk scenarios
 		{
+			name:             "30GB boot disk only (issue #220)",
+			bootDiskGiB:      30,
+			totalSSDGiB:      0,
+			localSSDCount:    0,
+			expectedEviction: 3,  // 10% of 30GB
+			expectedSystem:   15, // min(15, 10+6, 100) = min(15, 16, 100) = 15
+		},
+		{
 			name:             "100GB boot disk only",
 			bootDiskGiB:      100,
 			totalSSDGiB:      0,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes incorrect `kubeReserved: ephemeral-storage` written to the kubelet config when a `GCENodeClass` with a small boot disk (e.g. 30 GiB) is used after a NodeClass with a larger disk (e.g. 200 GiB) was evaluated. Two root causes are fixed:

**1. Cache key missing disk configuration (`instancetype.go`)**
`DefaultProvider.List()` cached results keyed on KubeletConfiguration, zones, and sequence numbers, but omitted `Spec.Disks`. When multiple `GCENodeClass` objects shared the same KubeletConfiguration but had different boot disk sizes, the stale overhead from the first evaluation (e.g. 76 Gi for a 200 GiB disk) was returned for a subsequent NodeClass with a smaller disk (e.g. 30 GiB → should be 15 Gi). This could cause kubelet startup to fail with "reservation > capacity".

Fix: add a `disksHash` of `nodeClass.Spec.Disks` as a fifth component in the cache key so each distinct disk configuration gets an independent cache entry.

**2. Integer truncation in ephemeral storage reservation formula (`utils.go`)**
GKE computes the system reservation as `min(50% × boot, 35% × boot + 6 GiB, 100 GiB)` using floating-point arithmetic. The previous code used bare `int64()` casts (truncation) instead of `math.Round()`, which can produce results up to ~0.35 GiB lower than GKE's actual reservation.

Fix: apply `math.Round` to both `option1` and `option2` before the `int64` cast.

**Test additions:**
- `pkg/utils/utils_test.go`: added 30 GiB boot disk test case (the failing scenario from issue #220)
- `pkg/providers/instancetype/types_test.go`: added `TestListEphemeralStorageCacheIsolation` — a regression test that calls `List()` with two different disk sizes and asserts both the per-NodeClass storage values and that two independent cache entries are created
- `pkg/providers/instancetype/fakeproviders_test.go`: extracted reusable fake `gke.Provider`, `pricing.Provider`, and `newTestProvider()` into a dedicated file so future `List()`-level tests can use them without duplicating setup

#### Which issue(s) this PR fixes:

Fixes #220

#### Special notes for your reviewer:

The cache key fix is the primary bug fix; the rounding fix is a secondary alignment improvement. They are committed separately so each can be reviewed and reverted independently.

#### Does this PR introduce a user-facing change?

```release-note
Fixes incorrect kubeReserved ephemeral-storage calculation when multiple GCENodeClass objects share the same KubeletConfiguration but have different boot disk sizes, by including disk configuration in the instance type cache key. Also aligns ephemeral storage system reservation calculation with GKE's rounding behavior.
```