### PR TITLE
chore(ci): fix toolchain caching — skip install on hit, cache kubebuilder, pin @latest tools

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -23,12 +23,16 @@ jobs:
           go-version-file: go.mod
 
       - name: Cache toolchain binaries
+        id: cache-toolchain
         uses: actions/cache@v4
         with:
-          path: ~/go/bin
+          path: |
+            ~/go/bin
+            ~/.local/kubebuilder
           key: toolchain-${{ runner.os }}-${{ hashFiles('hack/toolchain.sh') }}
 
       - name: Install toolchain
+        if: steps.cache-toolchain.outputs.cache-hit != 'true'
         run: |
           make toolchain
 

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -15,19 +15,19 @@ tools() {
     go install github.com/google/ko@v0.17.0
     go install github.com/mikefarah/yq/v4@v4.44.3
     go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
-    go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+    go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260418192536-e4a998cc6b09
     go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.20.1
-    go install github.com/sigstore/cosign/v2/cmd/cosign@latest
+    go install github.com/sigstore/cosign/v2/cmd/cosign@v2.6.3
     go install -tags extended github.com/gohugoio/hugo@v0.110.0
-    go install golang.org/x/vuln/cmd/govulncheck@latest
+    go install golang.org/x/vuln/cmd/govulncheck@v1.2.0
     go install github.com/onsi/ginkgo/v2/ginkgo@v2.20.2
     go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.2
     go install github.com/mattn/goveralls@v0.0.12
-    go install github.com/google/go-containerregistry/cmd/crane@latest
+    go install github.com/google/go-containerregistry/cmd/crane@v0.21.5
     go install oras.land/oras/cmd/oras@v1.2.0
     go install k8s.io/code-generator/cmd/deepcopy-gen@v0.27.0
-    go install github.com/elastic/crd-ref-docs@latest
-    go install github.com/bwplotka/mdox@latest
+    go install github.com/elastic/crd-ref-docs@v0.3.0
+    go install github.com/bwplotka/mdox@v0.9.0
 
     if ! echo "$PATH" | grep -q "${GOPATH:-undefined}/bin\|$HOME/go/bin"; then
         echo "Go workspace's \"bin\" directory is not in PATH. Run 'export PATH=\"\$PATH:\${GOPATH:-\$HOME/go}/bin\"'."


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The CI toolchain step was taking ~7 minutes on every run, even when the `~/go/bin` cache hit — because `make toolchain` always ran unconditionally and re-downloaded + recompiled all tools from scratch.

Three fixes:

1. **Skip `make toolchain` on cache hit** — add `id: cache-toolchain` to the cache step and `if: steps.cache-toolchain.outputs.cache-hit != 'true'` to the install step. On a hit the toolchain step now takes ~0 s instead of ~7 min.

2. **Add `~/.local/kubebuilder` to cache path** — `setup-envtest` downloads kubebuilder binaries (etcd, kubectl, kube-apiserver) to `~/.local/kubebuilder/bin`, which was not cached. Now included alongside `~/go/bin`.

3. **Pin all `@latest` tool versions** — `setup-envtest`, `cosign`, `govulncheck`, `crane` were unpinned. `@latest` resolves from the network on every run, making the cache key (`toolchain.sh` hash) unreliable if a tool releases a new version between a cache write and restore. Pinned to current latest:
   - `setup-envtest@v0.0.0-20260418192536-e4a998cc6b09`
   - `cosign@v2.6.3`
   - `govulncheck@v1.2.0`
   - `crane@v0.21.5`

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

- On the first run after this PR merges, the cache key changes (toolchain.sh changed) so `make toolchain` runs once to warm the new cache. All subsequent runs will skip it.
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```