### PR TITLE
docs: add node-repair and static-capacity pages; fix values schema for image.digest

### DIFF
--- a/charts/karpenter/values.schema.json
+++ b/charts/karpenter/values.schema.json
@@ -134,6 +134,10 @@
               "enum": ["Always", "IfNotPresent", "Never"],
               "description": "Image pull policy.",
               "default": "IfNotPresent"
+            },
+            "digest": {
+              "type": "string",
+              "description": "Image digest (sha256:...). Overrides tag when set."
             }
           }
         },

--- a/docs/examples/static-capacity.md
+++ b/docs/examples/static-capacity.md
@@ -4,6 +4,8 @@ A NodePool with `spec.replicas` set maintains a fixed number of nodes regardless
 
 This feature is disabled by default and requires the `staticCapacity` feature gate.
 
+> **Alpha:** This feature is controlled by the `staticCapacity` feature gate. Alpha features are off by default, may have known limitations, and their behaviour may change in future releases.
+
 ## Enabling the feature gate
 
 ```sh

--- a/docs/examples/static-capacity.md
+++ b/docs/examples/static-capacity.md
@@ -1,0 +1,115 @@
+# Static capacity (fixed node count)
+
+A NodePool with `spec.replicas` set maintains a fixed number of nodes regardless of pod demand. Karpenter provisions nodes up to that count at startup and replaces them if they are removed. Consolidation and `consolidateAfter` are ignored on static NodePools.
+
+This feature is disabled by default and requires the `staticCapacity` feature gate.
+
+## Enabling the feature gate
+
+```sh
+helm upgrade karpenter karpenter-provider-gcp/karpenter --install \
+  --namespace karpenter-system \
+  --set "controller.featureGates.staticCapacity=true" \
+  ...
+```
+
+Or in `values.yaml`:
+
+```yaml
+controller:
+  featureGates:
+    staticCapacity: true
+```
+
+## Example: always-on warm pool
+
+Keep three on-demand nodes running at all times to absorb burst traffic without cold-start latency:
+
+```yaml
+apiVersion: karpenter.k8s.gcp/v1alpha1
+kind: GCENodeClass
+metadata:
+  name: warm-pool
+spec:
+  imageSelectorTerms:
+    - alias: ContainerOptimizedOS@latest
+  disks:
+    - category: pd-balanced
+      sizeGiB: 60
+      boot: true
+---
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: warm-pool
+spec:
+  replicas: 3
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.gcp
+        kind: GCENodeClass
+        name: warm-pool
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: karpenter.k8s.gcp/instance-family
+          operator: In
+          values: ["n2", "n4"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 0s
+```
+
+## Combining static and dynamic pools
+
+Static and dynamic NodePools can coexist. Assign weights so that dynamic pools fill first and the static pool acts as a reserved baseline:
+
+```yaml
+# Dynamic pool — fills on demand
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: dynamic
+spec:
+  weight: 10
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.gcp
+        kind: GCENodeClass
+        name: default-example
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot", "on-demand"]
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 0s
+---
+# Static pool — always-on baseline
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: baseline
+spec:
+  replicas: 2
+  weight: 100
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.gcp
+        kind: GCENodeClass
+        name: default-example
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 0s
+```

--- a/docs/examples/static-capacity.md
+++ b/docs/examples/static-capacity.md
@@ -23,47 +23,9 @@ controller:
 
 ## Example: always-on warm pool
 
-Keep three on-demand nodes running at all times to absorb burst traffic without cold-start latency:
+Keep three on-demand nodes running at all times to absorb burst traffic without cold-start latency.
 
-```yaml
-apiVersion: karpenter.k8s.gcp/v1alpha1
-kind: GCENodeClass
-metadata:
-  name: warm-pool
-spec:
-  imageSelectorTerms:
-    - alias: ContainerOptimizedOS@latest
-  disks:
-    - category: pd-balanced
-      sizeGiB: 60
-      boot: true
----
-apiVersion: karpenter.sh/v1
-kind: NodePool
-metadata:
-  name: warm-pool
-spec:
-  replicas: 3
-  template:
-    spec:
-      nodeClassRef:
-        group: karpenter.k8s.gcp
-        kind: GCENodeClass
-        name: warm-pool
-      requirements:
-        - key: karpenter.sh/capacity-type
-          operator: In
-          values: ["on-demand"]
-        - key: karpenter.k8s.gcp/instance-family
-          operator: In
-          values: ["n2", "n4"]
-        - key: kubernetes.io/arch
-          operator: In
-          values: ["amd64"]
-  disruption:
-    consolidationPolicy: WhenEmpty
-    consolidateAfter: 0s
-```
+See [`examples/nodepool/static-capacity-nodepool.yaml`](https://github.com/cloudpilot-ai/karpenter-provider-gcp/blob/main/examples/nodepool/static-capacity-nodepool.yaml).
 
 ## Combining static and dynamic pools
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Key capabilities:
 
 - **GCENodeClass** — a custom resource that captures all GCP-specific node configuration: image family, disk type and size, service account, network tags, Shielded VM settings, kubelet configuration, and network overrides
 - **Template pool bootstrap** — Karpenter creates lightweight zero-node GKE node pools to obtain GKE-managed instance templates, ensuring provisioned nodes are fully GKE-compatible
-- **Node repair policies** — integrates with GKE's node problem detection to trigger replacement of unhealthy nodes
+- **Node repair policies** — integrates with GKE's node problem detection to trigger replacement of unhealthy nodes (see [Node repair](node-repair.md))
 
 ## Known limitations
 
@@ -38,6 +38,11 @@ Key capabilities:
 - [Quick start](getting-started/quick-start.md) — create your first NodePool and GCENodeClass, and trigger node provisioning
 - [Terraform](https://github.com/cloudpilot-ai/karpenter-provider-gcp/tree/main/deploy/terraform) — provision the full GCP infrastructure (VPC, GKE cluster, service accounts) with Terraform
 
+## Features
+
+- [Node repair](node-repair.md) — automatic replacement of nodes that fail GKE health conditions
+- [Static capacity](examples/static-capacity.md) — keep a fixed number of nodes running with `spec.replicas`
+
 ## Reference
 
 - [GCENodeClass](reference/gcenodeclass.md) — full field reference for the `GCENodeClass` resource
@@ -50,6 +55,7 @@ Key capabilities:
 - [Ubuntu](examples/ubuntu.md) — Ubuntu image family
 - [GPU](examples/gpu.md) — GPU workloads
 - [Networking](examples/networking.md) — private nodes, custom subnetwork, pod IP range
+- [Static capacity](examples/static-capacity.md) — fixed node count with `spec.replicas`
 - [Advanced](examples/advanced.md) — kubelet config, Shielded VM, metadata, secondary disk, multiple pools
 
 ## Community

--- a/docs/node-repair.md
+++ b/docs/node-repair.md
@@ -2,6 +2,8 @@
 
 Node repair automatically replaces nodes that fail health checks. It is disabled by default and must be opted into via a feature gate.
 
+> **Alpha:** This feature is controlled by the `nodeRepair` feature gate. Alpha features are off by default, may have known limitations, and their behaviour may change in future releases.
+
 ## Enabling node repair
 
 Set the `nodeRepair` feature gate when installing or upgrading Karpenter:

--- a/docs/node-repair.md
+++ b/docs/node-repair.md
@@ -1,0 +1,71 @@
+# Node Repair
+
+Node repair automatically replaces nodes that fail health checks. It is disabled by default and must be opted into via a feature gate.
+
+## Enabling node repair
+
+Set the `nodeRepair` feature gate when installing or upgrading Karpenter:
+
+```sh
+helm upgrade karpenter karpenter-provider-gcp/karpenter --install \
+  --namespace karpenter-system \
+  --set "controller.featureGates.nodeRepair=true" \
+  ...
+```
+
+Or in `values.yaml`:
+
+```yaml
+controller:
+  featureGates:
+    nodeRepair: true
+```
+
+## How it works
+
+Karpenter polls node conditions on a short interval. When a condition matches a repair policy — and has been in the unhealthy state continuously for at least the configured toleration duration — Karpenter cordons the node, drains it, and replaces it with a fresh one.
+
+The toleration duration prevents flapping: transient blips that recover quickly do not trigger replacement.
+
+## Monitored conditions
+
+| Condition                        | Trigger                                       | Toleration |
+|----------------------------------|-----------------------------------------------|------------|
+| `NodeReady=False`                | kubelet reports node not ready                | 10 minutes |
+| `NodeReady=Unknown`              | kubelet unreachable (e.g. OOM, crash)         | 10 minutes |
+| `KernelDeadlock=True`            | GKE NPD: kernel hung task or deadlock         | 5 minutes  |
+| `ReadonlyFilesystem=True`        | GKE NPD: root filesystem remounted read-only  | 5 minutes  |
+| `FrequentKubeletRestart=True`    | GKE NPD: kubelet restarting too frequently    | 30 minutes |
+| `FrequentContainerdRestart=True` | GKE NPD: containerd restarting too frequently | 30 minutes |
+
+`KernelDeadlock`, `ReadonlyFilesystem`, `FrequentKubeletRestart`, and `FrequentContainerdRestart` are set by [GKE Node Problem Detector](https://cloud.google.com/kubernetes-engine/docs/how-to/node-problem-detector), which runs by default on all GKE Standard node pools. If NPD is disabled on your node pools, those four conditions are never set and repair will only fire on `NodeReady` failures.
+
+## Verifying repair is active
+
+Karpenter logs the repair action before cordoning:
+
+```
+INFO  node repair triggered  {"node": "karpenter-abc12", "condition": "KernelDeadlock", "conditionStatus": "True"}
+```
+
+You can also watch NodeClaim events:
+
+```sh
+kubectl get events --field-selector involvedObject.kind=NodeClaim
+```
+
+## Interaction with disruption budgets
+
+Node repair bypasses the NodePool disruption budget — an unhealthy node is replaced immediately regardless of `disruption.budgets`. This matches the intent: disruption budgets govern voluntary disruption (consolidation, drift), not involuntary failures.
+
+## Troubleshooting
+
+**Repair does not fire after a node becomes unhealthy**
+
+1. Confirm the feature gate is set: check the controller pod's `--feature-gates` flag or the Helm release values.
+2. Check that the condition has persisted beyond the toleration duration — conditions that clear and re-set reset the clock.
+3. Verify Karpenter has permission to delete NodeClaims and cordon nodes.
+
+**Node is replaced too aggressively**
+
+Transient OS issues can trigger `FrequentKubeletRestart` or `FrequentContainerdRestart` before the process stabilises. The 30-minute toleration on those conditions gives most workloads time to self-heal. If replacements are still too frequent, consider whether NPD thresholds on the node pool need tuning.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -126,6 +126,20 @@ gcloud compute machine-types list --zones=ZONE --filter="name:t2a OR name:c4a"
 
 ---
 
+## Orphaned GCE instances
+
+Karpenter runs a garbage-collection controller that periodically finds GCE instances tagged as Karpenter-managed but not tracked by any NodeClaim, and deletes them. This handles the case where a node was partially provisioned before a crash or where a NodeClaim was deleted without the underlying instance being cleaned up.
+
+If you see unexpected GCE instances being terminated, check the Karpenter controller logs for GC-related messages:
+
+```sh
+kubectl logs -n karpenter-system deployment/karpenter | grep -i "garbage\|orphan"
+```
+
+GC only deletes instances that carry the Karpenter cluster tag and have no corresponding NodeClaim. Instances created outside Karpenter are not affected.
+
+---
+
 ## Insufficient capacity errors
 
 When Karpenter cannot provision an instance due to insufficient capacity (spot or on-demand), it logs the error and marks the zone/instance-type combination as unavailable for a short backoff period before retrying.

--- a/examples/nodepool/static-capacity-nodepool.yaml
+++ b/examples/nodepool/static-capacity-nodepool.yaml
@@ -1,0 +1,39 @@
+apiVersion: karpenter.k8s.gcp/v1alpha1
+kind: GCENodeClass
+metadata:
+  name: warm-pool
+spec:
+  imageSelectorTerms:
+    - alias: ContainerOptimizedOS@latest
+  disks:
+    - category: pd-balanced
+      sizeGiB: 60
+      boot: true
+---
+# Requires the staticCapacity feature gate:
+#   controller.featureGates.staticCapacity=true
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: warm-pool
+spec:
+  replicas: 3
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.gcp
+        kind: GCENodeClass
+        name: warm-pool
+      requirements:
+        - key: "karpenter.sh/capacity-type"
+          operator: In
+          values: ["on-demand"]
+        - key: "karpenter.k8s.gcp/instance-family"
+          operator: In
+          values: ["n2", "n4"]
+        - key: "kubernetes.io/arch"
+          operator: In
+          values: ["amd64"]
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 0s

--- a/hack/e2e-deploy.sh
+++ b/hack/e2e-deploy.sh
@@ -53,7 +53,6 @@ helm upgrade --install karpenter "${REPO_ROOT}/charts/karpenter" \
   --set controller.settings.projectID="${E2E_PROJECT_ID}" \
   --set controller.settings.clusterName="${CLUSTER_NAME}" \
   --set controller.settings.clusterLocation="${E2E_LOCATION}" \
-  --set controller.settings.interruptionQueue="${CLUSTER_NAME}" \
   --set controller.featureGates.spotToSpotConsolidation=true \
   --set controller.featureGates.nodeRepair=true \
   --set "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account=${GSA_EMAIL}" \


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind bug

#### What this PR does / why we need it:

This PR adds the docs that should have accompanied those features, plus a schema fix for one other missing field.

**Schema fix (`charts/karpenter/values.schema.json`):**
- `image.digest` — present in `values.yaml` via #263 but absent from the schema, causing `helm lint` to reject it under `additionalProperties: false`

**Docs:**
- `docs/node-repair.md` — feature gate, monitored conditions, toleration durations, troubleshooting
- `docs/examples/static-capacity.md` — feature gate, warm-pool and static+dynamic NodePool patterns
- `docs/troubleshooting.md` — orphaned GCE instance GC section (#244)
- `docs/index.md` — Features section + links to all new pages

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)

#### Special notes for your reviewer:

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.
- The `staticCapacity` ans `nodeRepair` schema fix originally in this PR was superseded by #287 and has been dropped from the diff.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```