### PR TITLE
chore(release): add release process documentation and tooling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+# All approvers from OWNERS are codeowners for the entire repository.
+* @patrostkowski @jwcesign @thameezb @dm3ch

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - kind/api-change
+        - kind/deprecation
+    - title: New Features
+      labels:
+        - kind/feature
+    - title: Bug Fixes
+      labels:
+        - kind/bug
+        - kind/regression
+    - title: Maintenance
+      labels:
+        - kind/cleanup
+        - kind/chore
+    - title: Documentation
+      labels:
+        - kind/documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,15 @@ e2e-check-clean: ## Report any orphaned e2e GCP resources (does not delete)
 	E2E_LOCATION=$(E2E_LOCATION) \
 	./hack/e2e-check-clean.sh
 
+release: ## Cut a release. Usage: make release VERSION=vX.Y.Z
+	@test -n "$(VERSION)" || (echo "ERROR: VERSION is required. Usage: make release VERSION=vX.Y.Z" >&2 && exit 1)
+	./hack/release.sh $(VERSION)
+
+cherry-pick: ## Backport commits to a release branch. Usage: make cherry-pick BRANCH=release-v0.3.x COMMITS="sha1 sha2"
+	@test -n "$(BRANCH)"  || (echo "ERROR: BRANCH is required.  Usage: make cherry-pick BRANCH=release-vX.Y.x COMMITS=\"sha1 sha2\"" >&2 && exit 1)
+	@test -n "$(COMMITS)" || (echo "ERROR: COMMITS is required. Usage: make cherry-pick BRANCH=release-vX.Y.x COMMITS=\"sha1 sha2\"" >&2 && exit 1)
+	./hack/cherry-pick.sh $(BRANCH) $(COMMITS)
+
 coverage:
 	go tool cover -html coverage.out -o coverage.html
 
@@ -169,7 +178,7 @@ codegen: ## Auto generate files based on GCP APIs
 crds: ## Apply CRDs
 	kubectl apply -f charts/karpenter/crds/
 
-.PHONY: help presubmit run ut-test require-project-id e2e-setup e2e-tests e2e-test e2e-teardown e2e-check-clean e2e-deploy coverage update verify-codegen verify image apply delete toolchain tidy download
+.PHONY: help presubmit run ut-test require-project-id e2e-setup e2e-tests e2e-test e2e-teardown e2e-check-clean e2e-deploy coverage update verify-codegen verify image apply delete toolchain tidy download release cherry-pick
 
 define newline
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,182 @@
+# Release Process
+
+This document describes how to cut releases of karpenter-provider-gcp.
+
+## Roles
+
+Any of the four project approvers listed in [OWNERS](OWNERS) may cut a release:
+
+- [@patrostkowski](https://github.com/patrostkowski)
+- [@jwcesign](https://github.com/jwcesign)
+- [@thameezb](https://github.com/thameezb)
+- [@dm3ch](https://github.com/dm3ch)
+
+Cherry-pick PRs targeting a release branch require approval from **at least one approver who is not
+the author** before merging.
+
+---
+
+## Versioning
+
+The project uses [Semantic Versioning 2.0.0](https://semver.org/).
+
+While the project is at `v0.x.y` (pre-v1):
+
+| Version component | When to bump |
+|---|---|
+| `y` (patch) | Bug fixes and security patches only — no new features, no breaking changes |
+| `x` (minor) | New features **or** breaking changes |
+| Major (`v1.0.0`) | TBD — requires explicit team decision |
+
+Release candidates are tagged as `vX.Y.Z-rc.N` (e.g. `v0.3.0-rc.0`) from the release branch
+before cutting the stable tag.
+
+---
+
+## Cadence
+
+- **Minor releases** — approximately monthly, driven by accumulated merged features. The release
+  manager for that cycle decides when `main` is ready.
+- **Patch releases** — on-demand, for critical bug fixes or CVEs. No fixed schedule.
+- **Release candidates** — optional, used when a minor release contains significant changes that
+  benefit from broader testing before a stable tag.
+
+---
+
+## Release Branches
+
+| Branch name | Convention |
+|---|---|
+| New branches | `release-v<major>.<minor>.x` (e.g. `release-v0.3.x`) |
+| Legacy | `release-0.1`, `release-0.2` — frozen, no new patches |
+
+A release branch is created from `main` at the moment the first `vX.Y.0` tag is pushed. Patch
+releases (`vX.Y.1`, `vX.Y.2`, …) are cut from the same `release-vX.Y.x` branch via cherry-pick.
+
+---
+
+## Minor / Major Release
+
+> Requires `gh` CLI and push access to `upstream` (the canonical repo remote).
+
+1. Ensure `main` CI is green.
+
+2. From `main`, run:
+
+   ```bash
+   make release VERSION=vX.Y.0
+   ```
+
+   The script will:
+   - Validate the version string and working-tree cleanliness.
+   - Generate a `CHANGELOG.md` entry by extracting `release-note` blocks from PRs merged since the
+     previous tag, grouped by `kind/` label.
+   - Commit the changelog update.
+   - Create and push the `release-vX.Y.x` branch.
+   - Create an annotated tag `vX.Y.0` and push it.
+   - Open a GitHub Release (draft) with the generated release notes.
+
+3. Verify the `release-build` GitHub Actions workflow completes successfully (image published to
+   ECR, Helm chart deployed to GitHub Pages).
+
+4. Publish the draft GitHub Release once you are satisfied with the release notes.
+
+5. Open a follow-up PR on `main` that re-adds the empty `## Unreleased` block to `CHANGELOG.md`.
+
+---
+
+## Patch / Hotfix Release
+
+Fixes must be merged to `main` first (fast-forward), then cherry-picked to the release branch.
+
+> **Exception**: if the fix cannot land on `main` first (e.g. `main` already contains a
+> breaking change), discuss with the other approvers before proceeding.
+
+1. Identify the commit SHA(s) on `main` to backport.
+
+2. From any clean checkout, run:
+
+   ```bash
+   make cherry-pick BRANCH=release-vX.Y.x COMMITS="<sha1> [<sha2> ...]"
+   ```
+
+   The script will check out the release branch, cherry-pick the commits, push a
+   `cherry-pick/release-vX.Y.x-<short-sha>` branch, and open a draft PR.
+
+3. Get **at least one other approver** to review and merge the cherry-pick PR.
+
+4. Once merged, check out the release branch locally and run:
+
+   ```bash
+   make release VERSION=vX.Y.Z
+   ```
+
+---
+
+## Release Candidate
+
+1. From the `release-vX.Y.x` branch, tag manually:
+
+   ```bash
+   git tag -a vX.Y.Z-rc.N -m "Release candidate vX.Y.Z-rc.N"
+   git push upstream vX.Y.Z-rc.N
+   ```
+
+   No CHANGELOG entry is required for RCs; the stable release entry covers them.
+
+2. The `release-build` workflow fires on the `rc` tag and publishes the image and Helm chart with
+   the RC tag, so users can test before the stable release.
+
+3. When ready, promote to stable by running `make release VERSION=vX.Y.Z` from the release branch.
+
+---
+
+## Cherry-Pick Policy
+
+Only **bug fixes** and **security patches** are eligible for backporting to a release branch.
+New features are never cherry-picked.
+
+A commit is eligible if:
+- It is already merged to `main`.
+- It targets a currently supported minor release (see [Support Window](#support-window) below).
+- It is labelled `kind/bug`, `kind/regression`, or involves a CVE.
+
+---
+
+## Support Window
+
+The project maintains the **most recent minor release** with patch fixes. Older minor releases
+receive no further patches once a newer minor is tagged.
+
+| Release | Status |
+|---|---|
+| Latest minor | Active — receives bug-fix patches |
+| Previous minor | End of life once the next minor ships |
+
+---
+
+## Branch Protection
+
+Release branches (`release-v*`) should be protected by org admins with the following ruleset.
+If you are cutting the first release on a new branch, **open a GitHub issue or contact an org admin**
+to have these rules applied before merging any cherry-pick PRs:
+
+| Rule | Setting |
+|---|---|
+| Branch name pattern | `release-v*` |
+| Require pull request before merging | ✅ — at least 1 approving review |
+| Required status checks | `presubmit` (CI job) |
+| Require branches to be up to date | ✅ |
+| Allow force pushes | ❌ |
+| Allow deletions | ❌ |
+| Restrict who can push directly | Approvers only: patrostkowski, jwcesign, thameezb, dm3ch |
+
+---
+
+## Post-Release Checklist
+
+- [ ] GitHub Release is published (not draft)
+- [ ] `release-build` workflow completed — image and Helm chart are live
+- [ ] `## Unreleased` block re-added to `CHANGELOG.md` on `main` (follow-up PR)
+- [ ] Helm repo `index.yaml` on GitHub Pages lists the new version (`helm repo update && helm search repo karpenter-gcp`)
+- [ ] Previous minor release branch is marked as archived / EOL in this document (if applicable)

--- a/hack/cherry-pick.sh
+++ b/hack/cherry-pick.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Usage: ./hack/cherry-pick.sh <release-branch> <commit> [<commit> ...]
+#   e.g. ./hack/cherry-pick.sh release-v0.3.x abc1234 def5678
+#
+# Checks out the release branch, cherry-picks the given commits onto a new
+# branch, pushes it, and opens a draft PR for review.
+#
+# Requires: git, gh (GitHub CLI)
+
+set -euo pipefail
+
+RELEASE_BRANCH="${1:-}"
+shift || true
+COMMITS=("$@")
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+die()  { echo "ERROR: $*" >&2; exit 1; }
+info() { echo "==> $*"; }
+
+# ── validation ────────────────────────────────────────────────────────────────
+
+[[ -n "${RELEASE_BRANCH}" ]]   || die "Usage: $0 <release-branch> <commit> [<commit> ...]"
+[[ "${#COMMITS[@]}" -gt 0 ]]   || die "At least one commit SHA is required."
+
+if ! [[ "${RELEASE_BRANCH}" =~ ^release-v[0-9]+\.[0-9]+\.x$ ]]; then
+  die "Release branch must match 'release-vX.Y.x'. Got: '${RELEASE_BRANCH}'"
+fi
+
+command -v gh &>/dev/null || die "'gh' CLI is required. Install from https://cli.github.com/"
+
+# ── stash any uncommitted work ────────────────────────────────────────────────
+
+STASH_NEEDED=false
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  info "Stashing uncommitted changes..."
+  git stash push -m "cherry-pick.sh auto-stash"
+  STASH_NEEDED=true
+fi
+
+# restore stash on exit (best-effort)
+cleanup() {
+  if [[ "${STASH_NEEDED}" == "true" ]]; then
+    info "Restoring stashed changes..."
+    git stash pop || echo "WARNING: Could not pop stash automatically. Run 'git stash pop' manually."
+  fi
+}
+trap cleanup EXIT
+
+ORIGINAL_BRANCH="$(git branch --show-current)"
+
+# ── fetch and check out release branch ───────────────────────────────────────
+
+info "Fetching upstream..."
+git fetch upstream
+
+if ! git branch --list "${RELEASE_BRANCH}" | grep -q .; then
+  info "Checking out '${RELEASE_BRANCH}' from upstream..."
+  git checkout -b "${RELEASE_BRANCH}" "upstream/${RELEASE_BRANCH}"
+else
+  info "Updating local '${RELEASE_BRANCH}'..."
+  git checkout "${RELEASE_BRANCH}"
+  git merge --ff-only "upstream/${RELEASE_BRANCH}"
+fi
+
+# ── create cherry-pick branch ─────────────────────────────────────────────────
+
+SHORT_SHA="$(git rev-parse --short "${COMMITS[0]}")"
+CP_BRANCH="cherry-pick/${RELEASE_BRANCH}-${SHORT_SHA}"
+
+info "Creating branch '${CP_BRANCH}'..."
+git checkout -b "${CP_BRANCH}"
+
+# ── cherry-pick ───────────────────────────────────────────────────────────────
+
+for COMMIT in "${COMMITS[@]}"; do
+  info "Cherry-picking ${COMMIT}..."
+  # -x appends "(cherry picked from commit <sha>)" to the commit message
+  git cherry-pick -x "${COMMIT}"
+done
+
+# ── push ─────────────────────────────────────────────────────────────────────
+
+info "Pushing '${CP_BRANCH}'..."
+git push upstream "${CP_BRANCH}"
+
+# ── open draft PR ─────────────────────────────────────────────────────────────
+
+PR_TITLE="cherry-pick: backport to ${RELEASE_BRANCH}"
+PR_BODY="$(cat <<EOF
+#### What type of PR is this?
+
+/kind bug
+
+#### What this PR does / why we need it:
+
+Cherry-pick of the following commit(s) from \`main\` onto \`${RELEASE_BRANCH}\`:
+
+$(for C in "${COMMITS[@]}"; do echo "- $(git log -1 --oneline "${C}")"; done)
+
+#### Which issue(s) this PR fixes:
+
+Fixes #
+
+#### Docs and examples
+
+- [x] \`docs/\` and \`examples/\` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
+
+#### Special notes for your reviewer:
+
+Please verify this cherry-pick applies cleanly and the fix is appropriate for a patch release.
+
+#### Does this PR introduce a user-facing change?
+
+\`\`\`release-note
+NONE
+\`\`\`
+EOF
+)"
+
+info "Opening draft PR against '${RELEASE_BRANCH}'..."
+PR_URL="$(gh pr create \
+  --base "${RELEASE_BRANCH}" \
+  --head "${CP_BRANCH}" \
+  --title "${PR_TITLE}" \
+  --body "${PR_BODY}" \
+  --draft)"
+
+info ""
+info "Draft PR opened: ${PR_URL}"
+info ""
+info "Next steps:"
+info "  1. Update the PR description (title, issue link, release-note block)."
+info "  2. Get at least one other approver to review and merge."
+info "  3. After merge, run: make release VERSION=vX.Y.Z"
+
+# return to original branch (cleanup trap handles stash pop)
+git checkout "${ORIGINAL_BRANCH}"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Usage: ./hack/release.sh <version>
+#   e.g. ./hack/release.sh v0.3.0
+#        ./hack/release.sh v0.3.0-rc.0
+#
+# Requires: git, gh (GitHub CLI), jq
+
+set -euo pipefail
+
+VERSION="${1:-}"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+info() { echo "==> $*"; }
+
+# ── validation ────────────────────────────────────────────────────────────────
+
+[[ -n "${VERSION}" ]] || die "Usage: $0 <version>  (e.g. v0.3.0)"
+
+# Accept vX.Y.Z or vX.Y.Z-rc.N
+if ! [[ "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+  die "Version '${VERSION}' is not valid semver. Expected vX.Y.Z or vX.Y.Z-rc.N"
+fi
+
+IS_RC=false
+[[ "${VERSION}" =~ -rc\. ]] && IS_RC=true
+
+# Working tree must be clean
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  die "Working tree is not clean. Commit or stash your changes first."
+fi
+
+CURRENT_BRANCH="$(git branch --show-current)"
+
+if [[ "${IS_RC}" == "false" ]]; then
+  # Determine if this is a minor/major (from main) or patch (from release branch)
+  if [[ "${CURRENT_BRANCH}" == "main" ]]; then
+    RELEASE_TYPE="minor"
+  elif [[ "${CURRENT_BRANCH}" =~ ^release-v[0-9]+\.[0-9]+\.x$ ]]; then
+    RELEASE_TYPE="patch"
+  else
+    die "Stable releases must be run from 'main' (minor/major) or 'release-vX.Y.x' (patch). Current branch: '${CURRENT_BRANCH}'"
+  fi
+fi
+
+# Tag must not already exist
+if git rev-parse "${VERSION}" &>/dev/null; then
+  die "Tag '${VERSION}' already exists."
+fi
+
+command -v gh  &>/dev/null || die "'gh' CLI is required. Install from https://cli.github.com/"
+command -v jq  &>/dev/null || die "'jq' is required."
+
+info "Releasing ${VERSION} (type: ${IS_RC:+RC}${IS_RC:-${RELEASE_TYPE:-rc}})"
+
+# ── derive version components ─────────────────────────────────────────────────
+
+SEMVER="${VERSION#v}"                            # strip leading v
+MAJOR="$(echo "${SEMVER}" | cut -d. -f1)"
+MINOR="$(echo "${SEMVER}" | cut -d. -f2)"
+RELEASE_BRANCH="release-v${MAJOR}.${MINOR}.x"
+
+# ── find previous tag (for CHANGELOG and PR range) ───────────────────────────
+
+PREV_TAG="$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)"
+[[ -n "${PREV_TAG}" ]] || die "No previous stable tag found. Cannot determine PR range."
+info "Previous stable tag: ${PREV_TAG}"
+
+# ── generate CHANGELOG section (stable releases only) ────────────────────────
+
+if [[ "${IS_RC}" == "false" ]]; then
+  info "Generating CHANGELOG section from merged PRs since ${PREV_TAG}..."
+
+  # Fetch merged PRs since the previous tag date
+  PREV_TAG_DATE="$(git log -1 --format=%aI "${PREV_TAG}")"
+
+  CHANGELOG_SECTION="$(
+    gh pr list \
+      --base main \
+      --state merged \
+      --json number,title,labels,body \
+      --limit 500 \
+      --jq "
+        [
+          .[] |
+          select(.mergedAt >= \"${PREV_TAG_DATE}\" // true) |
+          {
+            number: .number,
+            title:  .title,
+            labels: [.labels[].name],
+            note:   (
+              .body |
+              capture(\"[\\\\x60]{3}release-note\\n(?P<note>[\\\\s\\\\S]+?)\\n[\\\\x60]{3}\") |
+              .note // empty
+            )
+          } |
+          select(.note != null and (.note | ascii_downcase | ltrimstr(\" \") | ltrimstr(\"\\n\") | startswith(\"none\") | not))
+        ]
+      " 2>/dev/null
+  )"
+
+  # Build section text via jq
+  SECTION_TEXT="$(echo "${CHANGELOG_SECTION}" | jq -r --arg version "${VERSION}" '
+    def label_section(lbl):
+      map(select(.labels | index(lbl))) |
+      if length > 0 then
+        ["### " + (
+          if lbl == "kind/api-change" or lbl == "kind/deprecation" then "Breaking Changes"
+          elif lbl == "kind/feature" then "New Features"
+          elif lbl == "kind/bug" or lbl == "kind/regression" then "Bug Fixes"
+          elif lbl == "kind/cleanup" or lbl == "kind/chore" then "Maintenance"
+          elif lbl == "kind/documentation" then "Documentation"
+          else "Other Changes" end
+        )] + map("- \(.note | gsub("\n";" ")) (#\(.number))")
+      else [] end;
+
+    (
+      label_section("kind/api-change") +
+      label_section("kind/deprecation") +
+      label_section("kind/feature") +
+      label_section("kind/bug") +
+      label_section("kind/regression") +
+      label_section("kind/cleanup") +
+      label_section("kind/chore") +
+      label_section("kind/documentation") +
+      (
+        map(select(
+          (.labels | (index("kind/api-change") == null)) and
+          (.labels | (index("kind/deprecation") == null)) and
+          (.labels | (index("kind/feature") == null)) and
+          (.labels | (index("kind/bug") == null)) and
+          (.labels | (index("kind/regression") == null)) and
+          (.labels | (index("kind/cleanup") == null)) and
+          (.labels | (index("kind/chore") == null)) and
+          (.labels | (index("kind/documentation") == null))
+        )) |
+        if length > 0 then
+          ["### Other Changes"] + map("- \(.note | gsub("\n";" ")) (#\(.number))")
+        else [] end
+      )
+    ) | join("\n")
+  ')"
+
+  if [[ -z "${SECTION_TEXT}" ]]; then
+    SECTION_TEXT="No user-facing changes."
+  fi
+
+  NEW_SECTION="## ${VERSION}"$'\n\n'"${SECTION_TEXT}"
+
+  # Prepend new section after the header line(s) in CHANGELOG.md
+  # The header block is everything up to and including the blank line after "## Unreleased" or the first "## v"
+  CHANGELOG="CHANGELOG.md"
+  [[ -f "${CHANGELOG}" ]] || die "CHANGELOG.md not found in $(pwd)"
+
+  # Insert new section: after the first blank line that follows the file header (before any existing ## section)
+  HEADER_END="$(grep -n '^## ' "${CHANGELOG}" | head -1 | cut -d: -f1)"
+  if [[ -n "${HEADER_END}" ]]; then
+    # Insert before the first existing ## section
+    INSERT_AT="$((HEADER_END - 1))"
+    {
+      head -n "${INSERT_AT}" "${CHANGELOG}"
+      echo ""
+      echo "${NEW_SECTION}"
+      echo ""
+      tail -n +"$((INSERT_AT + 1))" "${CHANGELOG}"
+    } > "${CHANGELOG}.tmp"
+    mv "${CHANGELOG}.tmp" "${CHANGELOG}"
+  else
+    # No sections yet — append
+    printf '\n%s\n' "${NEW_SECTION}" >> "${CHANGELOG}"
+  fi
+
+  info "Committing CHANGELOG.md..."
+  git add CHANGELOG.md
+  git commit -m "chore: finalize CHANGELOG for ${VERSION}"
+fi
+
+# ── create release branch (minor/major only) ──────────────────────────────────
+
+if [[ "${IS_RC}" == "false" && "${RELEASE_TYPE}" == "minor" ]]; then
+  if git branch --list "${RELEASE_BRANCH}" | grep -q .; then
+    info "Release branch '${RELEASE_BRANCH}' already exists locally — skipping creation."
+  else
+    info "Creating release branch ${RELEASE_BRANCH}..."
+    git checkout -b "${RELEASE_BRANCH}"
+    git push upstream "${RELEASE_BRANCH}"
+    git checkout main
+    info "Switched back to main."
+  fi
+fi
+
+# ── tag ───────────────────────────────────────────────────────────────────────
+
+info "Creating annotated tag ${VERSION}..."
+git tag -a "${VERSION}" -m "Release ${VERSION}"
+
+info "Pushing tag ${VERSION}..."
+git push upstream "${VERSION}"
+
+# ── GitHub Release ────────────────────────────────────────────────────────────
+
+info "Opening GitHub Release (draft)..."
+
+if [[ "${IS_RC}" == "true" ]]; then
+  RELEASE_NOTES="Release candidate ${VERSION}. See the upcoming stable release for the full changelog."
+  RELEASE_FLAGS="--prerelease --draft"
+else
+  # Extract the section we just wrote from CHANGELOG.md as the release body
+  RELEASE_NOTES="$(awk "/^## ${VERSION}/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md | sed '/^[[:space:]]*$/d;1s/^//' | head -200)"
+  RELEASE_FLAGS="--draft"
+fi
+
+# shellcheck disable=SC2086
+gh release create "${VERSION}" \
+  --title "Release ${VERSION}" \
+  --notes "${RELEASE_NOTES}" \
+  ${RELEASE_FLAGS}
+
+info "Done! The GitHub Release is open as a draft."
+info "Next steps:"
+info "  1. Wait for the 'release-build' CI workflow to complete."
+info "  2. Review and publish the draft GitHub Release."
+if [[ "${IS_RC}" == "false" && "${RELEASE_TYPE}" == "minor" ]]; then
+  info "  3. Open a follow-up PR on main re-adding the '## Unreleased' block to CHANGELOG.md."
+fi


### PR DESCRIPTION
#### What type of PR is this?

/kind chore
/kind documentation

#### What this PR does / why we need it:

Establishes the full release process infrastructure for the project — documentation, automation scripts, and GitHub configuration. Currently there is no documented release flow, no tooling to cut releases, and no cherry-pick process for patch releases.

**What's included:**

- **`RELEASE.md`** — Full release runbook: versioning scheme (semver, pre-v1 strategy), monthly minor cadence, roles (all four OWNERS approvers), release branch naming (`release-vX.Y.x`), step-by-step procedures for minor/major, patch/hotfix, and RC releases, cherry-pick policy, support window, branch protection guidance for org admins, and post-release checklist.

- **`hack/release.sh`** — Release automation script. Validates version and working tree, generates a `CHANGELOG.md` section by extracting `release-note` blocks from merged PRs (grouped by `kind/` label via `gh` CLI), commits the changelog, creates and pushes the `release-vX.Y.x` branch (minor releases), tags, pushes, and opens a draft GitHub Release.

- **`hack/cherry-pick.sh`** — Backport helper. Fetches the release branch, cherry-picks specified commits with `-x`, pushes a `cherry-pick/` branch, and opens a draft PR against the release branch for review.

- **`.github/release.yml`** — GitHub auto-generated release notes categories config, mapping `kind/*` PR labels to named sections on the GitHub Releases page.

- **`.github/CODEOWNERS`** — Assigns all OWNERS approvers as codeowners so GitHub auto-requests reviews and can enforce rules on release branches once branch protection is configured.

- **`Makefile`** — Adds `make release VERSION=vX.Y.Z` and `make cherry-pick BRANCH=... COMMITS=...` targets.

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)

#### Special notes for your reviewer:

**Branch protection**: `RELEASE.md` documents the exact ruleset to request from org admins for `release-v*` branches (require PR review, `presubmit` status check, no force-push, restricted push). Someone should open a request to the org admins before we cut the next release.

**`gh` CLI dependency**: both `hack/release.sh` and `hack/cherry-pick.sh` require `gh` to be installed and authenticated. This matches the assumption that only approvers run these scripts.

**CHANGELOG generation**: the release script queries merged PRs via `gh pr list` and extracts the ` ```release-note``` ` blocks from PR bodies (same format as our existing PR template). PRs with `NONE` in the block are skipped.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```