### PR TITLE
fix(instance): skip zones with cached insufficient capacity in zone selection

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -522,11 +522,9 @@ func (p *DefaultProvider) selectZone(ctx context.Context, nodeClaim *karpv1.Node
 	// Without this filter, every retry calls MarkUnavailable and resets the
 	// 30-min TTL, preventing natural expiry. Applied to both on-demand and
 	// spot so both paths behave consistently.
-	if p.unavailableOfferings != nil {
-		zones = lo.Filter(zones, func(z string, _ int) bool {
-			return !p.unavailableOfferings.IsUnavailable(instanceType.Name, z, capacityType)
-		})
-	}
+	zones = lo.Filter(zones, func(z string, _ int) bool {
+		return !p.unavailableOfferings.IsUnavailable(instanceType.Name, z, capacityType)
+	})
 	if len(zones) == 0 {
 		return "", cloudprovider.NewInsufficientCapacityError(
 			fmt.Errorf("all zones exhausted for instance type %s", instanceType.Name))

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -484,9 +484,6 @@ func cheapestCompatibleZone(zones []string, reqs scheduling.Requirements, offeri
 	cheapestPrice := math.MaxFloat64
 	zonesSet := sets.NewString(zones...)
 	for _, offering := range offerings {
-		if !offering.Available {
-			continue
-		}
 		if reqs.Compatible(offering.Requirements, scheduling.AllowUndefinedWellKnownLabels) != nil {
 			continue
 		}

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -518,21 +518,23 @@ func (p *DefaultProvider) selectZone(ctx context.Context, nodeClaim *karpv1.Node
 		return "", fmt.Errorf("no zones match topology requirement %q", corev1.LabelTopologyZone)
 	}
 
-	// For on-demand, skip zones already known to be unavailable so we don't
-	// waste an API call and refresh the 30-min ICE cache TTL on a guaranteed
-	// failure. The spot path handles this via cheapestCompatibleZone, which
-	// already filters by offering.Available.
-	if capacityType == karpv1.CapacityTypeOnDemand {
+	// Skip zones with known ICE for this instance type and capacity type.
+	// Without this filter, every retry calls MarkUnavailable and resets the
+	// 30-min TTL, preventing natural expiry. Applied to both on-demand and
+	// spot so both paths behave consistently.
+	if p.unavailableOfferings != nil {
 		zones = lo.Filter(zones, func(z string, _ int) bool {
-			return p.unavailableOfferings == nil || !p.unavailableOfferings.IsUnavailable(instanceType.Name, z, capacityType)
+			return !p.unavailableOfferings.IsUnavailable(instanceType.Name, z, capacityType)
 		})
-		if len(zones) == 0 {
-			return "", cloudprovider.NewInsufficientCapacityError(
-				fmt.Errorf("all zones exhausted for instance type %s", instanceType.Name))
-		}
+	}
+	if len(zones) == 0 {
+		return "", cloudprovider.NewInsufficientCapacityError(
+			fmt.Errorf("all zones exhausted for instance type %s", instanceType.Name))
+	}
+
+	if capacityType == karpv1.CapacityTypeOnDemand {
 		return randomZone(zones), nil
 	}
-	// else for spot, choose the cheapest zone
 	return cheapestCompatibleZone(zones, reqs, instanceType.Offerings), nil
 }
 

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -527,9 +527,12 @@ func (p *DefaultProvider) selectZone(ctx context.Context, nodeClaim *karpv1.Node
 			fmt.Errorf("all zones exhausted for instance type %s", instanceType.Name))
 	}
 
+	// For on-demand, randomly select a zone from those that satisfy the requirement,
+	// to spread load while still honoring topology constraints.
 	if capacityType == karpv1.CapacityTypeOnDemand {
 		return randomZone(zones), nil
 	}
+	// else for spot, choose the cheapest zone
 	return cheapestCompatibleZone(zones, reqs, instanceType.Offerings), nil
 }
 

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -518,9 +518,18 @@ func (p *DefaultProvider) selectZone(ctx context.Context, nodeClaim *karpv1.Node
 		return "", fmt.Errorf("no zones match topology requirement %q", corev1.LabelTopologyZone)
 	}
 
-	// For on-demand, randomly select a zone from those that satisfy the requirement,
-	// to spread load while still honoring topology constraints.
+	// For on-demand, skip zones already known to be unavailable so we don't
+	// waste an API call and refresh the 30-min ICE cache TTL on a guaranteed
+	// failure. The spot path handles this via cheapestCompatibleZone, which
+	// already filters by offering.Available.
 	if capacityType == karpv1.CapacityTypeOnDemand {
+		zones = lo.Filter(zones, func(z string, _ int) bool {
+			return p.unavailableOfferings == nil || !p.unavailableOfferings.IsUnavailable(instanceType.Name, z, capacityType)
+		})
+		if len(zones) == 0 {
+			return "", cloudprovider.NewInsufficientCapacityError(
+				fmt.Errorf("all zones exhausted for instance type %s", instanceType.Name))
+		}
 		return randomZone(zones), nil
 	}
 	// else for spot, choose the cheapest zone

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -483,6 +483,59 @@ func TestSelectZone_OnDemandReturnsICEWhenAllZonesUnavailable(t *testing.T) {
 		"should return InsufficientCapacityError when all zones are exhausted")
 }
 
+func TestSelectZone_SpotSkipsUnavailableZones(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	uo := pkgcache.NewUnavailableOfferings()
+	uo.MarkUnavailable(ctx, "ICE", "n2-standard-4", "europe-west4-a", karpv1.CapacityTypeSpot)
+
+	p := &DefaultProvider{
+		gkeProvider: &fakeGKEProvider{
+			zones: []string{"europe-west4-a", "europe-west4-b"},
+		},
+		unavailableOfferings: uo,
+	}
+	instanceType := &cloudprovider.InstanceType{
+		Name: "n2-standard-4",
+		Offerings: cloudprovider.Offerings{
+			{Available: true, Price: 1.0, Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "europe-west4-a"),
+			)},
+			{Available: true, Price: 0.5, Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "europe-west4-b"),
+			)},
+		},
+	}
+
+	zone, err := p.selectZone(ctx, &karpv1.NodeClaim{}, instanceType, karpv1.CapacityTypeSpot)
+	require.NoError(t, err)
+	require.Equal(t, "europe-west4-b", zone, "should skip the ICE-cached zone even though it has a cheaper offering")
+}
+
+func TestSelectZone_SpotReturnsICEWhenAllZonesUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	uo := pkgcache.NewUnavailableOfferings()
+	for _, z := range []string{"europe-west4-a", "europe-west4-b"} {
+		uo.MarkUnavailable(ctx, "ICE", "n2-standard-4", z, karpv1.CapacityTypeSpot)
+	}
+
+	p := &DefaultProvider{
+		gkeProvider: &fakeGKEProvider{
+			zones: []string{"europe-west4-a", "europe-west4-b"},
+		},
+		unavailableOfferings: uo,
+	}
+	instanceType := &cloudprovider.InstanceType{Name: "n2-standard-4"}
+
+	_, err := p.selectZone(ctx, &karpv1.NodeClaim{}, instanceType, karpv1.CapacityTypeSpot)
+	require.Error(t, err)
+	require.True(t, cloudprovider.IsInsufficientCapacityError(err),
+		"should return InsufficientCapacityError when all zones are exhausted for spot")
+}
+
 // amd64InstanceType returns a minimal InstanceType with amd64 architecture requirements.
 func amd64InstanceType() *cloudprovider.InstanceType {
 	return &cloudprovider.InstanceType{

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -432,6 +432,57 @@ func TestSelectZone_SpotChoosesCheapestWithinTopologyRequirement(t *testing.T) {
 	require.Equal(t, "europe-west4-b", zone)
 }
 
+func TestSelectZone_OnDemandSkipsUnavailableZones(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	uo := pkgcache.NewUnavailableOfferings()
+	uo.MarkUnavailable(ctx, "ICE", "n2-standard-4", "europe-west4-a", karpv1.CapacityTypeOnDemand)
+	uo.MarkUnavailable(ctx, "ICE", "n2-standard-4", "europe-west4-c", karpv1.CapacityTypeOnDemand)
+
+	p := &DefaultProvider{
+		gkeProvider: &fakeGKEProvider{
+			zones: []string{"europe-west4-a", "europe-west4-b", "europe-west4-c"},
+		},
+		unavailableOfferings: uo,
+	}
+	instanceType := &cloudprovider.InstanceType{
+		Name: "n2-standard-4",
+		Offerings: cloudprovider.Offerings{
+			{Available: true, Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "europe-west4-b"),
+			)},
+		},
+	}
+
+	zone, err := p.selectZone(ctx, &karpv1.NodeClaim{}, instanceType, karpv1.CapacityTypeOnDemand)
+	require.NoError(t, err)
+	require.Equal(t, "europe-west4-b", zone, "should skip the two unavailable zones and return the only available one")
+}
+
+func TestSelectZone_OnDemandReturnsICEWhenAllZonesUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	uo := pkgcache.NewUnavailableOfferings()
+	for _, z := range []string{"europe-west4-a", "europe-west4-b", "europe-west4-c"} {
+		uo.MarkUnavailable(ctx, "ICE", "n2-standard-4", z, karpv1.CapacityTypeOnDemand)
+	}
+
+	p := &DefaultProvider{
+		gkeProvider: &fakeGKEProvider{
+			zones: []string{"europe-west4-a", "europe-west4-b", "europe-west4-c"},
+		},
+		unavailableOfferings: uo,
+	}
+	instanceType := &cloudprovider.InstanceType{Name: "n2-standard-4"}
+
+	_, err := p.selectZone(ctx, &karpv1.NodeClaim{}, instanceType, karpv1.CapacityTypeOnDemand)
+	require.Error(t, err)
+	require.True(t, cloudprovider.IsInsufficientCapacityError(err),
+		"should return InsufficientCapacityError when all zones are exhausted")
+}
+
 // amd64InstanceType returns a minimal InstanceType with amd64 architecture requirements.
 func amd64InstanceType() *cloudprovider.InstanceType {
 	return &cloudprovider.InstanceType{

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -243,6 +243,7 @@ func TestSelectZone_OnDemandHonorsTopologyRequirement(t *testing.T) {
 		gkeProvider: &fakeGKEProvider{
 			zones: []string{"europe-west4-a", "europe-west4-b", "europe-west4-c"},
 		},
+		unavailableOfferings: pkgcache.NewUnavailableOfferings(),
 	}
 
 	nodeClaim := &karpv1.NodeClaim{
@@ -284,6 +285,7 @@ func TestSelectZone_FailsWhenNoZonesMatchRequirement(t *testing.T) {
 		gkeProvider: &fakeGKEProvider{
 			zones: []string{"europe-west4-a", "europe-west4-c"},
 		},
+		unavailableOfferings: pkgcache.NewUnavailableOfferings(),
 	}
 
 	nodeClaim := &karpv1.NodeClaim{
@@ -392,6 +394,7 @@ func TestSelectZone_SpotChoosesCheapestWithinTopologyRequirement(t *testing.T) {
 		gkeProvider: &fakeGKEProvider{
 			zones: []string{"europe-west4-a", "europe-west4-b"},
 		},
+		unavailableOfferings: pkgcache.NewUnavailableOfferings(),
 	}
 
 	nodeClaim := &karpv1.NodeClaim{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`selectZone` did not consult the unavailability cache before picking a zone, causing two problems:

1. **On-demand**: zones with cached insufficient capacity entries were retried on every provisioning attempt, calling `MarkUnavailable` each time and resetting the 30-minute TTL. Zones would stay poisoned indefinitely instead of recovering after 30 minutes.

2. **Spot**: `cheapestCompatibleZone` filtered by `offering.Available` (an indirect read of the same cache), so spot happened to be protected — but only as a side-effect of the price-selection logic, not explicitly.

**Fix**: add a single `IsUnavailable` pre-filter before the `capacityType` branch so both on-demand and spot skip zones with cached insufficient capacity entries via the same code path. Once a zone is skipped (not retried), its TTL ticks down naturally and the zone recovers after 30 minutes. If all zones for an instance type are exhausted, `selectZone` returns `InsufficientCapacityError` immediately instead of making a guaranteed-to-fail GCP API call.

The now-redundant `offering.Available` check has been removed from `cheapestCompatibleZone` since zones are pre-filtered before the call.

**Relationship to #238**: PR #238 fixes `capacityType` being mis-computed in `buildInstance`, which caused on-demand insufficient capacity errors to be cached under the wrong key (`spot` instead of `on-demand`). This PR is independent and correct with or without #238 merged, but the two together fully fix the unavailability cache correctness.

#### Which issue(s) this PR fixes:

Related to #237

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Fixed on-demand zone selection to skip zones with cached insufficient capacity entries, preventing indefinite TTL refresh and allowing zones to recover naturally after 30 minutes.
```