### PR TITLE
fix(ci): add explicit permissions to workflow jobs

### DIFF
--- a/.github/workflows/cloudpilot-latest-build.yaml
+++ b/.github/workflows/cloudpilot-latest-build.yaml
@@ -8,6 +8,8 @@ jobs:
   latest-image-build-publish:
     name:  Image publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,6 +12,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   image-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Set tag
         run: |


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fixes 3 CodeQL medium findings (\"Workflow does not contain permissions\") in:
- `.github/workflows/cloudpilot-latest-build.yaml` (job `latest-image-build-publish`)
- `.github/workflows/docs.yaml` (job `lint`)
- `.github/workflows/release-build.yaml` (job `image-publish`)

Each job was running with the default GITHUB_TOKEN permissions, which grants write access to several scopes by default. Since these jobs only check out and read the repository, \`permissions: contents: read\` is sufficient.

The \`package-chart\` job in \`release-build.yaml\` already had explicit permissions and is unchanged.

#### Which issue(s) this PR fixes:

Fixes CodeQL alerts #1, #4, #5

#### Docs and examples

N/A

#### Special notes for your reviewer:

N/A

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```