### PR TITLE
fix: propagate buildInstance errors instead of logging and returning nil

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -378,7 +378,10 @@ func (p *DefaultProvider) getOrCreateInstance(ctx context.Context, nodeClaim *ka
 		return instance, false, nil
 	}
 
-	instance = p.buildInstance(nodeClaim, nodeClass, instanceType, template, nodePoolName, zone, instanceName)
+	instance, err = p.buildInstance(nodeClaim, nodeClass, instanceType, template, nodePoolName, zone, instanceName)
+	if err != nil {
+		return nil, false, fmt.Errorf("building instance %s: %w", instanceName, err)
+	}
 	op, err := p.computeService.Instances.Insert(p.projectID, zone, instance).Context(ctx).Do()
 	if err != nil {
 		reason, reasonCode, insufficient := extractInsertInsufficientCapacityReason(err)
@@ -630,19 +633,17 @@ func (p *DefaultProvider) renderDiskProperties(instanceType *cloudprovider.Insta
 	return attachedDisks, nil
 }
 
-func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, template *compute.InstanceTemplate, nodePoolName, zone, instanceName string) *compute.Instance {
+func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, template *compute.InstanceTemplate, nodePoolName, zone, instanceName string) (*compute.Instance, error) {
 	attachedDisks, err := p.renderDiskProperties(instanceType, nodeClass, zone)
 	if err != nil {
-		log.FromContext(context.Background()).Error(err, "failed to render disk properties")
-		return nil
+		return nil, fmt.Errorf("rendering disk properties: %w", err)
 	}
 
 	capacityType := p.getCapacityType(nodeClaim, []*cloudprovider.InstanceType{instanceType})
 
 	// Setup metadata
 	if err := p.setupInstanceMetadata(template.Properties.Metadata, nodeClass, instanceType, nodeClaim, nodePoolName, capacityType); err != nil {
-		log.FromContext(context.Background()).Error(err, "failed to setup instance metadata")
-		return nil
+		return nil, fmt.Errorf("setting up instance metadata: %w", err)
 	}
 
 	// Setup service accounts
@@ -683,7 +684,7 @@ func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *
 	// Setup karpenter built-in labels
 	p.setupInstanceLabels(instance, nodeClaim, nodeClass, instanceType)
 
-	return instance
+	return instance, nil
 }
 
 // nolint:gocyclo


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`buildInstance` calls `renderDiskProperties` and `setupInstanceMetadata`, both of which can fail (e.g. no image found for the node class, kubelet config encoding error). Instead of returning an error, the current code logs via `context.Background()` and returns `nil`. The `nil` instance is then passed straight to `Instances.Insert`, which either panics or produces a confusing downstream error with no trace back to the root cause.

Using `context.Background()` also silently drops any trace/request context carried by the caller, so the error appears in the logs detached from the provisioning span.

**Fix:** change `buildInstance` to return `(*compute.Instance, error)`. Errors are now wrapped and propagated through `getOrCreateInstance`, producing a single coherent log line:

```
failed to create instance: building instance karpenter-abc123: rendering disk properties: no target image found for node class foo
```

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Signature change only: `*compute.Instance` → `(*compute.Instance, error)`. No logic change; `getOrCreateInstance` is updated to handle the new return value.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```