### PR TITLE
test(e2e): add provision, consolidation, drift, and expiration test suites

### DIFF
--- a/hack/e2e-teardown.sh
+++ b/hack/e2e-teardown.sh
@@ -116,13 +116,26 @@ if gcloud iam service-accounts describe "${GSA_EMAIL}" \
 fi
 
 # ── Subnet ─────────────────────────────────────────────────────────────────────
+# GKE cluster deletion is async: even after the cluster API object disappears,
+# GKE-managed instance groups may still hold the subnet for a minute or two.
+# Retry with backoff so we don't fail when re-running teardown after a partial run.
 if gcloud compute networks subnets describe "${SUBNET_NAME}" \
     --region "${E2E_REGION}" --project "${E2E_PROJECT_ID}" &>/dev/null; then
   log "Deleting subnet ${SUBNET_NAME}..."
-  gcloud compute networks subnets delete "${SUBNET_NAME}" \
-    --region "${E2E_REGION}" \
-    --project "${E2E_PROJECT_ID}" \
-    --quiet
+  WAIT_SECS=0
+  MAX_WAIT_SECS=600
+  until gcloud compute networks subnets delete "${SUBNET_NAME}" \
+      --region "${E2E_REGION}" \
+      --project "${E2E_PROJECT_ID}" \
+      --quiet 2>/dev/null; do
+    if [ "${WAIT_SECS}" -ge "${MAX_WAIT_SECS}" ]; then
+      echo "ERROR: subnet ${SUBNET_NAME} still in use after ${MAX_WAIT_SECS}s — GKE instance groups may not have fully cleaned up" >&2
+      exit 1
+    fi
+    log "Subnet still in use (GKE instance group cleanup in progress); retrying in 15s (${WAIT_SECS}s elapsed)..."
+    sleep 15
+    WAIT_SECS=$((WAIT_SECS + 15))
+  done
 fi
 
 # ── VPC ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind failing-test

#### What this PR does / why we need it:

Adds an end-to-end test infrastructure for karpenter-provider-gcp covering four disruption scenarios. The test structure mirrors karpenter-provider-aws: separate Ginkgo suite per scenario, shared helpers as methods on \`*Environment\` in \`test/pkg/environment/\`.

**Test suites:**

| Suite | Spec | Scenario |
|---|---|---|
| \`provisioning\` | amd64 on-demand, amd64 spot, arm64 on-demand, arm64 spot | Node provisioned, pod Running, node removed after workload deleted |
| \`consolidation\` | amd64 on-demand | Node emptied → removed by \`WhenEmptyOrUnderutilized\` without deleting NodePool |
| \`drift\` | amd64 on-demand | NodePool requirement updated to exclude provisioned instance type → node replaced |
| \`expiration\` | amd64 on-demand | \`expireAfter=12m\` → node replaced after expiry fires |

**Infrastructure:**
- \`test/pkg/environment/\` — shared harness (kubeconfig, GCP clients, karpenter readiness wait, node/pod/NodeClaim helpers)
- \`hack/e2e-setup.sh\` / \`e2e-deploy.sh\` / \`e2e-teardown.sh\` / \`e2e-check-clean.sh\`
- \`Makefile\` targets: \`e2e-setup\`, \`e2e-deploy\`, \`e2e-tests\`, \`e2e-test FOCUS="…" SUITE=<name>\`, \`e2e-teardown\`

**Suite isolation for parallel execution:** Each test creates resources with unique names via \`UniqueSuffix()\` (encodes Ginkgo process + atomic counter). \`Cleanup()\` is scoped to only the resources each \`Environment\` instance created, so suites can run concurrently with \`go test -p N ./test/suites/...\` without interfering. Default parallelism is \`-ginkgo.procs=2\` to avoid IP exhaustion on fresh GCP projects with low secondary-range quotas.

**ARM64 support (depends on #236):** Arch-native node pool templates (\`karpenter-cos-arm64\`, \`karpenter-ubuntu-arm64\`) are created at startup as best-effort (silently skipped if the region lacks ARM64 machine types). Instance routing is arch-aware: \`resolveNodePoolName\` selects the ARM64 template when \`kubernetes.io/arch=arm64\`. The \`patchKubeEnvForArch\` tarball-URL rewrite was removed — it caused bootstrap failures because the URL and its hash must be changed together; the arch-native pool template already carries the correct values.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- e2e tests are not run in CI (require a live GKE cluster). Run with \`make e2e-tests\` or \`make e2e-test SUITE=consolidation\`.
- \`expireAfter=12m\` is intentional: GCP provisioning can take up to ~7–8 min; a shorter value can cause an infinite replacement loop where nodes expire before they can register.
- The drift test retries NodePool updates on 409 Conflict since karpenter reconciles NodePools concurrently.
- Depends on #236 (ARM64 native templates) — rebased on top of it.

#### Does this PR introduce a user-facing change?

\`\`\`release-note
NONE
\`\`\`