### PR TITLE
feat: add CMEK and Secure Boot settings to template node pools

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -53,6 +53,14 @@ spec:
               value: {{ .Values.controller.settings.projectID }}
             - name: CLUSTER_LOCATION
               value: {{ .Values.controller.settings.clusterLocation }}
+            {{- if .Values.controller.settings.defaultNodePoolBootDiskKmsKey }}
+            - name: DEFAULT_NODEPOOL_BOOT_DISK_KMS_KEY
+              value: {{ .Values.controller.settings.defaultNodePoolBootDiskKmsKey }}
+            {{- end }}
+            {{- if .Values.controller.settings.defaultNodePoolShieldedVM }}
+            - name: DEFAULT_NODEPOOL_SHIELDED_VM
+              value: "true"
+            {{- end }}
             {{- if .Values.controller.settings.nodeLocation }}
             - name: NODE_LOCATION
               value: {{ .Values.controller.settings.nodeLocation }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -74,11 +74,17 @@ controller:
     projectID: ""
     # -- The GCP region for instance type discovery (e.g., us-central1)
     clusterLocation: ""
+    # -- The GCP cluster name.
+    clusterName: ""
+    # -- Cloud KMS key for boot disk encryption on default node pool templates.
+    # Format: projects/{project}/locations/{location}/keyRings/{keyring}/cryptoKeys/{key}
+    defaultNodePoolBootDiskKmsKey: ""
+    # -- Enable Shielded VM (Secure Boot) on default node pool templates.
+    # Required when the compute.requireShieldedVm org policy is enforced.
+    defaultNodePoolShieldedVM: false
     # -- The exact GCP cluster location for GKE API calls (e.g., us-central1-a for zonal, us-central1 for regional).
     # If not set, defaults to 'clusterLocation' for backward compatibility.
     nodeLocation: ""
-    # -- The GCP cluster name.
-    clusterName: ""
     # -- The VM memory overhead as a percent that will be subtracted from the total memory for all instance types. The value of `0.075` equals to 7.5%.
     vmMemoryOverheadPercent: 0.065
     # -- The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -103,6 +103,8 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		options.FromContext(ctx).NodePoolServiceAccount,
 		options.FromContext(ctx).ClusterLocation,
 		options.FromContext(ctx).NodeLocation,
+		options.FromContext(ctx).NodePoolBootDiskKmsKey,
+		options.FromContext(ctx).NodePoolShieldedVM,
 	)
 	imageProvider := imagefamily.NewDefaultProvider(computeService, nodeTemplateProvider)
 	pricingProvider, err := pricing.NewDefaultProvider(ctx, region)

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -40,8 +40,12 @@ const (
 	vmMemoryOverheadPercentFlagName   = "vm-memory-overhead-percent"
 	gkeEnableInterruption             = "INTERRUPTION"
 	GCPAuth                           = "GOOGLE_APPLICATION_CREDENTIALS"
+	nodePoolBootDiskKmsKeyEnvVarName  = "DEFAULT_NODEPOOL_BOOT_DISK_KMS_KEY"
+	nodePoolBootDiskKmsKeyFlagName    = "default-nodepool-boot-disk-kms-key"
 	nodePoolServiceAccountEnvVarName  = "DEFAULT_NODEPOOL_SERVICE_ACCOUNT"
 	nodePoolServiceAccountFlagName    = "default-nodepool-service-account"
+	nodePoolShieldedVMEnvVarName      = "DEFAULT_NODEPOOL_SHIELDED_VM"
+	nodePoolShieldedVMFlagName        = "default-nodepool-shielded-vm"
 )
 
 func init() {
@@ -59,7 +63,9 @@ type Options struct {
 	// GCPAuth is the path to the Google Application Credentials JSON file.
 	// https://cloud.google.com/docs/authentication/application-default-credentials
 	GCPAuth                string
+	NodePoolBootDiskKmsKey string
 	NodePoolServiceAccount string
+	NodePoolShieldedVM     bool
 	Interruption           bool
 }
 
@@ -70,7 +76,9 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.ClusterName, gkeClusterFlagName, env.WithDefaultString(gkeClusterNameEnvVarName, ""), "Name of the GKE cluster that provisioned nodes should connect to.")
 	fs.Float64Var(&o.VMMemoryOverheadPercent, vmMemoryOverheadPercentFlagName, utils.WithDefaultFloat64(vmMemoryOverheadPercentEnvVarName, 0.07), "Percentage of memory overhead for VM. If not set, the controller will use the default value 7%.")
 	fs.StringVar(&o.GCPAuth, GCPAuth, env.WithDefaultString(GCPAuth, ""), "Path to the Google Application Credentials JSON file. If not set, the controller will use the default credentials from the environment.")
+	fs.StringVar(&o.NodePoolBootDiskKmsKey, nodePoolBootDiskKmsKeyFlagName, env.WithDefaultString(nodePoolBootDiskKmsKeyEnvVarName, ""), "Cloud KMS key to use for boot disk encryption on default node pool templates. Format: projects/{project}/locations/{location}/keyRings/{keyring}/cryptoKeys/{key}")
 	fs.StringVar(&o.NodePoolServiceAccount, nodePoolServiceAccountFlagName, env.WithDefaultString(nodePoolServiceAccountEnvVarName, ""), "Service account to use for default node pool templates. If not set, uses <project number>-compute@developer.gserviceaccount.com")
+	fs.BoolVar(&o.NodePoolShieldedVM, nodePoolShieldedVMFlagName, env.WithDefaultBool(nodePoolShieldedVMEnvVarName, false), "Enable Shielded VM (Secure Boot) on default node pool templates.")
 	fs.BoolVar(&o.Interruption, gkeEnableInterruption, env.WithDefaultBool(gkeEnableInterruption, true), "Enable interruption handling.")
 }
 

--- a/pkg/providers/nodepooltemplate/nodepooltemplate.go
+++ b/pkg/providers/nodepooltemplate/nodepooltemplate.go
@@ -40,9 +40,11 @@ type Provider interface {
 }
 
 type DefaultProvider struct {
+	bootDiskKmsKey        string
 	computeService        *compute.Service
 	containerService      *container.Service
 	kubeClient            client.Client
+	shieldedVM            bool
 	versionProvider       version.Provider
 	ClusterInfo           ClusterInfo
 	defaultServiceAccount string
@@ -76,7 +78,8 @@ const arm64MachineType = "c4a-standard-1"
 
 func NewDefaultProvider(ctx context.Context, kubeClient client.Client, computeService *compute.Service,
 	containerService *container.Service, versionProvider version.Provider,
-	clusterName, region, projectID, serviceAccount, clusterLocation, nodeLocation string) *DefaultProvider {
+	clusterName, region, projectID, serviceAccount, clusterLocation, nodeLocation, bootDiskKmsKey string,
+	shieldedVM bool) *DefaultProvider {
 
 	zones, err := resolveZones(ctx, computeService, projectID, region)
 	if err != nil {
@@ -85,9 +88,11 @@ func NewDefaultProvider(ctx context.Context, kubeClient client.Client, computeSe
 	}
 
 	return &DefaultProvider{
+		bootDiskKmsKey:        bootDiskKmsKey,
 		kubeClient:            kubeClient,
 		computeService:        computeService,
 		containerService:      containerService,
+		shieldedVM:            shieldedVM,
 		versionProvider:       versionProvider,
 		defaultServiceAccount: serviceAccount,
 		ClusterInfo: ClusterInfo{
@@ -181,11 +186,17 @@ func (p *DefaultProvider) ensureKarpenterNodePoolTemplate(ctx context.Context, i
 	}
 
 	nodeConfig := &container.NodeConfig{
+		BootDiskKmsKey: p.bootDiskKmsKey,
 		ImageType:      imageType,
 		ServiceAccount: serviceAccount,
 	}
 	if machineType != "" {
 		nodeConfig.MachineType = machineType
+	}
+	if p.shieldedVM {
+		nodeConfig.ShieldedInstanceConfig = &container.ShieldedInstanceConfig{
+			EnableSecureBoot: true,
+		}
 	}
 	nodePoolOpts := &container.CreateNodePoolRequest{
 		NodePool: &container.NodePool{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The `nodepooltemplate` controller auto-creates `karpenter-default` and `karpenter-ubuntu` GKE node pools, but uses a minimal `NodeConfig` that lacks boot disk encryption and Shielded VM settings. This causes auto-creation to fail in environments that enforce `gcp.restrictNonCmekServices` or `compute.requireShieldedVm` org policy constraints.

This PR adds two new controller settings:

- **`DEFAULT_NODEPOOL_BOOT_DISK_KMS_KEY`** — Cloud KMS key for boot disk encryption on template node pools
- **`DEFAULT_NODEPOOL_SHIELDED_VM`** — enables Secure Boot on template node pools

Both settings are optional, backward-compatible, and follow the existing `DEFAULT_NODEPOOL_SERVICE_ACCOUNT` pattern.

Helm usage:

```yaml
controller:
  settings:
    defaultNodePoolBootDiskKmsKey: "projects/my-project/locations/us-central1/keyRings/my-ring/cryptoKeys/my-key"
    defaultNodePoolShieldedVM: true
```

#### Special notes for your reviewer:

When `defaultNodePoolShieldedVM` is `false` (default), we still send a `ShieldedInstanceConfig` struct with `EnableSecureBoot: false`. Since the field uses `omitempty`, it gets omitted from the JSON request and the GKE API uses its default. Same applies to `BootDiskKmsKey` with an empty string. 
I opted for this approach to keep the code minimal, but happy to add explicit nil-checking if you'd prefer.

#### Does this PR introduce a user-facing change?

```release-note
Add DEFAULT_NODEPOOL_BOOT_DISK_KMS_KEY and DEFAULT_NODEPOOL_SHIELDED_VM controller settings to configure boot disk encryption and Secure Boot on auto-created template node pools.
```