### PR TITLE
fix(instancetype): use GCP API architecture field instead of hardcoded ARM family list

### DIFF
--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -164,7 +164,7 @@ func computeRequirements(mt *computepb.MachineType, offerings cloudprovider.Offe
 		requirements.Get(v1alpha1.LabelInstanceFamily).Insert(instanceTypeParts[0])
 		requirements.Get(v1alpha1.LabelInstanceShape).Insert(instanceTypeParts[1])
 
-		requirements.Get(corev1.LabelArchStable).Insert(extractArch(instanceTypeParts[0]))
+		requirements.Get(corev1.LabelArchStable).Insert(machineTypeArch(mt))
 	}
 
 	return requirements
@@ -185,12 +185,15 @@ func extractGeneration(instanceTypePrefix string) string {
 	return string(instanceTypePrefix[len(instanceTypePrefix)-offset])
 }
 
-func extractArch(instanceTypePrefix string) string {
-	// referring to https://cloud.google.com/compute/docs/instances/arm-on-compute
-	if instanceTypePrefix == "a4x" || instanceTypePrefix == "c4a" || instanceTypePrefix == "t2a" {
+func machineTypeArch(mt *computepb.MachineType) string {
+	switch mt.GetArchitecture() {
+	case "ARM64":
 		return "arm64"
+	case "X86_64":
+		return "amd64"
+	default:
+		return "amd64"
 	}
-	return "amd64"
 }
 
 func computeCapacity(ctx context.Context, mt *computepb.MachineType, nodeClass *v1alpha1.GCENodeClass, totalStorageBytes int64) corev1.ResourceList {

--- a/pkg/providers/instancetype/types_test.go
+++ b/pkg/providers/instancetype/types_test.go
@@ -238,9 +238,10 @@ func TestComputeRequirements(t *testing.T) {
 		{
 			name: "ARM Instance (t2a-standard-1)",
 			mt: &computepb.MachineType{
-				Name:      aws.String("t2a-standard-1"),
-				GuestCpus: aws.Int32(1),
-				MemoryMb:  aws.Int32(4096),
+				Name:         aws.String("t2a-standard-1"),
+				GuestCpus:    aws.Int32(1),
+				MemoryMb:     aws.Int32(4096),
+				Architecture: aws.String("ARM64"),
 			},
 			offerings: cloudprovider.Offerings{
 				{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`extractArch` maintained a hardcoded whitelist of ARM machine family prefixes (`a4x`, `c4a`, `t2a`). This caused new ARM families — such as `n4a` (Google Axion, GA January 2026) — to be silently misclassified as `amd64`, breaking ARM NodePool scheduling.

The `computepb.MachineType` struct returned by the existing `AggregatedListMachineTypesRequest` already includes an `Architecture` field (`"ARM64"` / `"X86_64"`). This PR replaces `extractArch` with `machineTypeArch(mt)` that reads this field directly, so any current and future ARM families are recognized automatically without code changes.

#### Which issue(s) this PR fixes:

Fixes #258

#### Special notes for your reviewer:

- No new API calls — `Architecture` is already populated in the `MachineType` response we fetch today.
- Unknown/empty architecture values fall through to `"amd64"` for safe backward compatibility.
- The `t2a-standard-1` unit test fixture now sets `Architecture: "ARM64"` to exercise the new code path correctly.
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

#### Does this PR introduce a user-facing change?

```release-note
Fixed ARM64 instance families (e.g. n4a) being incorrectly classified as amd64. Architecture is now sourced directly from the GCP Compute API instead of a hardcoded allowlist.
```