### PR TITLE
fix(instance): retry transient 503s in operation poll to prevent double-insertion

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -124,6 +124,14 @@ func (p *DefaultProvider) waitOperationDone(ctx context.Context,
 			if waitCtx.Err() != nil {
 				return fmt.Errorf("waiting for operation %s: %w", operationName, waitCtx.Err())
 			}
+			if isTransientError(err) {
+				log.FromContext(ctx).V(1).Info("transient error polling operation, retrying",
+					"operation", operationName, "zone", zone, "error", err)
+				if tickErr := waitForNextTick(waitCtx, ticker); tickErr != nil {
+					return fmt.Errorf("waiting for operation %s: %w", operationName, tickErr)
+				}
+				continue
+			}
 			return fmt.Errorf("getting operation: %w", err)
 		}
 
@@ -167,6 +175,14 @@ func (p *DefaultProvider) handleZoneOperationError(ctx context.Context, op *comp
 		return e.Message
 	})
 	return fmt.Errorf("operation failed: %s", strings.Join(errorMsgs, "; "))
+}
+
+func isTransientError(err error) bool {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		return apiErr.Code >= 500
+	}
+	return false
 }
 
 func isInsufficientCapacityError(operationError *compute.OperationErrorErrors) bool {

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -19,8 +19,10 @@ package instance
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1215,6 +1217,62 @@ func TestSetupInstanceLabels_ClusterLocationNotOverwrittenByRequirements(t *test
 	locationKey := utils.SanitizeGCELabelValue(utils.LabelClusterLocationKey)
 	require.Equal(t, "us-central1-f", inst.Labels[locationKey],
 		"cluster location must not be overwritten by a NodePool label with the same key")
+}
+
+func TestIsTransientError_TrueFor5xx(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isTransientError(&googleapi.Error{Code: 503}))
+	require.True(t, isTransientError(&googleapi.Error{Code: 500}))
+}
+
+func TestIsTransientError_FalseForNon5xx(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, isTransientError(&googleapi.Error{Code: 404}))
+	require.False(t, isTransientError(&googleapi.Error{Code: 429}))
+}
+
+func TestIsTransientError_FalseForNonAPIError(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, isTransientError(fmt.Errorf("plain error")))
+}
+
+func TestWaitOperationDone_RetriesOnTransient503(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	p := newFakeComputeProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			writeJSON(w, &googleapi.Error{Code: http.StatusServiceUnavailable, Message: "Visibility check was unavailable"})
+			return
+		}
+		writeJSON(w, &compute.Operation{Name: "op-123", Status: "DONE"})
+	}))
+
+	err := p.waitOperationDone(context.Background(), "n1-standard-1", "us-central1-a", "on-demand", "op-123")
+
+	require.NoError(t, err)
+	require.Equal(t, int32(3), callCount.Load())
+}
+
+func TestWaitOperationDone_FailsOnPersistent503(t *testing.T) {
+	t.Parallel()
+
+	p := newFakeComputeProvider(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		writeJSON(w, &googleapi.Error{Code: http.StatusServiceUnavailable, Message: "Visibility check was unavailable"})
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := p.waitOperationDone(ctx, "n1-standard-1", "us-central1-a", "on-demand", "op-123")
+
+	require.Error(t, err)
 }
 
 func TestBelongsToCluster(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Adds retry on 5xx errors in `waitOperationDone`.

This allows us to prevent retry of the operation if we weren't able to retrieve the operation status just due to temporal server-side problems

For example, it fixes #267 where retry results in creation of a second VM, while the first one becomes an orphan.

#### Which issue(s) this PR fixes:

Fixes #267

#### Special notes for your reviewer:

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.


#### Does this PR introduce a user-facing change?

```release-note
Fix 5xx error handling during poll of operation status from GCP.
Fix instance double-insertion when GCP returns a transient 503 during operation polling.
Previously, a 503 from ZoneOperations.Get caused the retry loop to create a second VM in a different zone, leaving an orphaned VM and a broken NodeClaim providerID.
```