### PR TITLE
ci: enable Go module and toolchain caching in presubmit

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -21,7 +21,12 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: false
+
+      - name: Cache toolchain binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin
+          key: toolchain-${{ runner.os }}-${{ hashFiles('hack/toolchain.sh') }}
 
       - name: Install toolchain
         run: |


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Enables caching in the presubmit CI workflow to reduce wall time from ~12 min to ~4 min.

Two changes:
1. **Go module + build cache** — removes `cache: false` from `actions/setup-go`, enabling its built-in cache keyed on `go.sum`. This caches `~/go/pkg/mod` and the Go build cache.
2. **Toolchain binary cache** — adds `actions/cache@v4` for `~/go/bin` keyed on `hack/toolchain.sh` content hash. When the toolchain script hasn't changed, the ~8 min `make toolchain` step (which `go install`s 15+ tools from source) becomes a near-instant cache restore.

**Cache invalidation:**
- Go module cache invalidates when `go.sum` changes (handled by `actions/setup-go`)
- Toolchain cache invalidates when `hack/toolchain.sh` changes (explicit `hashFiles` key)
- Both caches are OS-scoped (`runner.os`)

**Expected impact:**
| Step | Before | After (cache hit) |
|---|---|---|
| Install toolchain | ~8 min | ~5s |
| Presubmit check | ~4 min | ~3 min (build cache helps) |
| **Total** | **~12 min** | **~3-4 min** |

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

First run after merge will still be slow (cold cache). Subsequent runs on the same OS with unchanged `go.sum`/`hack/toolchain.sh` will benefit from caching.

The `make toolchain` step still runs on cache hit — tools that are already in `~/go/bin` will be detected as installed by `go install` and skipped quickly.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```