### PR TITLE
test: add e2e test infrastructure with Terraform-based GKE lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ ut-test: ## Run unit tests
 	go test ./pkg/... \
 		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./...
 
+e2etests: ## Run e2e tests (requires E2E_PROJECT_ID, E2E_GCP_CREDENTIALS, E2E_PREFIX)
+	go test ./test/e2e/... -v -timeout=60m -count=1
+
 coverage:
 	go tool cover -html coverage.out -o coverage.html
 
@@ -92,7 +95,7 @@ codegen: ## Auto generate files based on GCP APIs
 crds: ## Apply CRDs
 	kubectl apply -f charts/karpenter/crds/
 
-.PHONY: help presubmit run ut-test coverage update verify-codegen verify image apply delete toolchain tidy download
+.PHONY: help presubmit run ut-test e2etests coverage update verify-codegen verify image apply delete toolchain tidy download
 
 define newline
 

--- a/test/e2e/PROPOSAL.md
+++ b/test/e2e/PROPOSAL.md
@@ -1,0 +1,43 @@
+# Future e2e test proposal
+
+## P1
+
+### Network configurations
+- Private cluster coverage with Workload Identity enabled
+- Custom subnet and secondary range selection via `subnetRangeName`
+
+### Disk size validation
+- Explicit boot disk sizing checks for `pd-ssd` and `pd-balanced`
+- Regression coverage for the SSD sizing issue so invalid disk settings fail fast
+
+## P2
+
+### Multi-network scenarios
+- Multiple subnet ranges per cluster
+- Distinct `networkTags` validation across NodeClasses
+
+### Consolidation behavior
+- Scale-down after workload deletion
+- Node replacement when a cheaper or better-fit node becomes available
+
+### Drift detection
+- NodeClass mutation triggers controlled node replacement
+- NodePool requirement changes force drifted nodes to roll
+
+## P3
+
+### Interruption handling
+- Spot preemption simulation with validation of cordon, drain, and replacement behavior
+
+### Custom machine types and accelerators
+- Custom machine type provisioning
+- GPU node provisioning and scheduling coverage
+
+## P4
+
+### Performance and load testing
+- Burst provisioning for 100+ nodes
+- Controller latency and scheduling throughput under sustained load
+
+### Regional vs zonal provisioning
+- Compare node selection and provisioning behavior between regional and zonal clusters

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,48 @@
+# E2E tests
+
+This suite provisions a real GKE cluster with Terraform, installs the local Karpenter chart with Helm, runs live provisioning tests, and destroys everything at the end.
+
+## Prerequisites
+
+- `terraform`
+- `gcloud`
+- `kubectl`
+- `helm`
+- GCP service account credentials JSON with permission to create GKE, networking, IAM, and service accounts in the target project
+
+## Inputs
+
+The suite accepts only these inputs:
+
+- `E2E_PROJECT_ID` — target GCP project ID
+- `E2E_GCP_CREDENTIALS` — absolute path to the service account JSON file
+- `E2E_PREFIX` — prefix applied to all Terraform resources and test resources
+
+## Run
+
+```sh
+export E2E_PROJECT_ID=<gcp-project-id>
+export E2E_GCP_CREDENTIALS=/absolute/path/to/key.json
+export E2E_PREFIX=karpenter-e2e
+
+make e2etests
+```
+
+The suite performs these steps:
+
+1. `terraform init` and `terraform apply` in `test/e2e/terraform/`
+2. `gcloud container clusters get-credentials` for the created cluster
+3. `helm upgrade --install` from `charts/karpenter`
+4. Run four provisioning cases:
+   - `TestOnDemandAMD64`
+   - `TestSpotAMD64`
+   - `TestOnDemandARM64`
+   - `TestSpotARM64`
+5. Delete test workloads and rely on Karpenter consolidation to remove the nodes
+6. `terraform destroy` during suite teardown
+
+## Notes
+
+- These tests create billable GCP resources.
+- The suite uses Workload Identity for the Karpenter controller, so Helm is installed with `credentials.enabled=false`.
+- Terraform defaults the cluster region to `us-central1`.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,316 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	gcpv1alpha1 "github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
+)
+
+const (
+	provisioningTimeout = 5 * time.Minute
+	cleanupTimeout      = 5 * time.Minute
+	pauseImage          = "registry.k8s.io/pause:3.10"
+)
+
+var (
+	gceNodeClassGVR = schema.GroupVersionResource{Group: "karpenter.k8s.gcp", Version: "v1alpha1", Resource: "gcenodeclasses"}
+	nodePoolGVR     = schema.GroupVersionResource{Group: "karpenter.sh", Version: "v1", Resource: "nodepools"}
+)
+
+type provisioningCase struct {
+	name         string
+	capacityType string
+	arch         string
+	families     []string
+}
+
+func TestE2E(t *testing.T) {
+	for _, tc := range append(onDemandCases(), spotCases()...) {
+		t.Run(tc.name, func(t *testing.T) {
+			runProvisioningTest(t, tc)
+		})
+	}
+}
+
+func runProvisioningTest(t *testing.T, tc provisioningCase) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	baseName := resourceName(testEnv.prefix, tc.name)
+	nodeClassName := resourceName(baseName, "class")
+	nodePoolName := resourceName(baseName, "pool")
+	deploymentName := resourceName(baseName, "deploy")
+	appLabel := resourceName(baseName, "app")
+
+	initialNodes, err := allNodeNames(ctx)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cleanupCancel()
+		deleteDeployment(cleanupCtx, deploymentName)
+		deleteNodePool(cleanupCtx, nodePoolName)
+		deleteNodeClass(cleanupCtx, nodeClassName)
+	})
+
+	require.NoError(t, createNodeClass(ctx, nodeClassName))
+	require.NoError(t, createNodePool(ctx, nodePoolName, nodeClassName, tc))
+	require.NoError(t, createDeployment(ctx, deploymentName, appLabel, nodePoolName))
+
+	pod, err := waitForRunningPod(ctx, appLabel)
+	require.NoError(t, err)
+	require.NotEmpty(t, pod.Spec.NodeName)
+
+	node, err := testEnv.clientset.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	_, existedBefore := initialNodes[node.Name]
+	assert.False(t, existedBefore, "expected a new node to be provisioned")
+	assert.Equal(t, "true", node.Labels[karpv1.NodeRegisteredLabelKey])
+	assert.Equal(t, nodePoolName, node.Labels[karpv1.NodePoolLabelKey])
+	assert.Equal(t, tc.capacityType, node.Labels[karpv1.CapacityTypeLabelKey])
+	assert.Equal(t, tc.arch, node.Labels[corev1.LabelArchStable])
+	assert.Contains(t, tc.families, node.Labels[gcpv1alpha1.LabelInstanceFamily])
+
+	require.NoError(t, deleteDeployment(ctx, deploymentName))
+	require.NoError(t, waitForNodeRemoval(ctx, node.Name))
+	require.NoError(t, deleteNodePool(ctx, nodePoolName))
+	require.NoError(t, deleteNodeClass(ctx, nodeClassName))
+}
+
+func createNodeClass(ctx context.Context, name string) error {
+	object := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "karpenter.k8s.gcp/v1alpha1",
+		"kind":       "GCENodeClass",
+		"metadata": map[string]any{
+			"name": name,
+		},
+		"spec": map[string]any{
+			"imageSelectorTerms": []any{
+				map[string]any{"alias": "ContainerOptimizedOS@latest"},
+			},
+			"disks": []any{
+				map[string]any{
+					"category": "pd-balanced",
+					"sizeGiB":  int64(60),
+					"boot":     true,
+				},
+			},
+		},
+	}}
+
+	_, err := testEnv.dynamicClient.Resource(gceNodeClassGVR).Create(ctx, object, metav1.CreateOptions{})
+	return err
+}
+
+func createNodePool(ctx context.Context, name, nodeClassName string, tc provisioningCase) error {
+	requirements := []any{
+		map[string]any{
+			"key":      karpv1.CapacityTypeLabelKey,
+			"operator": "In",
+			"values":   []any{tc.capacityType},
+		},
+		map[string]any{
+			"key":      gcpv1alpha1.LabelInstanceFamily,
+			"operator": "In",
+			"values":   stringSliceToAny(tc.families),
+		},
+		map[string]any{
+			"key":      corev1.LabelArchStable,
+			"operator": "In",
+			"values":   []any{tc.arch},
+		},
+		map[string]any{
+			"key":      corev1.LabelTopologyZone,
+			"operator": "In",
+			"values":   stringSliceToAny(testEnv.zones),
+		},
+	}
+
+	object := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "karpenter.sh/v1",
+		"kind":       "NodePool",
+		"metadata": map[string]any{
+			"name": name,
+		},
+		"spec": map[string]any{
+			"weight": int64(10),
+			"disruption": map[string]any{
+				"consolidateAfter":    "30s",
+				"consolidationPolicy": "WhenEmptyOrUnderutilized",
+				"budgets": []any{
+					map[string]any{"nodes": "100%"},
+				},
+			},
+			"template": map[string]any{
+				"spec": map[string]any{
+					"nodeClassRef": map[string]any{
+						"name":  nodeClassName,
+						"kind":  "GCENodeClass",
+						"group": "karpenter.k8s.gcp",
+					},
+					"requirements": requirements,
+				},
+			},
+		},
+	}}
+
+	_, err := testEnv.dynamicClient.Resource(nodePoolGVR).Create(ctx, object, metav1.CreateOptions{})
+	return err
+}
+
+func createDeployment(ctx context.Context, name, appLabel, nodePoolName string) error {
+	replicas := int32(1)
+	zero := int64(0)
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": appLabel}},
+				Spec: corev1.PodSpec{
+					NodeSelector:                  map[string]string{karpv1.NodePoolLabelKey: nodePoolName},
+					TerminationGracePeriodSeconds: &zero,
+					Containers: []corev1.Container{
+						{
+							Name:  "inflate",
+							Image: pauseImage,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("250m"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := testEnv.clientset.AppsV1().Deployments(testNamespace).Create(ctx, deployment, metav1.CreateOptions{})
+	return err
+}
+
+func waitForRunningPod(ctx context.Context, appLabel string) (*corev1.Pod, error) {
+	var runningPod *corev1.Pod
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, provisioningTimeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := testEnv.clientset.CoreV1().Pods(testNamespace).List(ctx, metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", appLabel)})
+		if err != nil {
+			return false, err
+		}
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			if pod.Status.Phase == corev1.PodRunning && pod.Spec.NodeName != "" {
+				runningPod = pod.DeepCopy()
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return runningPod, nil
+}
+
+func waitForNodeRemoval(ctx context.Context, nodeName string) error {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, cleanupTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err := testEnv.clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+}
+
+func deleteDeployment(ctx context.Context, name string) error {
+	err := testEnv.clientset.AppsV1().Deployments(testNamespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func deleteNodePool(ctx context.Context, name string) error {
+	err := testEnv.dynamicClient.Resource(nodePoolGVR).Delete(ctx, name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func deleteNodeClass(ctx context.Context, name string) error {
+	err := testEnv.dynamicClient.Resource(gceNodeClassGVR).Delete(ctx, name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func allNodeNames(ctx context.Context) (map[string]struct{}, error) {
+	nodes, err := testEnv.clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]struct{}, len(nodes.Items))
+	for _, node := range nodes.Items {
+		result[node.Name] = struct{}{}
+	}
+	return result, nil
+}
+
+func stringSliceToAny(values []string) []any {
+	result := make([]any, 0, len(values))
+	for _, value := range values {
+		result = append(result, value)
+	}
+	return result
+}
+
+func resourceName(parts ...string) string {
+	joined := strings.ToLower(strings.Join(parts, "-"))
+	joined = strings.NewReplacer("_", "-", "/", "-", ".", "-").Replace(joined)
+	var builder strings.Builder
+	for _, ch := range joined {
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' {
+			builder.WriteRune(ch)
+		}
+	}
+	base := strings.Trim(builder.String(), "-")
+	if base == "" {
+		base = "e2e"
+	}
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 36)
+	maxBaseLen := max(1, 63-len(suffix)-1)
+	if len(base) > maxBaseLen {
+		base = strings.Trim(base[:maxBaseLen], "-")
+	}
+	if base == "" {
+		base = "e2e"
+	}
+	return fmt.Sprintf("%s-%s", base, suffix)
+}

--- a/test/e2e/ondemand_test.go
+++ b/test/e2e/ondemand_test.go
@@ -1,0 +1,20 @@
+package e2e
+
+import karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+func onDemandCases() []provisioningCase {
+	return []provisioningCase{
+		{
+			name:         "TestOnDemandAMD64",
+			capacityType: karpv1.CapacityTypeOnDemand,
+			arch:         karpv1.ArchitectureAmd64,
+			families:     []string{"n2", "e2", "n4"},
+		},
+		{
+			name:         "TestOnDemandARM64",
+			capacityType: karpv1.CapacityTypeOnDemand,
+			arch:         karpv1.ArchitectureArm64,
+			families:     []string{"t2a"},
+		},
+	}
+}

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -1,0 +1,306 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+)
+
+const (
+	defaultRegion      = "us-central1"
+	karpenterNamespace = "karpenter-system"
+	testNamespace      = "karpenter-e2e"
+)
+
+type suiteState struct {
+	projectID        string
+	credentialsPath  string
+	prefix           string
+	region           string
+	repoRoot         string
+	terraformDir     string
+	chartPath        string
+	crdPath          string
+	kubeconfigPath   string
+	clusterName      string
+	karpenterSAEmail string
+	zones            []string
+	terraformApplied bool
+	clientset        kubernetes.Interface
+	dynamicClient    dynamic.Interface
+}
+
+type gkeClusterDescription struct {
+	Locations []string `json:"locations"`
+}
+
+var testEnv suiteState
+
+func TestMain(m *testing.M) {
+	exitCode := 1
+
+	if err := setupSuite(); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e setup failed: %v\n", err)
+	} else {
+		exitCode = m.Run()
+	}
+
+	if err := cleanupSuite(); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e cleanup failed: %v\n", err)
+		if exitCode == 0 {
+			exitCode = 1
+		}
+	}
+
+	os.Exit(exitCode)
+}
+
+func setupSuite() error {
+	credentialsPath := os.Getenv("E2E_GCP_CREDENTIALS")
+	if credentialsPath == "" {
+		return fmt.Errorf("E2E_GCP_CREDENTIALS must be set")
+	}
+	credentialsPath, err := filepath.Abs(credentialsPath)
+	if err != nil {
+		return fmt.Errorf("resolving credentials path: %w", err)
+	}
+	if _, err := os.Stat(credentialsPath); err != nil {
+		return fmt.Errorf("stat credentials path: %w", err)
+	}
+
+	repoRoot, err := repoRoot()
+	if err != nil {
+		return err
+	}
+
+	projectID := os.Getenv("E2E_PROJECT_ID")
+	if projectID == "" {
+		return fmt.Errorf("E2E_PROJECT_ID must be set")
+	}
+	prefix := os.Getenv("E2E_PREFIX")
+	if prefix == "" {
+		return fmt.Errorf("E2E_PREFIX must be set")
+	}
+
+	testEnv = suiteState{
+		projectID:       projectID,
+		credentialsPath: credentialsPath,
+		prefix:          prefix,
+		region:          defaultRegion,
+		repoRoot:        repoRoot,
+		terraformDir:    filepath.Join(repoRoot, "test", "e2e", "terraform"),
+		chartPath:       filepath.Join(repoRoot, "charts", "karpenter"),
+		crdPath:         filepath.Join(repoRoot, "charts", "karpenter", "crds"),
+	}
+
+	if err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credentialsPath); err != nil {
+		return fmt.Errorf("setting GOOGLE_APPLICATION_CREDENTIALS: %w", err)
+	}
+
+	if err := runCommand(repoRoot, "gcloud", "auth", "activate-service-account", "--key-file", credentialsPath); err != nil {
+		return err
+	}
+	if err := runCommand(testEnv.terraformDir, "terraform", "init", "-input=false"); err != nil {
+		return err
+	}
+	if err := runCommand(testEnv.terraformDir, "terraform", append([]string{"apply", "-input=false", "-auto-approve"}, terraformVarArgs()...)...); err != nil {
+		return err
+	}
+	testEnv.terraformApplied = true
+
+	clusterName, err := terraformOutput("cluster_name")
+	if err != nil {
+		return err
+	}
+	karpenterSAEmail, err := terraformOutput("karpenter_sa_email")
+	if err != nil {
+		return err
+	}
+	kubeconfigPath, err := terraformOutput("kubeconfig_path")
+	if err != nil {
+		return err
+	}
+
+	testEnv.clusterName = clusterName
+	testEnv.karpenterSAEmail = karpenterSAEmail
+	testEnv.kubeconfigPath = kubeconfigPath
+
+	if err := runCommand(repoRoot, "gcloud", "container", "clusters", "get-credentials", clusterName, "--region", testEnv.region, "--project", testEnv.projectID); err != nil {
+		return err
+	}
+	if err := runCommand(repoRoot, "kubectl", "apply", "-f", testEnv.crdPath); err != nil {
+		return err
+	}
+	if err := runCommand(repoRoot, "helm", "upgrade", "--install", "karpenter", testEnv.chartPath,
+		"--namespace", karpenterNamespace,
+		"--create-namespace",
+		"--wait",
+		"--timeout", "10m",
+		"--set", "controller.replicaCount=1",
+		"--set-string", fmt.Sprintf("controller.settings.projectID=%s", testEnv.projectID),
+		"--set-string", fmt.Sprintf("controller.settings.clusterLocation=%s", testEnv.region),
+		"--set-string", fmt.Sprintf("controller.settings.clusterName=%s", testEnv.clusterName),
+		"--set", "credentials.enabled=false",
+		"--set-string", fmt.Sprintf(`serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account=%s`, testEnv.karpenterSAEmail),
+	); err != nil {
+		return err
+	}
+
+	testEnv.zones, err = discoverZones()
+	if err != nil {
+		return err
+	}
+
+	restConfig, err := loadRESTConfig()
+	if err != nil {
+		return err
+	}
+	testEnv.clientset, err = kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("creating kubernetes client: %w", err)
+	}
+	testEnv.dynamicClient, err = dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("creating dynamic client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	_, err = testEnv.clientset.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: testNamespace},
+	}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating test namespace: %w", err)
+	}
+	return nil
+}
+
+func cleanupSuite() error {
+	if testEnv.clientset != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		_ = testEnv.clientset.CoreV1().Namespaces().Delete(ctx, testNamespace, metav1.DeleteOptions{})
+		cancel()
+	}
+	if testEnv.clusterName != "" {
+		_ = runCommand(testEnv.repoRoot, "helm", "uninstall", "karpenter", "--namespace", karpenterNamespace)
+	}
+	if !testEnv.terraformApplied {
+		return nil
+	}
+	return runCommand(testEnv.terraformDir, "terraform", append([]string{"destroy", "-input=false", "-auto-approve"}, terraformVarArgs()...)...)
+}
+
+func repoRoot() (string, error) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("locating setup_test.go")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..")), nil
+}
+
+func terraformVarArgs() []string {
+	return []string{
+		"-var", fmt.Sprintf("project_id=%s", testEnv.projectID),
+		"-var", fmt.Sprintf("credentials_path=%s", testEnv.credentialsPath),
+		"-var", fmt.Sprintf("prefix=%s", testEnv.prefix),
+		"-var", fmt.Sprintf("region=%s", testEnv.region),
+	}
+}
+
+func terraformOutput(name string) (string, error) {
+	output, err := commandOutput(testEnv.terraformDir, "terraform", "output", "-raw", name)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
+}
+
+func discoverZones() ([]string, error) {
+	output, err := commandOutput(testEnv.repoRoot, "gcloud", "container", "clusters", "describe", testEnv.clusterName,
+		"--region", testEnv.region,
+		"--project", testEnv.projectID,
+		"--format=json",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	description := &gkeClusterDescription{}
+	if err := json.Unmarshal([]byte(output), description); err != nil {
+		return nil, fmt.Errorf("parsing cluster description: %w", err)
+	}
+	if len(description.Locations) == 0 {
+		return []string{
+			fmt.Sprintf("%s-a", testEnv.region),
+			fmt.Sprintf("%s-b", testEnv.region),
+			fmt.Sprintf("%s-c", testEnv.region),
+		}, nil
+	}
+	return description.Locations, nil
+}
+
+func loadRESTConfig() (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if os.Getenv("KUBECONFIG") == "" {
+		kubeconfigPath := strings.TrimSpace(testEnv.kubeconfigPath)
+		if kubeconfigPath == "" {
+			kubeconfigPath = filepath.Join(homedir.HomeDir(), ".kube", "config")
+		}
+		loadingRules.ExplicitPath = kubeconfigPath
+	}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
+}
+
+func runCommand(workdir, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = workdir
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("running %s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func commandOutput(workdir, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = workdir
+	cmd.Env = os.Environ()
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("creating stdout pipe for %s: %w", name, err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("starting %s %s: %w", name, strings.Join(args, " "), err)
+	}
+	data, readErr := io.ReadAll(stdout)
+	waitErr := cmd.Wait()
+	if readErr != nil {
+		return "", fmt.Errorf("reading %s stdout: %w", name, readErr)
+	}
+	if waitErr != nil {
+		return "", fmt.Errorf("running %s %s: %w", name, strings.Join(args, " "), waitErr)
+	}
+	return string(data), nil
+}

--- a/test/e2e/spot_test.go
+++ b/test/e2e/spot_test.go
@@ -1,0 +1,20 @@
+package e2e
+
+import karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+func spotCases() []provisioningCase {
+	return []provisioningCase{
+		{
+			name:         "TestSpotAMD64",
+			capacityType: karpv1.CapacityTypeSpot,
+			arch:         karpv1.ArchitectureAmd64,
+			families:     []string{"n2", "e2", "n4"},
+		},
+		{
+			name:         "TestSpotARM64",
+			capacityType: karpv1.CapacityTypeSpot,
+			arch:         karpv1.ArchitectureArm64,
+			families:     []string{"t2a"},
+		},
+	}
+}

--- a/test/e2e/terraform/main.tf
+++ b/test/e2e/terraform/main.tf
@@ -1,0 +1,159 @@
+locals {
+  name_prefix = substr(replace(lower(var.prefix), "_", "-"), 0, 20)
+
+  cluster_name         = "${local.name_prefix}-cluster"
+  network_name         = "${local.name_prefix}-vpc"
+  subnet_name          = "${local.name_prefix}-subnet"
+  pods_range_name      = "${local.name_prefix}-pods"
+  services_range_name  = "${local.name_prefix}-svc"
+  karpenter_sa_id      = "${local.name_prefix}-karpenter"
+  node_sa_id           = "${local.name_prefix}-nodes"
+  system_nodepool_name = "${local.name_prefix}-default"
+  zones = [
+    "${var.region}-a",
+    "${var.region}-b",
+    "${var.region}-c",
+  ]
+}
+
+resource "google_project_service" "compute" {
+  project            = var.project_id
+  service            = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "container" {
+  project            = var.project_id
+  service            = "container.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_compute_network" "e2e" {
+  name                    = local.network_name
+  auto_create_subnetworks = false
+
+  depends_on = [
+    google_project_service.compute,
+  ]
+}
+
+resource "google_compute_subnetwork" "e2e" {
+  name          = local.subnet_name
+  region        = var.region
+  network       = google_compute_network.e2e.id
+  ip_cidr_range = "10.10.0.0/20"
+
+  secondary_ip_range {
+    range_name    = local.pods_range_name
+    ip_cidr_range = "10.20.0.0/16"
+  }
+
+  secondary_ip_range {
+    range_name    = local.services_range_name
+    ip_cidr_range = "10.30.0.0/20"
+  }
+}
+
+resource "google_service_account" "karpenter" {
+  account_id   = local.karpenter_sa_id
+  display_name = "${var.prefix} Karpenter controller"
+}
+
+resource "google_service_account" "nodes" {
+  account_id   = local.node_sa_id
+  display_name = "${var.prefix} GKE nodes"
+}
+
+resource "google_project_iam_member" "karpenter_compute_admin" {
+  project = var.project_id
+  role    = "roles/compute.admin"
+  member  = "serviceAccount:${google_service_account.karpenter.email}"
+}
+
+resource "google_project_iam_member" "karpenter_container_admin" {
+  project = var.project_id
+  role    = "roles/container.admin"
+  member  = "serviceAccount:${google_service_account.karpenter.email}"
+}
+
+resource "google_project_iam_member" "karpenter_sa_user" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.karpenter.email}"
+}
+
+resource "google_project_iam_member" "nodes_default_permissions" {
+  project = var.project_id
+  role    = "roles/container.defaultNodeServiceAccount"
+  member  = "serviceAccount:${google_service_account.nodes.email}"
+}
+
+resource "google_service_account_iam_member" "karpenter_workload_identity" {
+  service_account_id = google_service_account.karpenter.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[karpenter-system/karpenter]"
+}
+
+resource "google_container_cluster" "e2e" {
+  provider = google-beta
+
+  name                = local.cluster_name
+  location            = var.region
+  network             = google_compute_network.e2e.id
+  subnetwork          = google_compute_subnetwork.e2e.name
+  deletion_protection = false
+
+  networking_mode          = "VPC_NATIVE"
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = local.pods_range_name
+    services_secondary_range_name = local.services_range_name
+  }
+
+  release_channel {
+    channel = "REGULAR"
+  }
+
+  depends_on = [
+    google_project_service.compute,
+    google_project_service.container,
+  ]
+}
+
+resource "google_container_node_pool" "default" {
+  name           = local.system_nodepool_name
+  cluster        = google_container_cluster.e2e.name
+  location       = google_container_cluster.e2e.location
+  node_locations = local.zones
+
+  autoscaling {
+    total_min_node_count = 1
+    total_max_node_count = 3
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  node_config {
+    machine_type    = "e2-medium"
+    service_account = google_service_account.nodes.email
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    labels = {
+      pool = local.system_nodepool_name
+    }
+  }
+
+  depends_on = [
+    google_project_iam_member.nodes_default_permissions,
+    google_container_cluster.e2e,
+  ]
+}

--- a/test/e2e/terraform/outputs.tf
+++ b/test/e2e/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_name" {
+  description = "Created GKE cluster name."
+  value       = google_container_cluster.e2e.name
+}
+
+output "cluster_endpoint" {
+  description = "Created GKE cluster endpoint."
+  value       = google_container_cluster.e2e.endpoint
+}
+
+output "kubeconfig_path" {
+  description = "Local kubeconfig file used by the e2e suite."
+  value       = pathexpand("~/.kube/config")
+}
+
+output "karpenter_sa_email" {
+  description = "Workload Identity Google service account for the Karpenter controller."
+  value       = google_service_account.karpenter.email
+}

--- a/test/e2e/terraform/variables.tf
+++ b/test/e2e/terraform/variables.tf
@@ -1,0 +1,20 @@
+variable "project_id" {
+  description = "GCP project ID used for the e2e cluster."
+  type        = string
+}
+
+variable "region" {
+  description = "Regional location for the GKE cluster."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "prefix" {
+  description = "Prefix applied to all e2e resources."
+  type        = string
+}
+
+variable "credentials_path" {
+  description = "Absolute path to the GCP service account credentials JSON file."
+  type        = string
+}

--- a/test/e2e/terraform/versions.tf
+++ b/test/e2e/terraform/versions.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.37"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.37"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "google" {
+  project     = var.project_id
+  region      = var.region
+  credentials = file(var.credentials_path)
+}
+
+provider "google-beta" {
+  project     = var.project_id
+  region      = var.region
+  credentials = file(var.credentials_path)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a complete e2e test suite under `test/e2e/` that provisions a real GKE cluster via Terraform, deploys Karpenter from the local Helm chart, runs provisioning test cases, and tears everything down.

**Test cases:**
1. `TestOnDemandAMD64` — on-demand node provisioning with amd64 architecture
2. `TestSpotAMD64` — spot node provisioning with amd64 architecture
3. `TestOnDemandARM64` — on-demand node provisioning with arm64 architecture
4. `TestSpotARM64` — spot node provisioning with arm64 architecture

Each test creates a unique NodePool + GCENodeClass, deploys a workload, waits for Karpenter to provision a node, verifies labels (capacity-type, arch, instance-family, `karpenter.sh/registered=true`), then cleans up and verifies node removal.

**Infrastructure (Terraform):**
- VPC + subnet with secondary ranges for pods/services
- Regional GKE cluster with small system node pool
- Workload Identity enabled
- Karpenter GCP service account with required IAM roles
- All resources prefixed with `E2E_PREFIX` for isolation

**Inputs (env vars only):**
- `E2E_PROJECT_ID` — GCP project
- `E2E_GCP_CREDENTIALS` — path to service account JSON
- `E2E_PREFIX` — resource name prefix

**Run:** `make e2etests`

Also includes `test/e2e/PROPOSAL.md` with phased future test coverage plan (network configs, drift detection, interruption handling, GPU, load testing).

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- Uses standard Go `testing` + `testify` (no Ginkgo)
- Terraform handles full cluster lifecycle — no manual setup required
- The `make e2etests` target is added to the Makefile
- CI integration for e2e tests is tracked separately (requires GCP credentials/budget discussion)
- These tests create **billable GCP resources** — the suite destroys everything in `TestMain` teardown

#### Does this PR introduce a user-facing change?

```release-note
NONE
```