### PR TITLE
feat(cloudprovider): implement GKE-correct RepairPolicies and NodeRepair feature gate

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -77,7 +77,9 @@ helm install karpenter karpenter-gcp/karpenter \
 | controller.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution[0].topologyKey | string | `"kubernetes.io/hostname"` |  |
 | controller.env | list | `[]` |  |
 | controller.featureGates.nodeOverlay | bool | `false` | nodeOverlay is ALPHA and is disabled by default. Setting this will allow the use of node overlay to impact scheduling decisions |
+| controller.featureGates.nodeRepair | bool | `false` | nodeRepair is ALPHA and is disabled by default. When enabled, Karpenter replaces nodes that fail GKE Node Problem Detector health conditions. |
 | controller.featureGates.spotToSpotConsolidation | bool | `true` |  |
+| controller.featureGates.staticCapacity | bool | `false` | staticCapacity is ALPHA and is disabled by default. When enabled, a NodePool with spec.replicas set maintains a fixed number of nodes regardless of pod demand (static node pool). consolidationPolicy and consolidateAfter are ignored on static NodePools. |
 | controller.healthProbe.port | int | `8081` |  |
 | controller.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controller.image.repository | string | `"public.ecr.aws/cloudpilotai/gcp/karpenter"` |  |

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
                   divisor: "0"
                   resource: limits.memory
             - name: FEATURE_GATES
-              value: "SpotToSpotConsolidation={{ .Values.controller.featureGates.spotToSpotConsolidation }},NodeOverlay={{ .Values.controller.featureGates.nodeOverlay }},StaticCapacity={{ .Values.controller.featureGates.staticCapacity }}"
+              value: "SpotToSpotConsolidation={{ .Values.controller.featureGates.spotToSpotConsolidation }},NodeOverlay={{ .Values.controller.featureGates.nodeOverlay }},StaticCapacity={{ .Values.controller.featureGates.staticCapacity }},NodeRepair={{ .Values.controller.featureGates.nodeRepair }}"
             {{- with .Values.controller.settings.batchMaxDuration }}
             - name: BATCH_MAX_DURATION
               value: "{{ . }}"

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -66,6 +66,9 @@ controller:
     # regardless of pod demand (static node pool). consolidationPolicy and consolidateAfter
     # are ignored on static NodePools.
     staticCapacity: false
+    # -- nodeRepair is ALPHA and is disabled by default.
+    # When enabled, Karpenter replaces nodes that fail GKE Node Problem Detector health conditions.
+    nodeRepair: false
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/hack/e2e-deploy.sh
+++ b/hack/e2e-deploy.sh
@@ -55,6 +55,7 @@ helm upgrade --install karpenter "${REPO_ROOT}/charts/karpenter" \
   --set controller.settings.clusterLocation="${E2E_LOCATION}" \
   --set controller.settings.interruptionQueue="${CLUSTER_NAME}" \
   --set controller.featureGates.spotToSpotConsolidation=true \
+  --set controller.featureGates.nodeRepair=true \
   --set "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account=${GSA_EMAIL}" \
   --set controller.replicaCount=1 \
   --set credentials.enabled=false \

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -252,44 +252,52 @@ func (c *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeCla
 	return c.isNodeClassDrifted(ctx, nodeClaim, nodePool, nodeClass), nil
 }
 
+// RepairPolicies returns the node health conditions that trigger node replacement.
+// Polarity on GKE differs by source:
+//   - kubelet conditions (NodeReady, etc.): False/Unknown = problem
+//   - Node Problem Detector conditions (KernelDeadlock, etc.): True = problem
 func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
 	return []cloudprovider.RepairPolicy{
-		// Supported Kubelet Node Conditions
+		// Standard Kubernetes kubelet conditions.
+		// NodeReady=False/Unknown covers the broadest failure mode: an unresponsive kubelet.
+		// GKE nodes boot in ~2 min; 10 min matches Azure managed K8s and avoids 15× boot-time waits.
 		{
 			ConditionType:      corev1.NodeReady,
-			ConditionStatus:    corev1.ConditionFalse,
-			TolerationDuration: 30 * time.Minute,
-		},
-		{
-			ConditionType:      corev1.NodeReady,
-			ConditionStatus:    corev1.ConditionUnknown,
-			TolerationDuration: 30 * time.Minute,
-		},
-		// Support Node Monitoring Agent Conditions
-		//
-		{
-			ConditionType:      "AcceleratedHardwareReady",
 			ConditionStatus:    corev1.ConditionFalse,
 			TolerationDuration: 10 * time.Minute,
 		},
 		{
-			ConditionType:      "StorageReady",
-			ConditionStatus:    corev1.ConditionFalse,
+			ConditionType:      corev1.NodeReady,
+			ConditionStatus:    corev1.ConditionUnknown,
+			TolerationDuration: 10 * time.Minute,
+		},
+		// GKE Node Problem Detector — kernel-monitor conditions (enabled by default on all node pools).
+		// KernelDeadlock and ReadonlyFilesystem are unrecoverable OS failures; short toleration
+		// avoids keeping a broken node alive longer than necessary.
+		// Note: NPD owns these conditions, not the kubelet. The kubelet will not reset them between
+		// heartbeats, so a patch setting KernelDeadlock=True is stable until NPD clears it.
+		{
+			ConditionType:      "KernelDeadlock",
+			ConditionStatus:    corev1.ConditionTrue,
+			TolerationDuration: 5 * time.Minute,
+		},
+		{
+			ConditionType:      "ReadonlyFilesystem",
+			ConditionStatus:    corev1.ConditionTrue,
+			TolerationDuration: 5 * time.Minute,
+		},
+		// GKE Node Problem Detector — restart-monitor conditions. Longer toleration
+		// lets transient restarts self-heal before triggering replacement.
+		// FrequentDockerRestart is intentionally omitted: GKE node pools use containerd
+		// since GKE 1.24 and Docker is no longer shipped on standard node images.
+		{
+			ConditionType:      "FrequentKubeletRestart",
+			ConditionStatus:    corev1.ConditionTrue,
 			TolerationDuration: 30 * time.Minute,
 		},
 		{
-			ConditionType:      "NetworkingReady",
-			ConditionStatus:    corev1.ConditionFalse,
-			TolerationDuration: 30 * time.Minute,
-		},
-		{
-			ConditionType:      "KernelReady",
-			ConditionStatus:    corev1.ConditionFalse,
-			TolerationDuration: 30 * time.Minute,
-		},
-		{
-			ConditionType:      "ContainerRuntimeReady",
-			ConditionStatus:    corev1.ConditionFalse,
+			ConditionType:      "FrequentContainerdRestart",
+			ConditionStatus:    corev1.ConditionTrue,
 			TolerationDuration: 30 * time.Minute,
 		},
 	}

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -258,9 +258,7 @@ func (c *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeCla
 //   - Node Problem Detector conditions (KernelDeadlock, etc.): True = problem
 func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
 	return []cloudprovider.RepairPolicy{
-		// Standard Kubernetes kubelet conditions.
-		// NodeReady=False/Unknown covers the broadest failure mode: an unresponsive kubelet.
-		// GKE nodes boot in ~2 min; 10 min matches Azure managed K8s and avoids 15× boot-time waits.
+		// Standard kubelet conditions — NodeReady=False/Unknown means the node is unresponsive.
 		{
 			ConditionType:      corev1.NodeReady,
 			ConditionStatus:    corev1.ConditionFalse,
@@ -272,10 +270,7 @@ func (c *CloudProvider) RepairPolicies() []cloudprovider.RepairPolicy {
 			TolerationDuration: 10 * time.Minute,
 		},
 		// GKE Node Problem Detector — kernel-monitor conditions (enabled by default on all node pools).
-		// KernelDeadlock and ReadonlyFilesystem are unrecoverable OS failures; short toleration
-		// avoids keeping a broken node alive longer than necessary.
-		// Note: NPD owns these conditions, not the kubelet. The kubelet will not reset them between
-		// heartbeats, so a patch setting KernelDeadlock=True is stable until NPD clears it.
+		// KernelDeadlock and ReadonlyFilesystem are unrecoverable OS failures.
 		{
 			ConditionType:      "KernelDeadlock",
 			ConditionStatus:    corev1.ConditionTrue,

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instance"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
@@ -61,4 +63,105 @@ func TestInstanceToNodeClaim_AbsentClusterLocationLabelNotInvented(t *testing.T)
 	_, hasLabel := nc.Labels[utils.LabelClusterLocationKey]
 	require.False(t, hasLabel,
 		"NodeClaim built from a label-less instance must not carry cluster-location; GC skip depends on its absence")
+}
+
+func TestRepairPolicies_NonEmpty(t *testing.T) {
+	t.Parallel()
+	policies := (&CloudProvider{}).RepairPolicies()
+	require.NotEmpty(t, policies, "RepairPolicies must return at least one policy")
+}
+
+func TestRepairPolicies_NoDuplicates(t *testing.T) {
+	t.Parallel()
+	policies := (&CloudProvider{}).RepairPolicies()
+	seen := map[string]bool{}
+	for _, p := range policies {
+		key := string(p.ConditionType) + "/" + string(p.ConditionStatus)
+		require.False(t, seen[key], "duplicate repair policy for condition %s/%s", p.ConditionType, p.ConditionStatus)
+		seen[key] = true
+	}
+}
+
+func TestRepairPolicies_PositiveTolerationDuration(t *testing.T) {
+	t.Parallel()
+	for _, p := range (&CloudProvider{}).RepairPolicies() {
+		require.Greater(t, p.TolerationDuration, time.Duration(0),
+			"TolerationDuration for condition %s must be positive", p.ConditionType)
+	}
+}
+
+func TestRepairPolicies_ContainsNodeReady(t *testing.T) {
+	t.Parallel()
+	policies := (&CloudProvider{}).RepairPolicies()
+	contains := func(status corev1.ConditionStatus) bool {
+		for _, p := range policies {
+			if p.ConditionType == corev1.NodeReady && p.ConditionStatus == status {
+				return true
+			}
+		}
+		return false
+	}
+	require.True(t, contains(corev1.ConditionFalse), "must have NodeReady=False repair policy")
+	require.True(t, contains(corev1.ConditionUnknown), "must have NodeReady=Unknown repair policy")
+}
+
+func TestRepairPolicies_ContainsGKENPDConditions(t *testing.T) {
+	t.Parallel()
+	// GKE runs Node Problem Detector by default. These conditions use True=problem polarity.
+	expectedNPD := []string{
+		"KernelDeadlock",
+		"ReadonlyFilesystem",
+		"FrequentKubeletRestart",
+		"FrequentContainerdRestart",
+	}
+	policies := (&CloudProvider{}).RepairPolicies()
+	conditionSet := map[corev1.NodeConditionType]cloudprovider.RepairPolicy{}
+	for _, p := range policies {
+		conditionSet[p.ConditionType] = p
+	}
+	for _, name := range expectedNPD {
+		p, ok := conditionSet[corev1.NodeConditionType(name)]
+		require.True(t, ok, "must have repair policy for GKE NPD condition %s", name)
+		require.Equal(t, corev1.ConditionTrue, p.ConditionStatus,
+			"GKE NPD condition %s uses True=problem polarity", name)
+	}
+}
+
+func TestRepairPolicies_NPDConditionsRequireTrue(t *testing.T) {
+	t.Parallel()
+	// NPD conditions use True=problem polarity. A node without NPD running will never have
+	// these conditions set (they simply don't exist in node.status.conditions), so the
+	// node.health controller will never match them — no false-positive replacements occur
+	// when NPD is disabled or absent.
+	npdConditions := map[corev1.NodeConditionType]bool{
+		"KernelDeadlock":            true,
+		"ReadonlyFilesystem":        true,
+		"FrequentKubeletRestart":    true,
+		"FrequentContainerdRestart": true,
+	}
+	for _, p := range (&CloudProvider{}).RepairPolicies() {
+		if npdConditions[p.ConditionType] {
+			require.Equal(t, corev1.ConditionTrue, p.ConditionStatus,
+				"NPD condition %s must require ConditionTrue; ConditionFalse would fire on nodes without NPD since absent conditions default to False", p.ConditionType)
+		}
+	}
+}
+
+func TestRepairPolicies_NoAWSConditions(t *testing.T) {
+	t.Parallel()
+	// These are AWS EKS Node Monitoring Agent conditions that do not exist on GKE.
+	awsOnlyConditions := []corev1.NodeConditionType{
+		"AcceleratedHardwareReady",
+		"StorageReady",
+		"NetworkingReady",
+		"KernelReady",
+		"ContainerRuntimeReady",
+	}
+	policies := (&CloudProvider{}).RepairPolicies()
+	for _, p := range policies {
+		for _, aws := range awsOnlyConditions {
+			require.NotEqual(t, aws, p.ConditionType,
+				"condition %s is an AWS EKS condition and must not be used on GKE", aws)
+		}
+	}
 }

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -65,23 +65,6 @@ func TestInstanceToNodeClaim_AbsentClusterLocationLabelNotInvented(t *testing.T)
 		"NodeClaim built from a label-less instance must not carry cluster-location; GC skip depends on its absence")
 }
 
-func TestRepairPolicies_NonEmpty(t *testing.T) {
-	t.Parallel()
-	policies := (&CloudProvider{}).RepairPolicies()
-	require.NotEmpty(t, policies, "RepairPolicies must return at least one policy")
-}
-
-func TestRepairPolicies_NoDuplicates(t *testing.T) {
-	t.Parallel()
-	policies := (&CloudProvider{}).RepairPolicies()
-	seen := map[string]bool{}
-	for _, p := range policies {
-		key := string(p.ConditionType) + "/" + string(p.ConditionStatus)
-		require.False(t, seen[key], "duplicate repair policy for condition %s/%s", p.ConditionType, p.ConditionStatus)
-		seen[key] = true
-	}
-}
-
 func TestRepairPolicies_PositiveTolerationDuration(t *testing.T) {
 	t.Parallel()
 	for _, p := range (&CloudProvider{}).RepairPolicies() {
@@ -142,25 +125,6 @@ func TestRepairPolicies_NPDConditionsRequireTrue(t *testing.T) {
 		if npdConditions[p.ConditionType] {
 			require.Equal(t, corev1.ConditionTrue, p.ConditionStatus,
 				"NPD condition %s must require ConditionTrue; ConditionFalse would fire on nodes without NPD since absent conditions default to False", p.ConditionType)
-		}
-	}
-}
-
-func TestRepairPolicies_NoAWSConditions(t *testing.T) {
-	t.Parallel()
-	// These are AWS EKS Node Monitoring Agent conditions that do not exist on GKE.
-	awsOnlyConditions := []corev1.NodeConditionType{
-		"AcceleratedHardwareReady",
-		"StorageReady",
-		"NetworkingReady",
-		"KernelReady",
-		"ContainerRuntimeReady",
-	}
-	policies := (&CloudProvider{}).RepairPolicies()
-	for _, p := range policies {
-		for _, aws := range awsOnlyConditions {
-			require.NotEqual(t, aws, p.ConditionType,
-				"condition %s is an AWS EKS condition and must not be used on GKE", aws)
 		}
 	}
 }

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -92,17 +92,16 @@ func TestRepairPolicies_PositiveTolerationDuration(t *testing.T) {
 
 func TestRepairPolicies_ContainsNodeReady(t *testing.T) {
 	t.Parallel()
-	policies := (&CloudProvider{}).RepairPolicies()
-	contains := func(status corev1.ConditionStatus) bool {
-		for _, p := range policies {
-			if p.ConditionType == corev1.NodeReady && p.ConditionStatus == status {
-				return true
-			}
+	var hasReadyFalse, hasReadyUnknown bool
+	for _, p := range (&CloudProvider{}).RepairPolicies() {
+		if p.ConditionType != corev1.NodeReady {
+			continue
 		}
-		return false
+		hasReadyFalse = hasReadyFalse || p.ConditionStatus == corev1.ConditionFalse
+		hasReadyUnknown = hasReadyUnknown || p.ConditionStatus == corev1.ConditionUnknown
 	}
-	require.True(t, contains(corev1.ConditionFalse), "must have NodeReady=False repair policy")
-	require.True(t, contains(corev1.ConditionUnknown), "must have NodeReady=Unknown repair policy")
+	require.True(t, hasReadyFalse, "must have NodeReady=False repair policy")
+	require.True(t, hasReadyUnknown, "must have NodeReady=Unknown repair policy")
 }
 
 func TestRepairPolicies_ContainsGKENPDConditions(t *testing.T) {

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instance"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
@@ -65,56 +64,11 @@ func TestInstanceToNodeClaim_AbsentClusterLocationLabelNotInvented(t *testing.T)
 		"NodeClaim built from a label-less instance must not carry cluster-location; GC skip depends on its absence")
 }
 
-func TestRepairPolicies_PositiveTolerationDuration(t *testing.T) {
+func TestRepairPolicies_NPDConditionsPolarity(t *testing.T) {
 	t.Parallel()
-	for _, p := range (&CloudProvider{}).RepairPolicies() {
-		require.Greater(t, p.TolerationDuration, time.Duration(0),
-			"TolerationDuration for condition %s must be positive", p.ConditionType)
-	}
-}
-
-func TestRepairPolicies_ContainsNodeReady(t *testing.T) {
-	t.Parallel()
-	var hasReadyFalse, hasReadyUnknown bool
-	for _, p := range (&CloudProvider{}).RepairPolicies() {
-		if p.ConditionType != corev1.NodeReady {
-			continue
-		}
-		hasReadyFalse = hasReadyFalse || p.ConditionStatus == corev1.ConditionFalse
-		hasReadyUnknown = hasReadyUnknown || p.ConditionStatus == corev1.ConditionUnknown
-	}
-	require.True(t, hasReadyFalse, "must have NodeReady=False repair policy")
-	require.True(t, hasReadyUnknown, "must have NodeReady=Unknown repair policy")
-}
-
-func TestRepairPolicies_ContainsGKENPDConditions(t *testing.T) {
-	t.Parallel()
-	// GKE runs Node Problem Detector by default. These conditions use True=problem polarity.
-	expectedNPD := []string{
-		"KernelDeadlock",
-		"ReadonlyFilesystem",
-		"FrequentKubeletRestart",
-		"FrequentContainerdRestart",
-	}
-	policies := (&CloudProvider{}).RepairPolicies()
-	conditionSet := map[corev1.NodeConditionType]cloudprovider.RepairPolicy{}
-	for _, p := range policies {
-		conditionSet[p.ConditionType] = p
-	}
-	for _, name := range expectedNPD {
-		p, ok := conditionSet[corev1.NodeConditionType(name)]
-		require.True(t, ok, "must have repair policy for GKE NPD condition %s", name)
-		require.Equal(t, corev1.ConditionTrue, p.ConditionStatus,
-			"GKE NPD condition %s uses True=problem polarity", name)
-	}
-}
-
-func TestRepairPolicies_NPDConditionsRequireTrue(t *testing.T) {
-	t.Parallel()
-	// NPD conditions use True=problem polarity. A node without NPD running will never have
-	// these conditions set (they simply don't exist in node.status.conditions), so the
-	// node.health controller will never match them — no false-positive replacements occur
-	// when NPD is disabled or absent.
+	// GKE Node Problem Detector conditions use True=problem polarity (opposite of NodeReady).
+	// ConditionFalse must never be used here: absent conditions default to False in the
+	// Kubernetes API, so a False-triggered policy would fire on every node that lacks NPD.
 	npdConditions := map[corev1.NodeConditionType]bool{
 		"KernelDeadlock":            true,
 		"ReadonlyFilesystem":        true,
@@ -124,7 +78,7 @@ func TestRepairPolicies_NPDConditionsRequireTrue(t *testing.T) {
 	for _, p := range (&CloudProvider{}).RepairPolicies() {
 		if npdConditions[p.ConditionType] {
 			require.Equal(t, corev1.ConditionTrue, p.ConditionStatus,
-				"NPD condition %s must require ConditionTrue; ConditionFalse would fire on nodes without NPD since absent conditions default to False", p.ConditionType)
+				"NPD condition %s must use ConditionTrue polarity", p.ConditionType)
 		}
 	}
 }

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -67,8 +67,8 @@ func TestInstanceToNodeClaim_AbsentClusterLocationLabelNotInvented(t *testing.T)
 func TestRepairPolicies_NPDConditionsPolarity(t *testing.T) {
 	t.Parallel()
 	// GKE Node Problem Detector conditions use True=problem polarity (opposite of NodeReady).
-	// ConditionFalse must never be used here: absent conditions default to False in the
-	// Kubernetes API, so a False-triggered policy would fire on every node that lacks NPD.
+	// NPD sets a condition to True when a problem is detected and omits it otherwise.
+	// ConditionFalse would never match and ConditionTrue must be used to trigger repair.
 	npdConditions := map[corev1.NodeConditionType]bool{
 		"KernelDeadlock":            true,
 		"ReadonlyFilesystem":        true,

--- a/test/pkg/environment/helpers.go
+++ b/test/pkg/environment/helpers.go
@@ -62,6 +62,7 @@ type TestCase struct {
 	// ImageFamily selects the OS image family for the NodeClass.
 	// Defaults to ContainerOptimizedOS when empty.
 	ImageFamily string
+	ConsolidationPolicy string // defaults to WhenEmptyOrUnderutilized when empty
 }
 
 // UniqueSuffix returns a 6-character random hex string safe for use in k8s names.
@@ -164,8 +165,12 @@ func (e *Environment) createNodePool(ctx context.Context, name, nodeClassName st
 	requirements := []any{
 		map[string]any{"key": karpv1.CapacityTypeLabelKey, "operator": "In", "values": []any{tc.CapacityType}},
 		map[string]any{"key": gcpv1alpha1.LabelInstanceFamily, "operator": "In", "values": toAny(tc.Families)},
-		map[string]any{"key": corev1.LabelInstanceTypeStable, "operator": "In", "values": toAny(tc.InstanceTypes)},
 		map[string]any{"key": corev1.LabelArchStable, "operator": "In", "values": []any{tc.Arch}},
+	}
+	if len(tc.InstanceTypes) > 0 {
+		requirements = append(requirements, map[string]any{
+			"key": corev1.LabelInstanceTypeStable, "operator": "In", "values": toAny(tc.InstanceTypes),
+		})
 	}
 	templateSpec := map[string]any{
 		"nodeClassRef": map[string]any{
@@ -185,11 +190,14 @@ func (e *Environment) createNodePool(ctx context.Context, name, nodeClassName st
 	if expireAfter != "" {
 		templateSpec["expireAfter"] = expireAfter
 	}
-	// When expireAfter is set we use WhenEmpty rather than WhenEmptyOrUnderutilized
-	// so that node replacement is driven solely by expiration, not by concurrent
-	// utilization-based consolidation which would interfere with the test.
+	// Use WhenEmpty when: expireAfter is set (so expiration drives replacement, not
+	// consolidation), or the caller explicitly requests it (e.g. repair tests, where
+	// WhenEmptyOrUnderutilized could consolidate the node before the health toleration
+	// expires and mask whether the node.health controller actually fired).
 	consolidationPolicy := "WhenEmptyOrUnderutilized"
-	if expireAfter != "" {
+	if tc.ConsolidationPolicy != "" {
+		consolidationPolicy = tc.ConsolidationPolicy
+	} else if expireAfter != "" {
 		consolidationPolicy = "WhenEmpty"
 	}
 	deleteIfExists(ctx, e.DynamicClient, nodePoolGVR, name)

--- a/test/suites/repair/repair_test.go
+++ b/test/suites/repair/repair_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
+	gcpv1alpha1 "github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/test/pkg/environment"
 )
 
@@ -64,7 +65,7 @@ func runRepairTest(ctx context.Context, tc environment.TestCase) {
 		}
 	})
 
-	env.CreateNodeClass(ctx, name)
+	env.CreateNodeClass(ctx, name, gcpv1alpha1.ImageFamilyContainerOptimizedOS)
 	env.CreateNodePool(ctx, name, name, tc)
 	env.CreateDeployment(ctx, name, name, name, tc.Arch)
 

--- a/test/suites/repair/repair_test.go
+++ b/test/suites/repair/repair_test.go
@@ -72,11 +72,23 @@ func runRepairTest(ctx context.Context, tc environment.TestCase) {
 	Expect(firstPod.Spec.NodeName).NotTo(BeEmpty())
 	originalNodeName = firstPod.Spec.NodeName
 
-	// KernelDeadlock toleration is 5 minutes; the node.health controller then
-	// deletes the node and Karpenter provisions a replacement.
-	GinkgoWriter.Printf("patching KernelDeadlock=True on node %s\n", originalNodeName)
+	// Record the transition time once. GKE's embedded node monitoring periodically
+	// resets NPD-owned conditions (KernelDeadlock, etc.) to False. To prevent the
+	// node.health toleration clock from being reset each time GKE overwrites the
+	// condition, all re-patches must reuse the same transition time so that
+	// LastTransitionTime remains stable from the controller's perspective.
+	transitionTime := metav1.Now()
+
+	GinkgoWriter.Printf("patching KernelDeadlock=True on node %s (transitionTime=%s)\n",
+		originalNodeName, transitionTime.Format(time.RFC3339))
 	patchNodeCondition(ctx, env.KubeClient, originalNodeName,
-		"KernelDeadlock", corev1.ConditionTrue,
+		"KernelDeadlock", corev1.ConditionTrue, transitionTime,
+		"TestSimulation", "e2e repair test: simulated kernel deadlock")
+
+	// Hold the condition True against GKE's periodic resets. The goroutine
+	// exits when the context is cancelled (spec completion) or the node is gone.
+	holdNodeCondition(ctx, env.KubeClient, originalNodeName,
+		"KernelDeadlock", corev1.ConditionTrue, transitionTime,
 		"TestSimulation", "e2e repair test: simulated kernel deadlock")
 
 	replacementPod := env.WaitForPodOnDifferentNode(ctx, name, originalNodeName, nodeRepairTimeout)
@@ -88,26 +100,61 @@ func runRepairTest(ctx context.Context, tc environment.TestCase) {
 	originalNodeName = ""
 }
 
-// patchNodeCondition sets or upserts a node status condition to simulate an
-// unhealthy state without inducing actual OS failures on the GCE VM.
-// LastTransitionTime is set to now so the repair toleration starts immediately.
-// Retries on resourceVersion conflict — the kubelet updates node status every 10s.
-// NPD-owned conditions (KernelDeadlock, ReadonlyFilesystem, etc.) are not reset by
-// the kubelet between heartbeats, so the patched value remains stable until NPD clears it.
+// holdNodeCondition launches a background goroutine that re-patches the given
+// node condition every 30 s using the fixed transitionTime. GKE's embedded node
+// monitoring periodically overwrites NPD-owned conditions to False; this keeps
+// the condition stable so the node.health toleration clock runs from transitionTime.
+// The goroutine exits when ctx is done or the node no longer exists.
+// It is safe to call from a Ginkgo spec goroutine; no Gomega assertions are made
+// inside the goroutine.
+func holdNodeCondition(ctx context.Context, client kubernetes.Interface, nodeName string,
+	condType corev1.NodeConditionType, status corev1.ConditionStatus,
+	transitionTime metav1.Time, reason, message string) {
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				err := applyNodeCondition(ctx, client, nodeName, condType, status, transitionTime, reason, message)
+				if apierrors.IsNotFound(err) {
+					return
+				}
+				if err != nil && ctx.Err() == nil {
+					GinkgoWriter.Printf("holdNodeCondition: re-patch %s on %s: %v\n", condType, nodeName, err)
+				}
+			}
+		}
+	}()
+}
+
+// patchNodeCondition sets or upserts a node status condition, asserting success.
+// transitionTime must be supplied by the caller; reuse the same value for any
+// subsequent holdNodeCondition calls so the node.health toleration clock is not reset.
 func patchNodeCondition(ctx context.Context, client kubernetes.Interface, nodeName string,
 	condType corev1.NodeConditionType, status corev1.ConditionStatus,
-	reason, message string) {
-	err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+	transitionTime metav1.Time, reason, message string) {
+	err := applyNodeCondition(ctx, client, nodeName, condType, status, transitionTime, reason, message)
+	Expect(err).NotTo(HaveOccurred(), "patchNodeCondition: %s", nodeName)
+}
+
+// applyNodeCondition performs a single attempt to upsert the node status condition,
+// retrying on resourceVersion conflicts (the kubelet updates node status every 10 s).
+func applyNodeCondition(ctx context.Context, client kubernetes.Interface, nodeName string,
+	condType corev1.NodeConditionType, status corev1.ConditionStatus,
+	transitionTime metav1.Time, reason, message string) error {
+	return wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
 		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
-		now := metav1.Now()
 		newCond := corev1.NodeCondition{
 			Type:               condType,
 			Status:             status,
-			LastHeartbeatTime:  now,
-			LastTransitionTime: now,
+			LastHeartbeatTime:  metav1.Now(),
+			LastTransitionTime: transitionTime,
 			Reason:             reason,
 			Message:            message,
 		}
@@ -128,5 +175,4 @@ func patchNodeCondition(ctx context.Context, client kubernetes.Interface, nodeNa
 		}
 		return err == nil, err
 	})
-	Expect(err).NotTo(HaveOccurred(), "patchNodeCondition: %s", nodeName)
 }

--- a/test/suites/repair/repair_test.go
+++ b/test/suites/repair/repair_test.go
@@ -84,7 +84,7 @@ func runRepairTest(ctx context.Context, tc environment.TestCase) {
 		"TestSimulation", "e2e repair test: simulated kernel deadlock")
 
 	// Hold the condition True against GKE's periodic resets. The goroutine
-	// exits when the context is cancelled (spec completion) or the node is gone.
+	// exits when the context is canceled (spec completion) or the node is gone.
 	holdNodeCondition(ctx, env.KubeClient, originalNodeName,
 		"KernelDeadlock", corev1.ConditionTrue, transitionTime,
 		"TestSimulation", "e2e repair test: simulated kernel deadlock")
@@ -100,7 +100,7 @@ func runRepairTest(ctx context.Context, tc environment.TestCase) {
 
 // holdNodeCondition re-patches the condition every 30 s with a fixed transitionTime.
 // GKE's embedded node monitoring periodically resets NPD conditions to False; this
-// keeps the condition alive until ctx is cancelled or the node is gone.
+// keeps the condition alive until ctx is canceled or the node is gone.
 func holdNodeCondition(ctx context.Context, client kubernetes.Interface, nodeName string,
 	condType corev1.NodeConditionType, status corev1.ConditionStatus,
 	transitionTime metav1.Time, reason, message string) {

--- a/test/suites/repair/repair_test.go
+++ b/test/suites/repair/repair_test.go
@@ -32,11 +32,9 @@ import (
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/test/pkg/environment"
 )
 
-// nodeRepairTimeout is the budget for node.health to detect the pre-expired
-// KernelDeadlock condition and provision a replacement. The condition is
-// back-dated by 6 minutes so karpenter fires within ~30 s of the patch; 3
-// minutes gives ample headroom for reconciliation lag and replacement
-// provisioning startup before WaitForPodOnDifferentNode takes over.
+// nodeRepairTimeout is the budget for node.health to detect the back-dated
+// KernelDeadlock condition and delete the NodeClaim. WaitForPodOnDifferentNode
+// then has the remaining ProvisioningTimeout to boot the replacement.
 const nodeRepairTimeout = 3 * time.Minute
 
 var _ = Describe("NodeRepair", func() {
@@ -74,15 +72,9 @@ func runRepairTest(ctx context.Context, tc environment.TestCase) {
 	Expect(firstPod.Spec.NodeName).NotTo(BeEmpty())
 	originalNodeName = firstPod.Spec.NodeName
 
-	// Back-date the transition time by 6 minutes — one minute past the 5-minute
-	// KernelDeadlock toleration. node.health computes terminationTime as
-	// LastTransitionTime + TolerationDuration; with a 6-minute-old transition the
-	// toleration is already expired and repair fires within one reconcile cycle
-	// (~10–30 s) rather than waiting 5 real minutes.
-	//
-	// The hold goroutine below reuses this fixed time on every re-patch so that
-	// GKE's embedded node monitoring cannot reset LastTransitionTime to a future
-	// value and restart the clock.
+	// Back-date by 6 min (1 min past the 5-min KernelDeadlock toleration) so
+	// node.health fires in ~30 s instead of waiting 5 real minutes.
+	// The hold goroutine reuses this fixed time so GKE can't reset the clock.
 	transitionTime := metav1.NewTime(time.Now().Add(-6 * time.Minute))
 
 	GinkgoWriter.Printf("patching KernelDeadlock=True on node %s (transitionTime=%s)\n",
@@ -106,13 +98,9 @@ func runRepairTest(ctx context.Context, tc environment.TestCase) {
 	originalNodeName = ""
 }
 
-// holdNodeCondition launches a background goroutine that re-patches the given
-// node condition every 30 s using the fixed transitionTime. GKE's embedded node
-// monitoring periodically overwrites NPD-owned conditions to False; this keeps
-// the condition stable so the node.health toleration clock runs from transitionTime.
-// The goroutine exits when ctx is done or the node no longer exists.
-// It is safe to call from a Ginkgo spec goroutine; no Gomega assertions are made
-// inside the goroutine.
+// holdNodeCondition re-patches the condition every 30 s with a fixed transitionTime.
+// GKE's embedded node monitoring periodically resets NPD conditions to False; this
+// keeps the condition alive until ctx is cancelled or the node is gone.
 func holdNodeCondition(ctx context.Context, client kubernetes.Interface, nodeName string,
 	condType corev1.NodeConditionType, status corev1.ConditionStatus,
 	transitionTime metav1.Time, reason, message string) {

--- a/test/suites/repair/repair_test.go
+++ b/test/suites/repair/repair_test.go
@@ -89,7 +89,7 @@ func runRepairTest(ctx context.Context, tc environment.TestCase) {
 		"KernelDeadlock", corev1.ConditionTrue, transitionTime,
 		"TestSimulation", "e2e repair test: simulated kernel deadlock")
 
-	replacementPod := env.WaitForPodOnDifferentNode(ctx, name, originalNodeName, nodeRepairTimeout)
+	replacementPod := env.WaitForPodOnDifferentNode(ctx, name, originalNodeName, environment.ProvisioningTimeout)
 	Expect(replacementPod.Spec.NodeName).NotTo(Equal(originalNodeName),
 		"pod must move to a replacement node after KernelDeadlock repair")
 

--- a/test/suites/repair/repair_test.go
+++ b/test/suites/repair/repair_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2025 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repair_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/test/pkg/environment"
+)
+
+// nodeRepairTimeout covers the KernelDeadlock toleration window (5m) plus
+// controller reconciliation lag and new node provisioning time. 15m gives
+// headroom while keeping SpecTimeout at 25m — within the 30m go test budget.
+const nodeRepairTimeout = 15 * time.Minute
+
+var _ = Describe("NodeRepair", func() {
+	It("should replace a node whose KernelDeadlock condition has been True beyond the toleration",
+		func(ctx SpecContext) {
+			runRepairTest(ctx, environment.TestCase{
+				CapacityType:        karpv1.CapacityTypeOnDemand,
+				Arch:                karpv1.ArchitectureAmd64,
+				Families:            []string{"n2"},
+				ConsolidationPolicy: "WhenEmpty",
+			})
+		}, SpecTimeout(nodeRepairTimeout+environment.ProvisioningTimeout))
+})
+
+func runRepairTest(ctx context.Context, tc environment.TestCase) {
+	prefix := environment.TestPrefix(tc.Arch, tc.CapacityType, "repair")
+	suffix := environment.UniqueSuffix()
+	name := prefix + "-" + suffix
+
+	var originalNodeName string
+	DeferCleanup(func(ctx context.Context) {
+		env.DeleteDeployment(ctx, name)
+		env.DeleteNodePool(ctx, name)
+		env.DeleteNodeClass(ctx, name)
+		if originalNodeName != "" {
+			_ = env.WaitForNodeRemoval(ctx, originalNodeName)
+		}
+	})
+
+	env.CreateNodeClass(ctx, name)
+	env.CreateNodePool(ctx, name, name, tc)
+	env.CreateDeployment(ctx, name, name, name, tc.Arch)
+
+	firstPod := env.WaitForRunningPod(ctx, name)
+	Expect(firstPod.Spec.NodeName).NotTo(BeEmpty())
+	originalNodeName = firstPod.Spec.NodeName
+
+	// KernelDeadlock toleration is 5 minutes; the node.health controller then
+	// deletes the node and Karpenter provisions a replacement.
+	GinkgoWriter.Printf("patching KernelDeadlock=True on node %s\n", originalNodeName)
+	patchNodeCondition(ctx, env.KubeClient, originalNodeName,
+		"KernelDeadlock", corev1.ConditionTrue,
+		"TestSimulation", "e2e repair test: simulated kernel deadlock")
+
+	replacementPod := env.WaitForPodOnDifferentNode(ctx, name, originalNodeName, nodeRepairTimeout)
+	Expect(replacementPod.Spec.NodeName).NotTo(Equal(originalNodeName),
+		"pod must move to a replacement node after KernelDeadlock repair")
+
+	Expect(env.WaitForNodeRemoval(ctx, originalNodeName)).To(Succeed(),
+		"original node %s must be deleted after KernelDeadlock repair", originalNodeName)
+	originalNodeName = ""
+}
+
+// patchNodeCondition sets or upserts a node status condition to simulate an
+// unhealthy state without inducing actual OS failures on the GCE VM.
+// LastTransitionTime is set to now so the repair toleration starts immediately.
+// Retries on resourceVersion conflict — the kubelet updates node status every 10s.
+// NPD-owned conditions (KernelDeadlock, ReadonlyFilesystem, etc.) are not reset by
+// the kubelet between heartbeats, so the patched value remains stable until NPD clears it.
+func patchNodeCondition(ctx context.Context, client kubernetes.Interface, nodeName string,
+	condType corev1.NodeConditionType, status corev1.ConditionStatus,
+	reason, message string) {
+	err := wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (bool, error) {
+		node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		now := metav1.Now()
+		newCond := corev1.NodeCondition{
+			Type:               condType,
+			Status:             status,
+			LastHeartbeatTime:  now,
+			LastTransitionTime: now,
+			Reason:             reason,
+			Message:            message,
+		}
+		found := false
+		for i, c := range node.Status.Conditions {
+			if c.Type == condType {
+				node.Status.Conditions[i] = newCond
+				found = true
+				break
+			}
+		}
+		if !found {
+			node.Status.Conditions = append(node.Status.Conditions, newCond)
+		}
+		_, err = client.CoreV1().Nodes().UpdateStatus(ctx, node, metav1.UpdateOptions{})
+		if apierrors.IsConflict(err) {
+			return false, nil
+		}
+		return err == nil, err
+	})
+	Expect(err).NotTo(HaveOccurred(), "patchNodeCondition: %s", nodeName)
+}

--- a/test/suites/repair/repair_test.go
+++ b/test/suites/repair/repair_test.go
@@ -32,10 +32,12 @@ import (
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/test/pkg/environment"
 )
 
-// nodeRepairTimeout covers the KernelDeadlock toleration window (5m) plus
-// controller reconciliation lag and new node provisioning time. 15m gives
-// headroom while keeping SpecTimeout at 25m — within the 30m go test budget.
-const nodeRepairTimeout = 15 * time.Minute
+// nodeRepairTimeout is the budget for node.health to detect the pre-expired
+// KernelDeadlock condition and provision a replacement. The condition is
+// back-dated by 6 minutes so karpenter fires within ~30 s of the patch; 3
+// minutes gives ample headroom for reconciliation lag and replacement
+// provisioning startup before WaitForPodOnDifferentNode takes over.
+const nodeRepairTimeout = 3 * time.Minute
 
 var _ = Describe("NodeRepair", func() {
 	It("should replace a node whose KernelDeadlock condition has been True beyond the toleration",
@@ -72,12 +74,16 @@ func runRepairTest(ctx context.Context, tc environment.TestCase) {
 	Expect(firstPod.Spec.NodeName).NotTo(BeEmpty())
 	originalNodeName = firstPod.Spec.NodeName
 
-	// Record the transition time once. GKE's embedded node monitoring periodically
-	// resets NPD-owned conditions (KernelDeadlock, etc.) to False. To prevent the
-	// node.health toleration clock from being reset each time GKE overwrites the
-	// condition, all re-patches must reuse the same transition time so that
-	// LastTransitionTime remains stable from the controller's perspective.
-	transitionTime := metav1.Now()
+	// Back-date the transition time by 6 minutes — one minute past the 5-minute
+	// KernelDeadlock toleration. node.health computes terminationTime as
+	// LastTransitionTime + TolerationDuration; with a 6-minute-old transition the
+	// toleration is already expired and repair fires within one reconcile cycle
+	// (~10–30 s) rather than waiting 5 real minutes.
+	//
+	// The hold goroutine below reuses this fixed time on every re-patch so that
+	// GKE's embedded node monitoring cannot reset LastTransitionTime to a future
+	// value and restart the clock.
+	transitionTime := metav1.NewTime(time.Now().Add(-6 * time.Minute))
 
 	GinkgoWriter.Printf("patching KernelDeadlock=True on node %s (transitionTime=%s)\n",
 		originalNodeName, transitionTime.Format(time.RFC3339))

--- a/test/suites/repair/suite_test.go
+++ b/test/suites/repair/suite_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package repair_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/test/pkg/environment"
+)
+
+var env *environment.Environment
+
+func TestRepair(t *testing.T) {
+	RegisterFailHandler(Fail)
+	BeforeSuite(func() {
+		env = environment.NewEnvironment()
+		requireNodeRepairEnabled()
+	})
+	AfterSuite(func() {
+		if env != nil {
+			env.Cleanup()
+		}
+	})
+	RunSpecs(t, "Repair Suite")
+}
+
+// requireNodeRepairEnabled fails the suite immediately if the NodeRepair feature gate is not
+// enabled in the running karpenter deployment. This avoids spending 25m waiting for a repair
+// that will never happen when the gate is off or the deployment is misconfigured.
+func requireNodeRepairEnabled() {
+	dep, err := env.KubeClient.AppsV1().Deployments(environment.KarpenterNamespace).
+		Get(context.Background(), environment.KarpenterDeployment, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to get karpenter deployment")
+	for _, c := range dep.Spec.Template.Spec.Containers {
+		for _, e := range c.Env {
+			if e.Name == "FEATURE_GATES" {
+				Expect(strings.Contains(e.Value, "NodeRepair=true")).To(BeTrue(),
+					"NodeRepair=true must be set in FEATURE_GATES; got %q — redeploy with --set controller.featureGates.nodeRepair=true", e.Value)
+				return
+			}
+		}
+	}
+	Fail("FEATURE_GATES env var not found in karpenter deployment — is the controller deployed?")
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind cleanup

#### What this PR does / why we need it:
- Exposes the `NodeRepair` feature gate in Helm
- Replaces AWS copypasted repair conditions with correct GKE conditions
- Adds e2e suite to test repair

**Repair policy correction:**

The previous `RepairPolicies()` contained 5 conditions from the AWS provider (`AcceleratedHardwareReady`, `StorageReady`, `NetworkingReady`, `KernelReady`, `ContainerRuntimeReady`). These are [AWS EKS Node Monitoring Agent](https://github.com/aws/eks-node-monitoring-agent) conditions that are never set on GKE nodes — dead code.

Replaced with the correct GKE conditions from [Node Problem Detector](https://github.com/kubernetes/node-problem-detector), which runs by default on all GKE node pools:

| Condition | Status | Toleration | Source |
|---|---|---|---|
| `NodeReady` | `False` | 10m | Standard kubelet |
| `NodeReady` | `Unknown` | 10m | Standard kubelet |
| `KernelDeadlock` | `True` | 5m | GKE NPD (kernel-monitor) |
| `ReadonlyFilesystem` | `True` | 5m | GKE NPD (kernel-monitor) |
| `FrequentKubeletRestart` | `True` | 30m | GKE NPD (kernel-monitor) |
| `FrequentContainerdRestart` | `True` | 30m | GKE NPD (kernel-monitor) |

NodeReady toleration reduced 30m → 10m: GKE nodes boot in ~2 min (other Karpenter providers, for example Azure also have this timeout)

#### Which issue(s) this PR fixes:

Fixes N/A

#### Special notes for your reviewer:

- The 5 removed conditions were AWS EKS-specific and never triggered on GKE — confirmed by the [AWS NMA repo](https://github.com/aws/eks-node-monitoring-agent). Removing them is a correctness fix.
- NodProblemDetector conditions use `True = problem` polarity (opposite of `NodeReady`). Unit tests verify this explicitly.
- `NodeRepair` feature gate is `false` by default in production; no nodes are affected without explicit opt-in.
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

#### Does this PR introduce a user-facing change?

```release-note
Added NodeRepair feature gate to Helm values.yaml (default: false).
Corrected node repair policies to use GKE Node Problem Detector conditions (KernelDeadlock, ReadonlyFilesystem, FrequentKubeletRestart, FrequentContainerdRestart) instead of AWS EKS conditions that do not exist on GKE. Reduced NodeReady toleration from 30m to 10m. 
```