### PR TITLE
chore: upgrade Go version to 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudpilot-ai/karpenter-provider-gcp
 
-go 1.25.0
+go 1.26
 
 require (
 	cloud.google.com/go/compute v1.56.0


### PR DESCRIPTION
## What this does

Upgrades the project's minimum Go version from 1.25.0 to 1.26.

## Why

CI is currently printing a forced toolchain switch warning ([job 72305822341](https://github.com/cloudpilot-ai/karpenter-provider-gcp/actions/runs/24719919061/job/72305822341)):

```
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260418192536-e4a998cc6b09
    requires go >= 1.26.0; switching to go1.26.2
```

The `controller-runtime` `setup-envtest` tool now requires Go ≥ 1.26.0. Declaring `go 1.26` in our `go.mod` resolves this cleanly. Additionally:

- Upstream `sigs.k8s.io/karpenter` `main` already requires `go 1.26.2`, so this aligns us for future karpenter upgrades.
- Go 1.26 makes the **Green Tea GC the default**, reducing GC overhead 10–40% for long-running programs.
- Go 1.26 includes security improvements: heap base address randomization and post-quantum TLS key exchanges enabled by default.

All CI workflows already use `go-version-file: go.mod`, so no workflow changes are needed.

## Testing

- `make presubmit` passes locally (codegen verify + lint + unit tests)
- E2E tests are not required: this is a pure toolchain upgrade with no logic changes

## Which issue(s) this PR fixes

N/A

#### Special notes for your reviewer:

- This is a one-line change to `go.mod` plus a `go mod tidy` refresh of `go.sum`