### PR TITLE
chore: bump Go 1.24.6 → 1.25.0 and pin CI go-version-file

### DIFF
--- a/.github/workflows/cloudpilot-latest-build.yaml
+++ b/.github/workflows/cloudpilot-latest-build.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.4'
+          go-version-file: go.mod
           cache: false
 
       - name: Config env

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.5'
+          go-version-file: go.mod
           cache: false
 
       - name: Install toolchain

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.6'
+          go-version-file: go.mod
           cache: false
 
       - name: Config env

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudpilot-ai/karpenter-provider-gcp
 
-go 1.24.6
+go 1.25.0
 
 require (
 	cloud.google.com/go/compute v1.38.0


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Updates the `go` directive in `go.mod` from 1.24.6 to 1.25.0 (required by `cloud.google.com/go/compute` v1.56.0, handled in #227)
- Switches all three CI workflows from hardcoded `go-version: '1.24.x'` to `go-version-file: go.mod` so the version stays in sync with the module automatically

No logic changes. No vendor changes.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

**Part 1 of 3** in a series split from #222:

| # | PR | Depends on |
|---|---|---|
| 1 | #226 — Go 1.25 + CI (this PR) | — |
| 2 | #227 — compute SDK v1.56.0 | #226 |
| 3 | #228 — local SSD correctness fixes | #227 |

**#218** (new pricing provider) also depends on this series — it uses `BundledLocalSsds.PartitionCount` (introduced in the SDK bump) and `utils/localssd.LocalSSDTotalGiB` (introduced in #228) as its single source of truth for local SSD capacity.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```