### PR TITLE
fix: copy Scheduling struct in setupScheduling to avoid template mutation

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -812,14 +812,16 @@ func (p *DefaultProvider) setupServiceAccounts(nodeClass *v1alpha1.GCENodeClass,
 
 // setupScheduling configures scheduling for the instance
 func (p *DefaultProvider) setupScheduling(template *compute.InstanceTemplate, capacityType string) *compute.Scheduling {
-	sched := template.Properties.Scheduling
-	if sched == nil {
-		sched = &compute.Scheduling{}
+	// Copy the struct so we never mutate the shared template — the same template
+	// pointer is reused across zone and instance-type retries inside Create().
+	var sched compute.Scheduling
+	if template.Properties.Scheduling != nil {
+		sched = *template.Properties.Scheduling
 	}
 	if capacityType == karpv1.CapacityTypeSpot {
 		sched.InstanceTerminationAction = instanceTerminationActionDelete
 	}
-	return sched
+	return &sched
 }
 
 // initializeInstanceLabels initializes the instance labels map

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -572,3 +572,27 @@ func TestSetupNetworkInterfaces(t *testing.T) {
 		require.Equal(t, "/26", result[0].AliasIpRanges[0].IpCidrRange)
 	})
 }
+
+// TestSetupScheduling_DoesNotMutateTemplate guards against setupScheduling mutating the shared
+// template. The same template pointer is reused across zone and instance-type retries inside
+// Create(), so any in-place write to template.Properties.Scheduling would persist across
+// iterations and corrupt subsequent instances.
+func TestSetupScheduling_DoesNotMutateTemplate(t *testing.T) {
+	t.Parallel()
+
+	p := &DefaultProvider{}
+	template := &compute.InstanceTemplate{
+		Properties: &compute.InstanceProperties{
+			Scheduling: &compute.Scheduling{OnHostMaintenance: "MIGRATE"},
+		},
+	}
+
+	sched := p.setupScheduling(template, karpv1.CapacityTypeSpot)
+
+	require.Equal(t, instanceTerminationActionDelete, sched.InstanceTerminationAction,
+		"returned Scheduling must have InstanceTerminationAction set for spot")
+	require.Empty(t, template.Properties.Scheduling.InstanceTerminationAction,
+		"setupScheduling must not write to the original template Scheduling struct")
+	require.Equal(t, "MIGRATE", template.Properties.Scheduling.OnHostMaintenance,
+		"original template fields must be unchanged")
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`setupScheduling` assigned `template.Properties.Scheduling` to a local variable, which copies the pointer rather than the struct. For spot instances the subsequent write to `sched.InstanceTerminationAction` mutated the shared template in place.

This is a critical hazard: `InstanceTerminationAction = "DELETE"` is required for spot VMs but must not be set on on-demand VMs. Templates are keyed by image family and shared across capacity types, making them a natural caching target. If the template would be ever cached, a concurrent on-demand NodeClaim for the same image family would inherit the spot termination policy — GCE would either reject the request or silently treat the VM as preemptible, causing unexpected workload evictions with no trace in Karpenter logs.

Fix: copy the struct with `sched = *template.Properties.Scheduling` so writes go to a local copy and the template is never touched. `compute.Scheduling` is a plain Go struct (not protobuf), so struct value copy is the correct approach.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

One-line change in `setupScheduling`. `TestSetupScheduling_DoesNotMutateTemplate` asserts the template is unchanged after a spot call.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```