### PR TITLE
fix(toolchain): remove sudo from toolchain and codegen scripts

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 K8S_VERSION="${K8S_VERSION:="1.29.x"}"
-KUBEBUILDER_ASSETS="/usr/local/kubebuilder/bin"
+KUBEBUILDER_ASSETS="${KUBEBUILDER_ASSETS:-${HOME}/.local/kubebuilder/bin}"
 
 main() {
     tools
@@ -33,8 +33,7 @@ tools() {
 }
 
 kubebuilder() {
-    sudo mkdir -p ${KUBEBUILDER_ASSETS}
-    sudo chown "${USER}" ${KUBEBUILDER_ASSETS}
+    mkdir -p "${KUBEBUILDER_ASSETS}"
     arch=$(go env GOARCH)
     ln -sf "$(setup-envtest use -p path "${K8S_VERSION}" --arch="${arch}" --bin-dir="${KUBEBUILDER_ASSETS}")"/* ${KUBEBUILDER_ASSETS}
     find $KUBEBUILDER_ASSETS

--- a/hack/update-generated.sh
+++ b/hack/update-generated.sh
@@ -11,8 +11,8 @@ export REPO_ROOT=$(pwd)
 export GOPATH="${REPO_ROOT}/_go"
 
 cleanup() {
-  # TODO: In github action, it needs root privilege to delete this dir
-  sudo rm -rf "${GOPATH}"
+  chmod -R u+w "${GOPATH}" 2>/dev/null || true
+  rm -rf "${GOPATH}"
 }
 trap "cleanup" EXIT SIGINT
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Two places in the developer toolchain required `sudo` without any real need:

1. **`hack/toolchain.sh`** — `KUBEBUILDER_ASSETS` was set to `/usr/local/kubebuilder/bin`, a system-owned directory. Changed to `${KUBEBUILDER_ASSETS:-${HOME}/.local/kubebuilder/bin}` (user-owned, overridable via env). Drops `sudo mkdir` + `sudo chown`.

2. **`hack/update-generated.sh`** — the `cleanup()` trap used `sudo rm -rf "${GOPATH}"` because the go module cache inside `_go/pkg/mod` stores files as read-only. Fixed with `chmod -R u+w` before `rm -rf` — no privilege escalation needed.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

`KUBEBUILDER_ASSETS` remains overridable via environment variable for CI environments that use a custom path.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```