### PR TITLE
test(e2e): re-enable GC and networking e2e specs

### DIFF
--- a/test/suites/gc/gc_test.go
+++ b/test/suites/gc/gc_test.go
@@ -35,7 +35,7 @@ import (
 const gcTimeout = 6 * time.Minute
 
 var _ = Describe("GarbageCollection", func() {
-	XIt("should delete an orphaned VM after its NodeClaim is force-removed", func(ctx SpecContext) {
+	It("should delete an orphaned VM after its NodeClaim is force-removed", func(ctx SpecContext) {
 		runGCTest(ctx, environment.TestCase{
 			CapacityType:  karpv1.CapacityTypeOnDemand,
 			Arch:          karpv1.ArchitectureAmd64,

--- a/test/suites/networking/networking_test.go
+++ b/test/suites/networking/networking_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 var _ = Describe("Networking", func() {
-	// Disabled until PR #229 (networkConfig / private nodes) is merged.
-	XIt("should provision a node with no external IP when enableExternalIPAccess is false", func(ctx SpecContext) {
+	It("should provision a node with no external IP when enableExternalIPAccess is false", func(ctx SpecContext) {
 		runPrivateNodeTest(ctx, environment.TestCase{
 			CapacityType:  karpv1.CapacityTypeOnDemand,
 			Arch:          karpv1.ArchitectureAmd64,


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Re-enables the GC and Networking e2e specs that were previously disabled with `XIt` while their prerequisite features were in flight. Both blocking PRs have since been merged:

- **GC** (`XIt` in `test/suites/gc/gc_test.go`): blocked on the GC controller — merged in #244
- **Networking** (`XIt` in `test/suites/networking/networking_test.go`): blocked on NetworkConfig / private nodes — merged in #229

This PR simply removes the `X` prefix from both specs so they participate in the regular e2e suite.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```