### PR TITLE
fix: pass capacityType into buildInstance to prevent spot/on-demand provisioning mismatch

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -383,7 +383,7 @@ func (p *DefaultProvider) getOrCreateInstance(ctx context.Context, nodeClaim *ka
 		return instance, false, nil
 	}
 
-	instance, err = p.buildInstance(nodeClaim, nodeClass, instanceType, template, nodePoolName, zone, instanceName)
+	instance, err = p.buildInstance(nodeClaim, nodeClass, instanceType, template, nodePoolName, zone, instanceName, capacityType)
 	if err != nil {
 		return nil, false, fmt.Errorf("building instance %s: %w", instanceName, err)
 	}
@@ -653,13 +653,11 @@ func (p *DefaultProvider) renderDiskProperties(instanceType *cloudprovider.Insta
 	return attachedDisks, nil
 }
 
-func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, template *compute.InstanceTemplate, nodePoolName, zone, instanceName string) (*compute.Instance, error) {
+func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, template *compute.InstanceTemplate, nodePoolName, zone, instanceName, capacityType string) (*compute.Instance, error) {
 	attachedDisks, err := p.renderDiskProperties(instanceType, nodeClass, zone)
 	if err != nil {
 		return nil, fmt.Errorf("rendering disk properties: %w", err)
 	}
-
-	capacityType := p.getCapacityType(nodeClaim, []*cloudprovider.InstanceType{instanceType})
 
 	// Setup metadata
 	if err := p.setupInstanceMetadata(template.Properties.Metadata, nodeClass, instanceType, nodeClaim, nodePoolName, capacityType); err != nil {

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -798,3 +798,101 @@ func TestSetupScheduling_DoesNotMutateTemplate(t *testing.T) {
 	require.Equal(t, "MIGRATE", template.Properties.Scheduling.OnHostMaintenance,
 		"original template fields must be unchanged")
 }
+
+func spotOrOnDemandNodeClaim() *karpv1.NodeClaim {
+	return &karpv1.NodeClaim{
+		Spec: karpv1.NodeClaimSpec{
+			Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+				{
+					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+						Key:      karpv1.CapacityTypeLabelKey,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{karpv1.CapacityTypeSpot, karpv1.CapacityTypeOnDemand},
+					},
+				},
+			},
+		},
+	}
+}
+
+func onDemandNodeClaim() *karpv1.NodeClaim {
+	return &karpv1.NodeClaim{
+		Spec: karpv1.NodeClaimSpec{
+			Requirements: []karpv1.NodeSelectorRequirementWithMinValues{
+				{
+					NodeSelectorRequirement: corev1.NodeSelectorRequirement{
+						Key:      karpv1.CapacityTypeLabelKey,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{karpv1.CapacityTypeOnDemand},
+					},
+				},
+			},
+		},
+	}
+}
+
+func spotOffering() *cloudprovider.Offering {
+	return &cloudprovider.Offering{
+		Available: true,
+		Requirements: scheduling.NewRequirements(
+			scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, karpv1.CapacityTypeSpot),
+		),
+	}
+}
+
+func onDemandOffering() *cloudprovider.Offering {
+	return &cloudprovider.Offering{
+		Available: true,
+		Requirements: scheduling.NewRequirements(
+			scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, karpv1.CapacityTypeOnDemand),
+		),
+	}
+}
+
+func TestBuildInstance_UsesExternalCapacityTypeNotRecomputed(t *testing.T) {
+	t.Parallel()
+
+	p := &DefaultProvider{}
+
+	// on-demand-only: no spot offering — pre-fix buildInstance would recompute "on-demand" from this.
+	onDemandOnlyIT := &cloudprovider.InstanceType{
+		Name: "n2-standard-4",
+		Offerings: cloudprovider.Offerings{
+			{Available: true, Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, karpv1.CapacityTypeOnDemand),
+			)},
+		},
+		Requirements: scheduling.NewRequirements(
+			scheduling.NewRequirement(corev1.LabelArchStable, corev1.NodeSelectorOpIn, "amd64"),
+		),
+		Overhead: &cloudprovider.InstanceTypeOverhead{KubeReserved: corev1.ResourceList{}},
+	}
+
+	template := &compute.InstanceTemplate{
+		Properties: &compute.InstanceProperties{
+			Scheduling:        &compute.Scheduling{},
+			NetworkInterfaces: []*compute.NetworkInterface{},
+			Metadata: &compute.Metadata{
+				Items: []*compute.MetadataItems{
+					{Key: "kube-labels", Value: ptr.To("max-pods-per-node=110,max-pods=110")},
+					{Key: "kube-env", Value: ptr.To("KUBELET_ARGS: --max-pods=110\narch=amd64\n")},
+					{Key: "kubelet-config", Value: ptr.To("nodeStatusUpdateFrequency: 10s\n")},
+				},
+			},
+		},
+	}
+
+	instance, err := p.buildInstance(
+		spotOrOnDemandNodeClaim(),
+		&v1alpha1.GCENodeClass{},
+		onDemandOnlyIT,
+		template,
+		"default-pool", "us-central1-a", "karpenter-test",
+		karpv1.CapacityTypeSpot, // externally decided by Create() — must not be recomputed
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, instance)
+	require.Equal(t, "SPOT", instance.Scheduling.ProvisioningModel,
+		"buildInstance must use the passed capacityType, not recompute it from instanceType offerings")
+}

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -849,6 +849,63 @@ func onDemandOffering() *cloudprovider.Offering {
 	}
 }
 
+func TestGetCapacityType(t *testing.T) {
+	t.Parallel()
+
+	onDemandOnly := &cloudprovider.InstanceType{
+		Offerings: cloudprovider.Offerings{onDemandOffering()},
+	}
+	withSpot := &cloudprovider.InstanceType{
+		Offerings: cloudprovider.Offerings{spotOffering(), onDemandOffering()},
+	}
+	exhaustedSpot := &cloudprovider.InstanceType{
+		Offerings: cloudprovider.Offerings{
+			{Available: false, Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, karpv1.CapacityTypeSpot),
+			)},
+			onDemandOffering(),
+		},
+	}
+
+	tests := []struct {
+		name          string
+		nodeClaim     *karpv1.NodeClaim
+		instanceTypes []*cloudprovider.InstanceType
+		want          string
+	}{
+		{
+			// Spot is not the first type — confirms the loop scans all candidates.
+			name:          "returns spot when a later instance type has an available spot offering",
+			nodeClaim:     spotOrOnDemandNodeClaim(),
+			instanceTypes: []*cloudprovider.InstanceType{onDemandOnly, withSpot},
+			want:          karpv1.CapacityTypeSpot,
+		},
+		{
+			// All types have only exhausted or absent spot — confirms no false positive.
+			// Also validates that exhausted spot offerings (Available: false) are skipped.
+			name:          "falls back to on-demand when no available spot offerings exist",
+			nodeClaim:     spotOrOnDemandNodeClaim(),
+			instanceTypes: []*cloudprovider.InstanceType{exhaustedSpot, onDemandOnly},
+			want:          karpv1.CapacityTypeOnDemand,
+		},
+		{
+			// nodeClaim forbids spot; on-demand offering is present and must be selected.
+			name:          "respects on-demand-only node claim even when spot offerings exist",
+			nodeClaim:     onDemandNodeClaim(),
+			instanceTypes: []*cloudprovider.InstanceType{withSpot, onDemandOnly},
+			want:          karpv1.CapacityTypeOnDemand,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := &DefaultProvider{}
+			require.Equal(t, tt.want, p.getCapacityType(tt.nodeClaim, tt.instanceTypes))
+		})
+	}
+}
+
 func TestBuildInstance_UsesExternalCapacityTypeNotRecomputed(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`buildInstance` recomputed `capacityType` internally from the single instance type being attempted. `Create()` computes it from the full candidate list. These diverge when the chosen instance type has no spot offering but another candidate does — `Create()` returns `"spot"`, `buildInstance` returns `"on-demand"`.

Primary consequence: the wrong provisioning model is sent to the GCE API. A node requested as spot is silently provisioned as on-demand (higher cost, different eviction SLA). Secondary consequence: on insert failure, the wrong key is written to the unavailable-offerings cache, causing future scheduling cycles to mark the wrong offering exhausted.

**Fix:** remove the internal `getCapacityType` call in `buildInstance`; accept `capacityType` as a parameter so the GCE API call and the cache entry always agree with what `Create()` decided.

#### Which issue(s) this PR fixes:

Fixes #237

#### Special notes for your reviewer:

Two-line change in `instance.go`:
1. Add `capacityType string` to `buildInstance`'s signature
2. Remove the internal `getCapacityType` recomputation

Test changes:
- Four `TestGetCapacityType_*` functions collapsed into one table-driven `TestGetCapacityType`
- `TestBuildInstance_UsesExternalCapacityTypeNotRecomputed`: calls `buildInstance` with `capacityType="spot"` and an on-demand-only instance type, asserts `ProvisioningModel==SPOT` — **fails on `origin/main`**, passes on this branch

#### Does this PR introduce a user-facing change?

```release-note
NONE
```