### PR TITLE
fix(makefile): scope ut-test coverage to package under test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ delete: ## Delete the controller from your kubeconfig cluster
 
 ut-test: ## Run unit tests
 	go test ./pkg/... \
-		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./...
+		-cover -coverprofile=coverage.out -outputdir=.
 
 # E2E configuration — names are derived from E2E_PREFIX to stay consistent
 # between the setup script and the test binary.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes `-coverpkg=./...` from the `ut-test` Makefile target.

Before (we show the percent of statements package covers from ./...):
```
go test./pkg/... \
        -cover -coverprofile=coverage.out -outputdir=. -coverpkg=./...
?       github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis        [no test files]
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1               coverage: 0.0% of statements
?       github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/auth        [no test files]
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/cache       (cached)        coverage: 0.5% of statements in ./...
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/cloudprovider       1.990s  coverage: 1.0% of statements in ./...
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/cloudprovider/events                coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers         coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/csr             coverage: 0.0% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/interruption    (cached)        coverage: 1.6% of statements in ./...
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/interruption/events             coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/node            coverage: 0.0% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/nodeclaim/garbagecollection     (cached)        coverage: 1.2% of statements in ./...
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/nodeclass/hash          coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/nodeclass/status                coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/nodeclass/termination           coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/nodepooltemplate                coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/providers/instancetype          coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/providers/pricing               coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/telemetry               coverage: 0.0% of statements
?       github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/errors      [no test files]
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/operator            coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/operator/options            coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/gke               coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/imagefamily               coverage: 0.0% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instance  (cached)        coverage: 15.9% of statements in ./...
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instancetype      2.316s  coverage: 7.7% of statements in ./...
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/metadata  (cached)        coverage: 1.0% of statements in ./...
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/nodepooltemplate          coverage: 0.0% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/pricing   4.381s  coverage: 4.1% of statements in ./...
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/pricing/instanceprice     2.865s  coverage: 2.1% of statements in ./...
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/version           coverage: 0.0% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils       (cached)        coverage: 2.6% of statements in ./...
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils/localssd      (cached)        coverage: 0.5% of statements in ./...
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils/object                coverage: 0.0% of statements
```

After (show percent of statements that covers from a package the test was invoked):
```
go test ./pkg/... \
        -cover -coverprofile=coverage.out -outputdir=.
?       github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis        [no test files]
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1               coverage: 0.0% of statements
?       github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/auth        [no test files]
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/cache       2.567s  coverage: 73.3% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/cloudprovider       2.515s  coverage: 10.1% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/cloudprovider/events                coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers         coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/csr             coverage: 0.0% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/interruption    3.270s  coverage: 42.6% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/interruption/events             coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/node            coverage: 0.0% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/nodeclaim/garbagecollection     1.805s  coverage: 87.1% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/nodeclass/hash          coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/nodeclass/status                coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/nodeclass/termination           coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/nodepooltemplate                coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/providers/instancetype          coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/providers/pricing               coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/controllers/telemetry               coverage: 0.0% of statements
?       github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/errors      [no test files]
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/operator            coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/operator/options            coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/gke               coverage: 0.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/imagefamily               coverage: 0.0% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instance  3.495s  coverage: 44.4% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instancetype      5.135s  coverage: 65.7% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/metadata  4.036s  coverage: 12.6% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/nodepooltemplate          coverage: 0.0% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/pricing   7.289s  coverage: 86.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/version           coverage: 0.0% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils       5.709s  coverage: 70.6% of statements
ok      github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils/localssd      6.040s  coverage: 100.0% of statements
        github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils/object                coverage: 0.0% of statements
```

Other CNCF and Kubernetes project seems to use `-coverpkg` only in integration tests. 

#### Which issue(s) this PR fixes:

Fixes #N/A

#### Special notes for your reviewer:
- This is a single-line Makefile change with no logic impact.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```