### PR TITLE
chore(chart): add artifacthub-repo.yml for Verified Publisher badge

### DIFF
--- a/charts/artifacthub-repo.yml
+++ b/charts/artifacthub-repo.yml
@@ -1,0 +1,4 @@
+repositoryID: 7882dce7-02a8-451a-b2a3-59bf896e9124
+owners:
+  - name: CloudPilot AI
+    email: info@cloudpilot.ai

--- a/charts/karpenter/Chart.yaml
+++ b/charts/karpenter/Chart.yaml
@@ -22,3 +22,10 @@ version: v0.2.1
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v0.2.1"
+
+annotations:
+  artifacthub.io/links: |
+    - name: source
+      url: https://github.com/cloudpilot-ai/karpenter-provider-gcp
+    - name: support
+      url: https://github.com/cloudpilot-ai/karpenter-provider-gcp/issues


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds `charts/artifacthub-repo.yml` so Artifact Hub can verify that cloudpilot-ai owns the `karpenter-provider-gcp` Helm repository and grant the **Verified Publisher** badge.

AH verification works by fetching `artifacthub-repo.yml` from the Helm repo root URL (`https://cloudpilot-ai.github.io/karpenter-provider-gcp/artifacthub-repo.yml`) and matching the `repositoryID` against its records. The ID (`7882dce7-02a8-451a-b2a3-59bf896e9124`) corresponds to the already-registered repository on AH. The badge is granted automatically on the next AH crawl after this merges and GitHub Pages deploys.

#### Which issue(s) this PR fixes:

N/A

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)

#### Special notes for your reviewer:

- https://artifacthub.io/packages/helm/karpenter-provider-gcp/karpenter
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```