### PR TITLE
feat(chart): add karpenter-crd Helm chart for independent CRD lifecycle

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -104,26 +104,29 @@ jobs:
 
           helm repo add karpenter-gcp "${PAGES_URL}" --force-update
 
-          # Parse "chart_name version" pairs from the Helm index YAML using awk.
-          # Chart names appear at 2-space indent (e.g. "  karpenter:"); versions at 4-space indent.
-          awk '/^  [a-z].*:$/ { chart=$1; sub(/:$/,"",chart) } /^    version:/ { print chart " " $2 }' \
-            /tmp/merge-index.yaml > /tmp/chart-versions.txt
+          for CHART in karpenter karpenter-crd; do
+            VERSIONS=$(helm search repo "karpenter-gcp/${CHART}" --versions -o json 2>/dev/null | jq -r '.[].version' || true)
+            [ -z "${VERSIONS}" ] && continue
 
-          while read CHART VERSION; do
-            TARBALL="charts/${CHART}-${VERSION}.tgz"
-            if [ ! -f "${TARBALL}" ]; then
-              echo "Pulling ${CHART} ${VERSION}..."
-              helm pull "karpenter-gcp/${CHART}" --version "${VERSION}" --destination charts/ || \
-                echo "WARNING: could not pull ${CHART} ${VERSION}, skipping"
+            echo "${VERSIONS}" | while read VERSION; do
+              if [ ! -f "charts/${CHART}-${VERSION}.tgz" ]; then
+                echo "Pulling ${CHART} ${VERSION}..."
+                helm pull "karpenter-gcp/${CHART}" --version "${VERSION}" --destination charts/ || \
+                  echo "WARNING: could not pull ${CHART} ${VERSION}, skipping"
+              fi
+            done
+
+            # Fail rather than deploy an incomplete repo
+            ACTUAL=0
+            for V in ${VERSIONS}; do
+              [ -f "charts/${CHART}-${V}.tgz" ] && ACTUAL=$((ACTUAL + 1))
+            done
+            EXPECTED=$(echo "${VERSIONS}" | grep -c .)
+            if [ "${ACTUAL}" -lt "${EXPECTED}" ]; then
+              echo "ERROR: Expected ${EXPECTED} ${CHART} archives but only have ${ACTUAL}. Aborting."
+              exit 1
             fi
-          done < /tmp/chart-versions.txt
-
-          EXPECTED=$(wc -l < /tmp/chart-versions.txt | tr -d ' ')
-          ACTUAL=$(ls charts/karpenter*.tgz 2>/dev/null | wc -l | tr -d ' ')
-          if [ "${ACTUAL}" -lt "${EXPECTED}" ]; then
-            echo "ERROR: Expected ${EXPECTED} chart archives but only have ${ACTUAL}. Aborting."
-            exit 1
-          fi
+          done
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -81,8 +81,10 @@ jobs:
             exit 1
           fi
 
-      - name: Package chart
-        run: helm package charts/karpenter --version "${{ env.tag_semver }}" --app-version "${{ env.tag }}" -d charts/
+      - name: Package charts
+        run: |
+          helm package charts/karpenter     --version "${{ env.tag_semver }}" --app-version "${{ env.tag }}" -d charts/
+          helm package charts/karpenter-crd --version "${{ env.tag_semver }}" --app-version "${{ env.tag }}" -d charts/
 
       - name: Update Helm repo index
         run: |
@@ -98,22 +100,28 @@ jobs:
       - name: Restore previously published chart versions
         run: |
           PAGES_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
-          VERSIONS=$(grep '^    version:' /tmp/merge-index.yaml 2>/dev/null | awk '{print $2}')
-          [ -z "${VERSIONS}" ] && exit 0
+          [ ! -f /tmp/merge-index.yaml ] && exit 0
 
           helm repo add karpenter-gcp "${PAGES_URL}" --force-update
-          echo "${VERSIONS}" | while read VERSION; do
-            if [ ! -f "charts/karpenter-${VERSION}.tgz" ]; then
-              echo "Pulling karpenter ${VERSION}..."
-              helm pull karpenter-gcp/karpenter --version "${VERSION}" --destination charts/
-            fi
-          done
 
-          # Fail rather than deploy an incomplete repo
-          EXPECTED=$(echo "${VERSIONS}" | grep -c .)
-          ACTUAL=$(ls charts/karpenter-*.tgz 2>/dev/null | wc -l | tr -d ' ')
+          # Parse "chart_name version" pairs from the Helm index YAML using awk.
+          # Chart names appear at 2-space indent (e.g. "  karpenter:"); versions at 4-space indent.
+          awk '/^  [a-z].*:$/ { chart=$1; sub(/:$/,"",chart) } /^    version:/ { print chart " " $2 }' \
+            /tmp/merge-index.yaml > /tmp/chart-versions.txt
+
+          while read CHART VERSION; do
+            TARBALL="charts/${CHART}-${VERSION}.tgz"
+            if [ ! -f "${TARBALL}" ]; then
+              echo "Pulling ${CHART} ${VERSION}..."
+              helm pull "karpenter-gcp/${CHART}" --version "${VERSION}" --destination charts/ || \
+                echo "WARNING: could not pull ${CHART} ${VERSION}, skipping"
+            fi
+          done < /tmp/chart-versions.txt
+
+          EXPECTED=$(wc -l < /tmp/chart-versions.txt | tr -d ' ')
+          ACTUAL=$(ls charts/karpenter*.tgz 2>/dev/null | wc -l | tr -d ' ')
           if [ "${ACTUAL}" -lt "${EXPECTED}" ]; then
-            echo "ERROR: Expected ${EXPECTED} chart versions but only have ${ACTUAL}. Aborting."
+            echo "ERROR: Expected ${EXPECTED} chart archives but only have ${ACTUAL}. Aborting."
             exit 1
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,14 @@ update: tidy download ## Update go files header, CRD and generated code
 	hack/update-generated.sh
 	hack/docs-generate.sh
 	helm-docs -c charts/karpenter
+	helm-docs -c charts/karpenter-crd
 
 verify-codegen: update ## Verify generated code is up to date
 	git diff --exit-code || (echo "Generated files are out of date — run 'make update' and commit the changes" && exit 1)
 
-chart-lint: ## Lint the Helm chart (validates values.schema.json and templates)
+chart-lint: ## Lint the Helm charts (validates values.schema.json and templates)
 	helm lint charts/karpenter/
+	helm lint charts/karpenter-crd/
 
 verify: ## Verify code. Includes linting, formatting, etc
 	golangci-lint run --new-from-rev=origin/main --timeout=20m

--- a/charts/karpenter-crd/.helmignore
+++ b/charts/karpenter-crd/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/karpenter-crd/Chart.yaml
+++ b/charts/karpenter-crd/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: karpenter-crd
+description: Karpenter GCP CRD chart - installs and upgrades Karpenter CustomResourceDefinitions independently
+type: application
+version: 0.0.0
+appVersion: "0.0.0"
+
+annotations:
+  artifacthub.io/links: |
+    - name: source
+      url: https://github.com/cloudpilot-ai/karpenter-provider-gcp
+    - name: support
+      url: https://github.com/cloudpilot-ai/karpenter-provider-gcp/issues

--- a/charts/karpenter-crd/README.md
+++ b/charts/karpenter-crd/README.md
@@ -1,6 +1,6 @@
 # karpenter-crd
 
-Karpenter GCP CRD chart — installs and upgrades Karpenter CustomResourceDefinitions independently
+Karpenter GCP CRD chart - installs and upgrades Karpenter CustomResourceDefinitions independently
 
 The `karpenter-crd` chart installs and upgrades the Karpenter GCP CRDs independently
 of the controller chart. Installing CRDs via this chart allows `helm upgrade karpenter-crd`

--- a/charts/karpenter-crd/README.md
+++ b/charts/karpenter-crd/README.md
@@ -1,0 +1,40 @@
+# karpenter-crd
+
+Karpenter GCP CRD chart — installs and upgrades Karpenter CustomResourceDefinitions independently
+
+The `karpenter-crd` chart installs and upgrades the Karpenter GCP CRDs independently
+of the controller chart. Installing CRDs via this chart allows `helm upgrade karpenter-crd`
+to safely upgrade CRDs before rolling out a new controller version.
+
+## Why a separate CRD chart?
+
+Helm's `helm upgrade` deliberately never upgrades CRDs that already exist in the cluster.
+The standard workaround is a dedicated CRD chart whose resources live in `templates/`
+(not `crds/`) so that `helm upgrade` applies them normally.
+
+## Installation
+
+Install CRDs first:
+
+```bash
+helm repo add karpenter-provider-gcp https://cloudpilot-ai.github.io/karpenter-provider-gcp
+helm repo update
+
+helm upgrade --install karpenter-crd karpenter-provider-gcp/karpenter-crd
+```
+
+Then install the controller:
+
+```bash
+helm upgrade --install karpenter karpenter-provider-gcp/karpenter \
+  --namespace karpenter-system --create-namespace \
+  --set "controller.settings.projectID=<project>" \
+  --set "controller.settings.clusterName=<cluster>" \
+  --set "controller.settings.clusterLocation=<region-or-zone>"
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| additionalAnnotations | object | `{}` | Additional annotations to add to all CRD resources. |

--- a/charts/karpenter-crd/README.md.gotmpl
+++ b/charts/karpenter-crd/README.md.gotmpl
@@ -1,0 +1,36 @@
+# {{ template "chart.name" . }}
+
+{{ template "chart.description" . }}
+
+The `karpenter-crd` chart installs and upgrades the Karpenter GCP CRDs independently
+of the controller chart. Installing CRDs via this chart allows `helm upgrade karpenter-crd`
+to safely upgrade CRDs before rolling out a new controller version.
+
+## Why a separate CRD chart?
+
+Helm's `helm upgrade` deliberately never upgrades CRDs that already exist in the cluster.
+The standard workaround is a dedicated CRD chart whose resources live in `templates/`
+(not `crds/`) so that `helm upgrade` applies them normally.
+
+## Installation
+
+Install CRDs first:
+
+```bash
+helm repo add karpenter-provider-gcp https://cloudpilot-ai.github.io/karpenter-provider-gcp
+helm repo update
+
+helm upgrade --install karpenter-crd karpenter-provider-gcp/karpenter-crd
+```
+
+Then install the controller:
+
+```bash
+helm upgrade --install karpenter karpenter-provider-gcp/karpenter \
+  --namespace karpenter-system --create-namespace \
+  --set "controller.settings.projectID=<project>" \
+  --set "controller.settings.clusterName=<cluster>" \
+  --set "controller.settings.clusterLocation=<region-or-zone>"
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -1,0 +1,537 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    {{- with .Values.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: gcenodeclasses.karpenter.k8s.gcp
+spec:
+  group: karpenter.k8s.gcp
+  names:
+    categories:
+    - karpenter
+    kind: GCENodeClass
+    listKind: GCENodeClassList
+    plural: gcenodeclasses
+    shortNames:
+    - gcenc
+    - gcencs
+    singular: gcenodeclass
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: GCENodeClass is the Schema for the GCENodeClass API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              GCENodeClassSpec is the top level specification for the GCP Karpenter Provider.
+              This will contain the configuration necessary to launch instances in GCP.
+            properties:
+              disks:
+                description: Disk defines the disks to attach to the provisioned instance.
+                items:
+                  properties:
+                    boot:
+                      description: Indicates that this is a boot disk.
+                      type: boolean
+                    category:
+                      description: The category of the disk (e.g., pd-standard, pd-balanced,
+                        pd-ssd, pd-extreme).
+                      enum:
+                      - hyperdisk-balanced
+                      - hyperdisk-balanced-high-availability
+                      - hyperdisk-extreme
+                      - hyperdisk-ml
+                      - hyperdisk-throughput
+                      - local-ssd
+                      - pd-balanced
+                      - pd-extreme
+                      - pd-ssd
+                      - pd-standard
+                      type: string
+                    kmsKeyName:
+                      description: |-
+                        KMSKeyName is the Cloud KMS key to use for disk encryption.
+                        Format: projects/{project}/locations/{region}/keyRings/{keyring}/cryptoKeys/{key}
+                        Optionally, you can specify a version: projects/{project}/locations/{region}/keyRings/{keyring}/cryptoKeys/{key}/cryptoKeyVersions/{version}
+                      pattern: ^projects/[^/]+/locations/[^/]+/keyRings/[^/]+/cryptoKeys/[^/]+(/cryptoKeyVersions/[^/]+)?$
+                      type: string
+                    kmsKeyServiceAccount:
+                      description: |-
+                        KMSKeyServiceAccount is the service account to use for accessing the KMS key.
+                        If not specified, the Compute Engine default service account will be used.
+                      pattern: ^[^@]+@(developer\.gserviceaccount\.com|[^@]+\.iam\.gserviceaccount\.com)$
+                      type: string
+                    provisionedIOPS:
+                      description: |-
+                        ProvisionedIOPS is the number of I/O operations per second to provision for the disk.
+                        Applicable for: pd-extreme (2,500–120,000), hyperdisk-balanced (3,000–160,000),
+                        hyperdisk-balanced-high-availability (up to 100,000), and hyperdisk-extreme (up to 350,000).
+                      format: int64
+                      type: integer
+                    provisionedThroughput:
+                      description: |-
+                        ProvisionedThroughput is the throughput in MiB/s to provision for the disk.
+                        Applicable for: hyperdisk-balanced (140–2,400 MiB/s), hyperdisk-balanced-high-availability (up to 1,200 MiB/s),
+                        hyperdisk-throughput (up to 2,400 MiB/s), and hyperdisk-ml (up to 1,200,000 MiB/s).
+                      format: int64
+                      type: integer
+                    secondaryBootImage:
+                      description: SecondaryBootImage is the secondary boot disk image
+                        name (e.g. global/images/DISK_IMAGE_NAME).
+                      type: string
+                    secondaryBootMode:
+                      description: SecondaryBootMode is the secondary boot disk mode
+                        (e.g. CONTAINER_IMAGE_CACHE).
+                      enum:
+                      - MODE_UNSPECIFIED
+                      - CONTAINER_IMAGE_CACHE
+                      type: string
+                    sizeGiB:
+                      description: 'SizeGiB is the size of the disk. Unit: GiB'
+                      format: int32
+                      type: integer
+                      x-kubernetes-validations:
+                      - message: size invalid
+                        rule: self >= 10
+                  type: object
+                  x-kubernetes-validations:
+                  - message: provisionedIOPS is only applicable for pd-extreme, hyperdisk-balanced,
+                      hyperdisk-balanced-high-availability, and hyperdisk-extreme
+                    rule: '!has(self.provisionedIOPS) || self.category in [''pd-extreme'',
+                      ''hyperdisk-balanced'', ''hyperdisk-balanced-high-availability'',
+                      ''hyperdisk-extreme'']'
+                  - message: provisionedThroughput is only applicable for hyperdisk-balanced,
+                      hyperdisk-balanced-high-availability, hyperdisk-throughput,
+                      and hyperdisk-ml
+                    rule: '!has(self.provisionedThroughput) || self.category in [''hyperdisk-balanced'',
+                      ''hyperdisk-balanced-high-availability'', ''hyperdisk-throughput'',
+                      ''hyperdisk-ml'']'
+                  - message: provisionedIOPS and provisionedThroughput must both be
+                      set or both be unset for hyperdisk-balanced and hyperdisk-balanced-high-availability
+                    rule: '!(self.category in [''hyperdisk-balanced'', ''hyperdisk-balanced-high-availability''])
+                      || (has(self.provisionedIOPS) == has(self.provisionedThroughput))'
+                maxItems: 10
+                type: array
+              imageFamily:
+                description: |-
+                  ImageFamily dictates the instance template used when generating launch templates.
+                  If no ImageSelectorTerms alias is specified, this field is required.
+                enum:
+                - Ubuntu
+                - ContainerOptimizedOS
+                type: string
+              imageSelectorTerms:
+                description: |-
+                  ImageSelectorTerms is a list of or image selector terms. The terms are ORed.
+                  Remove or adjust mutual exclusivity rules since there's only one field
+                items:
+                  description: |-
+                    ImageSelectorTerm defines selection logic for an image used by Karpenter to launch nodes.
+                    If multiple fields are used for selection, the requirements are ANDed.
+                  properties:
+                    alias:
+                      description: |-
+                        Alias specifies which GKE image to select.
+                        Valid families include: ContainerOptimizedOS,Ubuntu
+                      maxLength: 60
+                      type: string
+                      x-kubernetes-validations:
+                      - message: '''alias'' is improperly formatted, must match the
+                          format ''family@version'''
+                        rule: self.matches('^[a-zA-Z0-9]+@.+$')
+                      - message: 'family is not supported, must be one of the following:
+                          ''ContainerOptimizedOS,Ubuntu'''
+                        rule: self.find('^[^@]+') in ['ContainerOptimizedOS', 'Ubuntu']
+                    id:
+                      description: ID specifies which GKE image to select.
+                      maxLength: 160
+                      type: string
+                      x-kubernetes-validations:
+                      - message: '''id'' is improperly formatted, must match the format
+                          ''id'''
+                        rule: self.matches('^.*$')
+                  type: object
+                maxItems: 30
+                minItems: 1
+                type: array
+                x-kubernetes-validations:
+                - message: '''alias'' is improperly formatted, must match the format
+                    ''family'''
+                  rule: self.all(x, has(x.alias) || has(x.id))
+              kubeletConfiguration:
+                description: |-
+                  KubeletConfiguration defines args to be used when configuring kubelet on provisioned nodes.
+                  They are a vswitch of the upstream types, recognizing not all options may be supported.
+                  Wherever possible, the types and names should reflect the upstream kubelet types.
+                properties:
+                  clusterDNS:
+                    description: |-
+                      clusterDNS is a list of IP addresses for the cluster DNS server.
+                      Note that not all providers may use all addresses.
+                    items:
+                      type: string
+                    type: array
+                  cpuCFSQuota:
+                    description: CPUCFSQuota enables CPU CFS quota enforcement for
+                      containers that specify CPU limits.
+                    type: boolean
+                  evictionHard:
+                    additionalProperties:
+                      type: string
+                    description: EvictionHard is the map of signal names to quantities
+                      that define hard eviction thresholds
+                    maxProperties: 10
+                    type: object
+                    x-kubernetes-validations:
+                    - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                      rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                  evictionMaxPodGracePeriod:
+                    description: |-
+                      EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
+                      response to soft eviction thresholds being met.
+                    format: int32
+                    type: integer
+                  evictionSoft:
+                    additionalProperties:
+                      type: string
+                    description: EvictionSoft is the map of signal names to quantities
+                      that define soft eviction thresholds
+                    maxProperties: 10
+                    type: object
+                    x-kubernetes-validations:
+                    - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                      rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                  evictionSoftGracePeriod:
+                    additionalProperties:
+                      type: string
+                    description: EvictionSoftGracePeriod is the map of signal names
+                      to quantities that define grace periods for each eviction signal
+                    maxProperties: 10
+                    type: object
+                    x-kubernetes-validations:
+                    - message: valid keys for evictionSoftGracePeriod are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
+                      rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                  imageGCHighThresholdPercent:
+                    description: |-
+                      ImageGCHighThresholdPercent is the percent of disk usage after which image
+                      garbage collection is always run. The percent is calculated by dividing this
+                      field value by 100, so this field must be between 0 and 100, inclusive.
+                      When specified, the value must be greater than ImageGCLowThresholdPercent.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                  imageGCLowThresholdPercent:
+                    description: |-
+                      ImageGCLowThresholdPercent is the percent of disk usage before which image
+                      garbage collection is never run. Lowest disk usage to garbage collect to.
+                      The percent is calculated by dividing this field value by 100,
+                      so the field value must be between 0 and 100, inclusive.
+                      When specified, the value must be less than imageGCHighThresholdPercent
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                  kubeReserved:
+                    additionalProperties:
+                      type: string
+                    description: KubeReserved contains resources reserved for Kubernetes
+                      system components.
+                    maxProperties: 10
+                    type: object
+                    x-kubernetes-validations:
+                    - message: valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']
+                      rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage'
+                        || x=='pid')
+                    - message: kubeReserved value cannot be a negative resource quantity
+                      rule: self.all(x, !self[x].startsWith('-'))
+                  maxPods:
+                    description: |-
+                      MaxPods is an override for the maximum number of pods that can run on
+                      a worker node instance.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  podsPerCore:
+                    description: |-
+                      PodsPerCore is an override for the number of pods that can run on a worker node
+                      instance based on the number of cpu cores. This value cannot exceed MaxPods, so, if
+                      MaxPods is a lower value, that value will be used.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  systemReserved:
+                    additionalProperties:
+                      type: string
+                    description: SystemReserved contains resources reserved for OS
+                      system daemons and kernel memory.
+                    maxProperties: 10
+                    type: object
+                    x-kubernetes-validations:
+                    - message: valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']
+                      rule: self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage'
+                        || x=='pid')
+                    - message: systemReserved value cannot be a negative resource
+                        quantity
+                      rule: self.all(x, !self[x].startsWith('-'))
+                type: object
+                x-kubernetes-validations:
+                - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent
+                  rule: 'has(self.imageGCHighThresholdPercent) && has(self.imageGCLowThresholdPercent)
+                    ?  self.imageGCHighThresholdPercent > self.imageGCLowThresholdPercent  :
+                    true'
+                - message: evictionSoft OwnerKey does not have a matching evictionSoftGracePeriod
+                  rule: has(self.evictionSoft) ? self.evictionSoft.all(e, (e in self.evictionSoftGracePeriod)):true
+                - message: evictionSoftGracePeriod OwnerKey does not have a matching
+                    evictionSoft
+                  rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e,
+                    (e in self.evictionSoft)):true
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels to be applied on GCE VM instance.
+                maxProperties: 20
+                type: object
+                x-kubernetes-validations:
+                - message: empty tag keys aren't supported
+                  rule: self.all(k, k != '')
+                - message: tag contains a restricted tag matching gce:gce-cluster-name
+                  rule: self.all(k, k !='gce:gce-cluster-name')
+                - message: tag contains a restricted tag matching kubernetes.io/cluster/
+                  rule: self.all(k, !k.startsWith('kubernetes.io/cluster') )
+                - message: tag contains a restricted tag matching karpenter.sh/nodepool
+                  rule: self.all(k, k != 'karpenter.sh/nodepool')
+                - message: tag contains a restricted tag matching karpenter.sh/nodeclaim
+                  rule: self.all(k, k !='karpenter.sh/nodeclaim')
+                - message: tag contains a restricted tag matching karpenter.k8s.gcp/gcenodeclass
+                  rule: self.all(k, k !='karpenter.k8s.gcp/gcenodeclass')
+              metadata:
+                additionalProperties:
+                  type: string
+                description: Metadata contains key/value pairs to set as instance
+                  metadata
+                type: object
+              networkConfig:
+                description: NetworkConfig allows overriding per-interface network
+                  settings for provisioned nodes.
+                properties:
+                  networkInterfaces:
+                    description: |-
+                      NetworkInterfaces is a list of per-interface overrides matched to the node pool template
+                      interfaces by position (index 0 = primary interface). Interfaces beyond the end of this
+                      list are left unchanged from the template.
+                    items:
+                      description: NetworkInterface defines overrides for a single
+                        network interface on provisioned nodes.
+                      properties:
+                        enableExternalIPAccess:
+                          description: |-
+                            EnableExternalIPAccess, when set to false, removes all access configs from this interface
+                            so that the node has no external (public) IP address. Setting it to true or leaving it
+                            unset inherits the template's access configs without modification — it does not add an
+                            external IP if the template has none.
+                          type: boolean
+                        subnetwork:
+                          description: |-
+                            Subnetwork is the self-link or partial URL of the subnetwork to use for this interface
+                            (e.g. "regions/us-central1/subnetworks/my-subnet").
+                            When unset, the subnetwork is inherited from the node pool template.
+                            Note: to override the pod IP range name on an interface, use spec.subnetRangeName instead.
+                          type: string
+                      type: object
+                    maxItems: 8
+                    type: array
+                type: object
+              networkTags:
+                description: NetworkTags is a list of network tags to apply to the
+                  node.
+                items:
+                  description: |-
+                    NetworkTag represents a single GCE network tag value.
+                    Network tags must be RFC1035 compliant, start with a lowercase letter, and contain only
+                    lowercase letters, digits, and hyphens.
+                  maxLength: 63
+                  minLength: 1
+                  pattern: ^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$
+                  type: string
+                maxItems: 20
+                type: array
+              serviceAccount:
+                description: ServiceAccount is the GCP IAM service account email to
+                  assign to the instance
+                pattern: ^[^@]+@(developer\.gserviceaccount\.com|[^@]+\.iam\.gserviceaccount\.com)$
+                type: string
+              shieldedInstanceConfig:
+                description: ShieldedInstanceConfig is the Shielded VM configuration
+                  for the instance.
+                properties:
+                  enableIntegrityMonitoring:
+                    description: EnableIntegrityMonitoring defines whether the instance
+                      has integrity monitoring enabled.
+                    type: boolean
+                  enableSecureBoot:
+                    description: EnableSecureBoot defines whether the instance has
+                      Secure Boot enabled.
+                    type: boolean
+                  enableVtpm:
+                    description: EnableVtpm defines whether the instance has the vTPM
+                      enabled.
+                    type: boolean
+                type: object
+              subnetRangeName:
+                description: |-
+                  SubnetRangeName is the name of the subnetwork secondary IPv4 range from which
+                  to allocate pod IP addresses. If not specified, the range inherited from the node
+                  pool instance template is used (typically the default pods range).
+                maxLength: 63
+                minLength: 1
+                pattern: ^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$
+                type: string
+            required:
+            - imageSelectorTerms
+            type: object
+          status:
+            description: GCENodeClassStatus contains the resolved state of the GCENodeClass
+            properties:
+              conditions:
+                description: Conditions contains signals for health and readiness
+                items:
+                  description: Condition aliases the upstream type and adds additional
+                    helper methods
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              images:
+                description: |-
+                  Image contains the current image that are available to the
+                  cluster under the Image selectors.
+                items:
+                  description: Image contains resolved image selector values utilized
+                    for node launch
+                  properties:
+                    requirements:
+                      description: Requirements of the Image to be utilized on an
+                        instance type
+                      items:
+                        description: |-
+                          A node selector requirement is a selector that contains values, a key, and an operator
+                          that relates the key and values.
+                        properties:
+                          key:
+                            description: The label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: |-
+                              Represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                            type: string
+                          values:
+                            description: |-
+                              An array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. If the operator is Gt or Lt, the values
+                              array must have a single element, which will be interpreted as an integer.
+                              This array is replaced during a strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    sourceImage:
+                      description: SourceImage represents the source image, format
+                        like projects/gke-node-images/global/images/gke-1309-gke1046000-cos-113-18244-291-9-c-pre
+                      type: string
+                  required:
+                  - requirements
+                  - sourceImage
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -345,32 +345,44 @@ spec:
                 description: NetworkConfig allows overriding per-interface network
                   settings for provisioned nodes.
                 properties:
-                  networkInterfaces:
+                  additionalNetworkInterfaces:
                     description: |-
-                      NetworkInterfaces is a list of per-interface overrides matched to the node pool template
-                      interfaces by position (index 0 = primary interface). Interfaces beyond the end of this
-                      list are left unchanged from the template.
+                      AdditionalNetworkInterfaces adds secondary network interfaces to provisioned nodes.
+                      Each entry must specify a subnetwork.
+                      Mirrors GKE node pool network_config.additional_node_network_configs.
                     items:
-                      description: NetworkInterface defines overrides for a single
-                        network interface on provisioned nodes.
+                      description: |-
+                        AdditionalNetworkInterface defines a secondary network interface on provisioned nodes.
+                        Mirrors an entry in GKE node pool network_config.additional_node_network_configs.
                       properties:
-                        enableExternalIPAccess:
+                        network:
                           description: |-
-                            EnableExternalIPAccess, when set to false, removes all access configs from this interface
-                            so that the node has no external (public) IP address. Setting it to true or leaving it
-                            unset inherits the template's access configs without modification — it does not add an
-                            external IP if the template has none.
-                          type: boolean
-                        subnetwork:
-                          description: |-
-                            Subnetwork is the self-link or partial URL of the subnetwork to use for this interface
-                            (e.g. "regions/us-central1/subnetworks/my-subnet").
-                            When unset, the subnetwork is inherited from the node pool template.
-                            Note: to override the pod IP range name on an interface, use spec.subnetRangeName instead.
+                            Network is the VPC network for this interface.
+                            When unset, defaults to the cluster's network.
                           type: string
+                        subnetwork:
+                          description: Subnetwork is the subnetwork for this interface.
+                            Required.
+                          minLength: 1
+                          type: string
+                      required:
+                      - subnetwork
                       type: object
-                    maxItems: 8
+                    maxItems: 7
                     type: array
+                  enablePrivateNodes:
+                    description: |-
+                      EnablePrivateNodes controls whether provisioned nodes have internal IP addresses only
+                      (no external IP). When unset, defaults to the cluster's EnablePrivateNodes setting.
+                      Mirrors GKE node pool network_config.enable_private_nodes.
+                    type: boolean
+                  subnetwork:
+                    description: |-
+                      Subnetwork is the subnetwork for the primary network interface.
+                      Format: projects/{project}/regions/{region}/subnetworks/{name}
+                      When unset, defaults to the cluster's primary subnetwork.
+                      Mirrors GKE node pool network_config.subnetwork.
+                    type: string
                 type: object
               networkTags:
                 description: NetworkTags is a list of network tags to apply to the

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
@@ -1,0 +1,379 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    {{- with .Values.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: nodeclaims.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+    - karpenter
+    kind: NodeClaim
+    listKind: NodeClaimList
+    plural: nodeclaims
+    singular: nodeclaim
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+      name: Type
+      type: string
+    - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+      name: Capacity
+      type: string
+    - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+      name: Zone
+      type: string
+    - jsonPath: .status.nodeName
+      name: Node
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.imageID
+      name: ImageID
+      priority: 1
+      type: string
+    - jsonPath: .status.providerID
+      name: ID
+      priority: 1
+      type: string
+    - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+      name: NodePool
+      priority: 1
+      type: string
+    - jsonPath: .spec.nodeClassRef.name
+      name: NodeClass
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Drifted")].status
+      name: Drifted
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: NodeClaim is the Schema for the NodeClaims API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NodeClaimSpec describes the desired state of the NodeClaim
+            properties:
+              expireAfter:
+                default: 720h
+                description: |-
+                  ExpireAfter is the duration the controller will wait
+                  before terminating a node, measured from when the node is created. This
+                  is useful to implement features like eventually consistent node upgrade,
+                  memory leak protection, and disruption testing.
+                pattern: ^(([0-9]+(s|m|h))+|Never)$
+                type: string
+              nodeClassRef:
+                description: NodeClassRef is a reference to an object that defines
+                  provider specific configuration
+                properties:
+                  group:
+                    description: API version of the referent
+                    pattern: ^[^/]*$
+                    type: string
+                    x-kubernetes-validations:
+                    - message: group may not be empty
+                      rule: self != ''
+                  kind:
+                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                    type: string
+                    x-kubernetes-validations:
+                    - message: kind may not be empty
+                      rule: self != ''
+                  name:
+                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                    x-kubernetes-validations:
+                    - message: name may not be empty
+                      rule: self != ''
+                required:
+                - group
+                - kind
+                - name
+                type: object
+              requirements:
+                description: Requirements are layered with GetLabels and applied to
+                  every node.
+                items:
+                  description: |-
+                    A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                    and minValues that represent the requirement to have at least that many values.
+                  properties:
+                    key:
+                      description: The label key that the selector applies to.
+                      type: string
+                    minValues:
+                      description: |-
+                        This field is ALPHA and can be dropped or replaced at any time
+                        MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                      maximum: 50
+                      minimum: 1
+                      type: integer
+                    operator:
+                      description: |-
+                        Represents a key's relationship to a set of values.
+                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                      type: string
+                    values:
+                      description: |-
+                        An array of string values. If the operator is In or NotIn,
+                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                        the values array must be empty. If the operator is Gt or Lt, the values
+                        array must have a single element, which will be interpreted as an integer.
+                        This array is replaced during a strategic merge patch.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  required:
+                  - key
+                  - operator
+                  type: object
+                maxItems: 100
+                type: array
+                x-kubernetes-validations:
+                - message: requirements with operator 'In' must have a value defined
+                  rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 :
+                    true)'
+                - message: requirements operator 'Gt' or 'Lt' must have a single positive
+                    integer value
+                  rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'')
+                    ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                - message: requirements with 'minValues' must have at least that many
+                    values specified in the 'values' field
+                  rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ?
+                    x.values.size() >= x.minValues : true)'
+              resources:
+                description: Resources models the resource requirements for the NodeClaim
+                  to launch
+                properties:
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: Requests describes the minimum required resources
+                      for the NodeClaim to launch
+                    type: object
+                type: object
+              startupTaints:
+                description: |-
+                  StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                  within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                  daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                  purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                items:
+                  description: |-
+                    The node this Taint is attached to has the "effect" on
+                    any pod that does not tolerate the Taint.
+                  properties:
+                    effect:
+                      description: |-
+                        Required. The effect of the taint on pods
+                        that do not tolerate the taint.
+                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Required. The taint key to be applied to a node.
+                      type: string
+                    timeAdded:
+                      description: TimeAdded represents the time at which the taint
+                        was added.
+                      format: date-time
+                      type: string
+                    value:
+                      description: The taint value corresponding to the taint key.
+                      type: string
+                  required:
+                  - effect
+                  - key
+                  type: object
+                type: array
+              taints:
+                description: Taints will be applied to the NodeClaim's node.
+                items:
+                  description: |-
+                    The node this Taint is attached to has the "effect" on
+                    any pod that does not tolerate the Taint.
+                  properties:
+                    effect:
+                      description: |-
+                        Required. The effect of the taint on pods
+                        that do not tolerate the taint.
+                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Required. The taint key to be applied to a node.
+                      type: string
+                    timeAdded:
+                      description: TimeAdded represents the time at which the taint
+                        was added.
+                      format: date-time
+                      type: string
+                    value:
+                      description: The taint value corresponding to the taint key.
+                      type: string
+                  required:
+                  - effect
+                  - key
+                  type: object
+                type: array
+              terminationGracePeriod:
+                description: |-
+                  TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                  Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                  This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                  When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                  Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                  If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                  that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                  The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                  If left undefined, the controller will wait indefinitely for pods to be drained.
+                pattern: ^([0-9]+(s|m|h))+$
+                type: string
+            required:
+            - nodeClassRef
+            - requirements
+            type: object
+            x-kubernetes-validations:
+            - message: spec is immutable
+              rule: self == oldSelf
+          status:
+            description: NodeClaimStatus defines the observed state of NodeClaim
+            properties:
+              allocatable:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Allocatable is the estimated allocatable capacity of
+                  the node
+                type: object
+              capacity:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Capacity is the estimated full capacity of the node
+                type: object
+              conditions:
+                description: Conditions contains signals for health and readiness
+                items:
+                  description: Condition aliases the upstream type and adds additional
+                    helper methods
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              imageID:
+                description: ImageID is an identifier for the image that runs on the
+                  node
+                type: string
+              lastPodEventTime:
+                description: |-
+                  LastPodEventTime is updated with the last time a pod was scheduled
+                  or removed from the node. A pod going terminal or terminating
+                  is also considered as removed.
+                format: date-time
+                type: string
+              nodeName:
+                description: NodeName is the name of the corresponding node object
+                type: string
+              providerID:
+                description: ProviderID of the corresponding node object
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeclaims.yaml
@@ -12,368 +12,383 @@ spec:
   group: karpenter.sh
   names:
     categories:
-    - karpenter
+      - karpenter
     kind: NodeClaim
     listKind: NodeClaimList
     plural: nodeclaims
     singular: nodeclaim
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
-      name: Type
-      type: string
-    - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
-      name: Capacity
-      type: string
-    - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
-      name: Zone
-      type: string
-    - jsonPath: .status.nodeName
-      name: Node
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.imageID
-      name: ImageID
-      priority: 1
-      type: string
-    - jsonPath: .status.providerID
-      name: ID
-      priority: 1
-      type: string
-    - jsonPath: .metadata.labels.karpenter\.sh/nodepool
-      name: NodePool
-      priority: 1
-      type: string
-    - jsonPath: .spec.nodeClassRef.name
-      name: NodeClass
-      priority: 1
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Drifted")].status
-      name: Drifted
-      priority: 1
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: NodeClaim is the Schema for the NodeClaims API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: NodeClaimSpec describes the desired state of the NodeClaim
-            properties:
-              expireAfter:
-                default: 720h
-                description: |-
-                  ExpireAfter is the duration the controller will wait
-                  before terminating a node, measured from when the node is created. This
-                  is useful to implement features like eventually consistent node upgrade,
-                  memory leak protection, and disruption testing.
-                pattern: ^(([0-9]+(s|m|h))+|Never)$
-                type: string
-              nodeClassRef:
-                description: NodeClassRef is a reference to an object that defines
-                  provider specific configuration
-                properties:
-                  group:
-                    description: API version of the referent
-                    pattern: ^[^/]*$
-                    type: string
-                    x-kubernetes-validations:
-                    - message: group may not be empty
-                      rule: self != ''
-                  kind:
-                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                    type: string
-                    x-kubernetes-validations:
-                    - message: kind may not be empty
-                      rule: self != ''
-                  name:
-                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                    type: string
-                    x-kubernetes-validations:
-                    - message: name may not be empty
-                      rule: self != ''
-                required:
-                - group
-                - kind
-                - name
-                type: object
-              requirements:
-                description: Requirements are layered with GetLabels and applied to
-                  every node.
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.labels.node\.kubernetes\.io/instance-type
+          name: Type
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/capacity-type
+          name: Capacity
+          type: string
+        - jsonPath: .metadata.labels.topology\.kubernetes\.io/zone
+          name: Zone
+          type: string
+        - jsonPath: .status.nodeName
+          name: Node
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.imageID
+          name: ImageID
+          priority: 1
+          type: string
+        - jsonPath: .status.providerID
+          name: ID
+          priority: 1
+          type: string
+        - jsonPath: .metadata.labels.karpenter\.sh/nodepool
+          name: NodePool
+          priority: 1
+          type: string
+        - jsonPath: .spec.nodeClassRef.name
+          name: NodeClass
+          priority: 1
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Drifted")].status
+          name: Drifted
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodeClaim is the Schema for the NodeClaims API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeClaimSpec describes the desired state of the NodeClaim
+              properties:
+                expireAfter:
+                  default: 720h
                   description: |-
-                    A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
-                    and minValues that represent the requirement to have at least that many values.
+                    ExpireAfter is the duration the controller will wait
+                    before terminating a node, measured from when the node is created. This
+                    is useful to implement features like eventually consistent node upgrade,
+                    memory leak protection, and disruption testing.
+                  pattern: ^(([0-9]+(s|m|h))+|Never)$
+                  type: string
+                nodeClassRef:
+                  description: NodeClassRef is a reference to an object that defines provider specific configuration
                   properties:
-                    key:
-                      description: The label key that the selector applies to.
+                    group:
+                      description: API version of the referent
+                      pattern: ^[^/]*$
                       type: string
-                    minValues:
-                      description: |-
-                        This field is ALPHA and can be dropped or replaced at any time
-                        MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
-                      maximum: 50
-                      minimum: 1
-                      type: integer
-                    operator:
-                      description: |-
-                        Represents a key's relationship to a set of values.
-                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                      x-kubernetes-validations:
+                        - message: group may not be empty
+                          rule: self != ''
+                    kind:
+                      description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                       type: string
-                    values:
-                      description: |-
-                        An array of string values. If the operator is In or NotIn,
-                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                        the values array must be empty. If the operator is Gt or Lt, the values
-                        array must have a single element, which will be interpreted as an integer.
-                        This array is replaced during a strategic merge patch.
-                      items:
-                        type: string
-                      type: array
-                      x-kubernetes-list-type: atomic
+                      x-kubernetes-validations:
+                        - message: kind may not be empty
+                          rule: self != ''
+                    name:
+                      description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                      x-kubernetes-validations:
+                        - message: name may not be empty
+                          rule: self != ''
                   required:
-                  - key
-                  - operator
+                    - group
+                    - kind
+                    - name
                   type: object
-                maxItems: 100
-                type: array
-                x-kubernetes-validations:
-                - message: requirements with operator 'In' must have a value defined
-                  rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 :
-                    true)'
-                - message: requirements operator 'Gt' or 'Lt' must have a single positive
-                    integer value
-                  rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'')
-                    ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
-                - message: requirements with 'minValues' must have at least that many
-                    values specified in the 'values' field
-                  rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ?
-                    x.values.size() >= x.minValues : true)'
-              resources:
-                description: Resources models the resource requirements for the NodeClaim
-                  to launch
-                properties:
-                  requests:
-                    additionalProperties:
-                      anyOf:
+                requirements:
+                  description: Requirements are layered with GetLabels and applied to every node.
+                  items:
+                    description: |-
+                      A node selector requirement is a selector that contains values, a key, an operator that relates the key and values
+                      and minValues that represent the requirement to have at least that many values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                      minValues:
+                        description: |-
+                          This field is ALPHA and can be dropped or replaced at any time
+                          MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                        maximum: 50
+                        minimum: 1
+                        type: integer
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.
+                        enum:
+                          - Gte
+                          - Lte
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                        type: string
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt, Lt, Gte, or Lte, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt', 'Lt', 'Gte', or 'Lte' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'' || x.operator == ''Gte'' || x.operator == ''Lte'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                      rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                resources:
+                  description: Resources models the resource requirements for the NodeClaim to launch
+                  properties:
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: Requests describes the minimum required resources for the NodeClaim to launch
+                      type: object
+                  type: object
+                startupTaints:
+                  description: |-
+                    StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                    within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                    daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                    purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: TimeAdded represents the time at which the taint was added.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                taints:
+                  description: Taints will be applied to the NodeClaim's node.
+                  items:
+                    description: |-
+                      The node this Taint is attached to has the "effect" on
+                      any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: |-
+                          Required. The effect of the taint on pods
+                          that do not tolerate the taint.
+                          Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                        enum:
+                          - NoSchedule
+                          - PreferNoSchedule
+                          - NoExecute
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                        minLength: 1
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                      timeAdded:
+                        description: TimeAdded represents the time at which the taint was added.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                    required:
+                      - effect
+                      - key
+                    type: object
+                  type: array
+                terminationGracePeriod:
+                  description: |-
+                    TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                    Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                    This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                    When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                    Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                    If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                    that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                    The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                    If left undefined, the controller will wait indefinitely for pods to be drained.
+                  pattern: ^([0-9]+(s|m|h))+$
+                  type: string
+              required:
+                - nodeClassRef
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: spec is immutable
+                  rule: self == oldSelf
+            status:
+              description: NodeClaimStatus defines the observed state of NodeClaim
+              properties:
+                allocatable:
+                  additionalProperties:
+                    anyOf:
                       - type: integer
                       - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: Requests describes the minimum required resources
-                      for the NodeClaim to launch
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Allocatable is the estimated allocatable capacity of the node
+                  type: object
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity is the estimated full capacity of the node
+                  type: object
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        pattern: ^([A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?|)$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - status
+                      - type
                     type: object
-                type: object
-              startupTaints:
-                description: |-
-                  StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
-                  within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
-                  daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
-                  purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
-                items:
+                  type: array
+                imageID:
+                  description: ImageID is an identifier for the image that runs on the node
+                  type: string
+                lastPodEventTime:
                   description: |-
-                    The node this Taint is attached to has the "effect" on
-                    any pod that does not tolerate the Taint.
-                  properties:
-                    effect:
-                      description: |-
-                        Required. The effect of the taint on pods
-                        that do not tolerate the taint.
-                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-                      type: string
-                    key:
-                      description: Required. The taint key to be applied to a node.
-                      type: string
-                    timeAdded:
-                      description: TimeAdded represents the time at which the taint
-                        was added.
-                      format: date-time
-                      type: string
-                    value:
-                      description: The taint value corresponding to the taint key.
-                      type: string
-                  required:
-                  - effect
-                  - key
-                  type: object
-                type: array
-              taints:
-                description: Taints will be applied to the NodeClaim's node.
-                items:
-                  description: |-
-                    The node this Taint is attached to has the "effect" on
-                    any pod that does not tolerate the Taint.
-                  properties:
-                    effect:
-                      description: |-
-                        Required. The effect of the taint on pods
-                        that do not tolerate the taint.
-                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-                      type: string
-                    key:
-                      description: Required. The taint key to be applied to a node.
-                      type: string
-                    timeAdded:
-                      description: TimeAdded represents the time at which the taint
-                        was added.
-                      format: date-time
-                      type: string
-                    value:
-                      description: The taint value corresponding to the taint key.
-                      type: string
-                  required:
-                  - effect
-                  - key
-                  type: object
-                type: array
-              terminationGracePeriod:
-                description: |-
-                  TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
-
-                  Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
-
-                  This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
-                  When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
-
-                  Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
-                  If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
-                  that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
-
-                  The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
-                  If left undefined, the controller will wait indefinitely for pods to be drained.
-                pattern: ^([0-9]+(s|m|h))+$
-                type: string
-            required:
-            - nodeClassRef
-            - requirements
-            type: object
-            x-kubernetes-validations:
-            - message: spec is immutable
-              rule: self == oldSelf
-          status:
-            description: NodeClaimStatus defines the observed state of NodeClaim
-            properties:
-              allocatable:
-                additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                description: Allocatable is the estimated allocatable capacity of
-                  the node
-                type: object
-              capacity:
-                additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                description: Capacity is the estimated full capacity of the node
-                type: object
-              conditions:
-                description: Conditions contains signals for health and readiness
-                items:
-                  description: Condition aliases the upstream type and adds additional
-                    helper methods
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-              imageID:
-                description: ImageID is an identifier for the image that runs on the
-                  node
-                type: string
-              lastPodEventTime:
-                description: |-
-                  LastPodEventTime is updated with the last time a pod was scheduled
-                  or removed from the node. A pod going terminal or terminating
-                  is also considered as removed.
-                format: date-time
-                type: string
-              nodeName:
-                description: NodeName is the name of the corresponding node object
-                type: string
-              providerID:
-                description: ProviderID of the corresponding node object
-                type: string
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                    LastPodEventTime is updated with the last time a pod was scheduled
+                    or removed from the node. A pod going terminal or terminating
+                    is also considered as removed.
+                  format: date-time
+                  type: string
+                nodeName:
+                  description: NodeName is the name of the corresponding node object
+                  type: string
+                providerID:
+                  description: ProviderID of the corresponding node object
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeoverlays.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeoverlays.yaml
@@ -1,0 +1,229 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    {{- with .Values.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: nodeoverlays.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+      - karpenter
+    kind: NodeOverlay
+    listKind: NodeOverlayList
+    plural: nodeoverlays
+    shortNames:
+      - overlays
+    singular: nodeoverlay
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: |-
+                    Capacity adds extended resources only, and does not replace any existing resources.
+                    These extended resources are appended to the node's existing resource list.
+                    Note: This field does not modify or override standard resources like cpu, memory, ephemeral-storage, or pods.
+                  type: object
+                  x-kubernetes-validations:
+                    - message: invalid resource restricted
+                      rule: self.all(x, !(x in ['cpu', 'memory', 'ephemeral-storage', 'pods']))
+                price:
+                  description: Price specifies amount for an instance types that match the specified labels. Users can override prices using a signed float representing the price override
+                  pattern: ^\d+(\.\d+)?$
+                  type: string
+                priceAdjustment:
+                  description: |-
+                    PriceAdjustment specifies the price change for matching instance types. Accepts either:
+                    - A fixed price modifier (e.g., -0.5, 1.2)
+                    - A percentage modifier (e.g., +10% for increase, -15% for decrees)
+                  pattern: ^(([+-]{1}(\d*\.?\d+))|(\+{1}\d*\.?\d+%)|(^(-\d{1,2}(\.\d+)?%)$)|(-100%))$
+                  type: string
+                requirements:
+                  description: |-
+                    Requirements constrain when this NodeOverlay is applied during scheduling simulations.
+                    These requirements can match:
+                    - Well-known labels (e.g., node.kubernetes.io/instance-type, karpenter.sh/nodepool)
+                    - Custom labels from NodePool's spec.template.labels
+                  items:
+                    description: |-
+                      A node selector requirement is a selector that contains values, a key, and an operator
+                      that relates the key and values.
+                    properties:
+                      key:
+                        description: The label key that the selector applies to.
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                        x-kubernetes-validations:
+                          - message: label domain "kubernetes.io" is restricted
+                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
+                          - message: label domain "k8s.io" is restricted
+                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
+                          - message: label domain "karpenter.sh" is restricted
+                            rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                          - message: label "kubernetes.io/hostname" is restricted
+                            rule: self != "kubernetes.io/hostname"
+                      operator:
+                        description: |-
+                          Represents a key's relationship to a set of values.
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                        type: string
+                        enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          - Gt
+                          - Lt
+                      values:
+                        description: |-
+                          An array of string values. If the operator is In or NotIn,
+                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                          the values array must be empty. If the operator is Gt or Lt, the values
+                          array must have a single element, which will be interpreted as an integer.
+                          This array is replaced during a strategic merge patch.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        maxLength: 63
+                        pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  maxItems: 100
+                  type: array
+                  x-kubernetes-validations:
+                    - message: requirements with operator 'NotIn' must have a value defined
+                      rule: 'self.all(x, x.operator == ''NotIn'' ? x.values.size() != 0 : true)'
+                    - message: requirements with operator 'In' must have a value defined
+                      rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                weight:
+                  description: |-
+                    Weight defines the priority of this NodeOverlay when overriding node attributes.
+                    NodeOverlays with higher numerical weights take precedence over those with lower weights.
+                    If no weight is specified, the NodeOverlay is treated as having a weight of 0.
+                    When multiple NodeOverlays have identical weights, they are merged in alphabetical order.
+                  format: int32
+                  maximum: 10000
+                  minimum: 1
+                  type: integer
+              required:
+                - requirements
+              type: object
+              x-kubernetes-validations:
+                - message: cannot set both 'price' and 'priceAdjustment'
+                  rule: '!has(self.price) || !has(self.priceAdjustment)'
+            status:
+              description: NodeOverlayStatus defines the observed state of NodeOverlay
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/charts/karpenter-crd/templates/karpenter.sh_nodeoverlays.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodeoverlays.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- with .Values.additionalAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: nodeoverlays.karpenter.sh
 spec:
   group: karpenter.sh
@@ -78,7 +78,7 @@ spec:
                   description: |-
                     PriceAdjustment specifies the price change for matching instance types. Accepts either:
                     - A fixed price modifier (e.g., -0.5, 1.2)
-                    - A percentage modifier (e.g., +10% for increase, -15% for decrees)
+                    - A percentage modifier (e.g., +10% for increase, -15% for decrease)
                   pattern: ^(([+-]{1}(\d*\.?\d+))|(\+{1}\d*\.?\d+%)|(^(-\d{1,2}(\.\d+)?%)$)|(-100%))$
                   type: string
                 requirements:
@@ -89,8 +89,8 @@ spec:
                     - Custom labels from NodePool's spec.template.labels
                   items:
                     description: |-
-                      A node selector requirement is a selector that contains values, a key, and an operator
-                      that relates the key and values.
+                      A node selector requirement is a selector that contains values, a key, an operator that relates the key and values
+                      to have at least that many values.
                     properties:
                       key:
                         description: The label key that the selector applies to.
@@ -98,10 +98,6 @@ spec:
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
                         x-kubernetes-validations:
-                          - message: label domain "kubernetes.io" is restricted
-                            rule: self in ["beta.kubernetes.io/instance-type", "failure-domain.beta.kubernetes.io/region", "beta.kubernetes.io/os", "beta.kubernetes.io/arch", "failure-domain.beta.kubernetes.io/zone", "topology.kubernetes.io/zone", "topology.kubernetes.io/region", "node.kubernetes.io/instance-type", "kubernetes.io/arch", "kubernetes.io/os", "node.kubernetes.io/windows-build"] || self.find("^([^/]+)").endsWith("node.kubernetes.io") || self.find("^([^/]+)").endsWith("node-restriction.kubernetes.io") || !self.find("^([^/]+)").endsWith("kubernetes.io")
-                          - message: label domain "k8s.io" is restricted
-                            rule: self.find("^([^/]+)").endsWith("kops.k8s.io") || !self.find("^([^/]+)").endsWith("k8s.io")
                           - message: label domain "karpenter.sh" is restricted
                             rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
                           - message: label "kubernetes.io/hostname" is restricted
@@ -109,22 +105,23 @@ spec:
                       operator:
                         description: |-
                           Represents a key's relationship to a set of values.
-                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                        type: string
+                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.
                         enum:
+                          - Gte
+                          - Lte
                           - In
                           - NotIn
                           - Exists
                           - DoesNotExist
                           - Gt
                           - Lt
+                        type: string
                       values:
                         description: |-
                           An array of string values. If the operator is In or NotIn,
                           the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                          the values array must be empty. If the operator is Gt or Lt, the values
+                          the values array must be empty. If the operator is Gt, Lt, Gte, or Lte, the values
                           array must have a single element, which will be interpreted as an integer.
-                          This array is replaced during a strategic merge patch.
                         items:
                           type: string
                         type: array
@@ -142,8 +139,8 @@ spec:
                       rule: 'self.all(x, x.operator == ''NotIn'' ? x.values.size() != 0 : true)'
                     - message: requirements with operator 'In' must have a value defined
                       rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
-                    - message: requirements operator 'Gt' or 'Lt' must have a single positive integer value
-                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                    - message: requirements operator 'Gt', 'Lt', 'Gte' or 'Lte' must have a single positive integer value
+                      rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'' || x.operator == ''Gte'' || x.operator == ''Lte'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
                 weight:
                   description: |-
                     Weight defines the priority of this NodeOverlay when overriding node attributes.

--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -1,0 +1,526 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    {{- with .Values.additionalAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: nodepools.karpenter.sh
+spec:
+  group: karpenter.sh
+  names:
+    categories:
+    - karpenter
+    kind: NodePool
+    listKind: NodePoolList
+    plural: nodepools
+    singular: nodepool
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.template.spec.nodeClassRef.name
+      name: NodeClass
+      type: string
+    - jsonPath: .status.nodes
+      name: Nodes
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.weight
+      name: Weight
+      priority: 1
+      type: integer
+    - jsonPath: .status.resources.cpu
+      name: CPU
+      priority: 1
+      type: string
+    - jsonPath: .status.resources.memory
+      name: Memory
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: NodePool is the Schema for the NodePools API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              NodePoolSpec is the top level nodepool specification. Nodepools
+              launch nodes in response to pods that are unschedulable. A single nodepool
+              is capable of managing a diverse set of nodes. Node properties are determined
+              from a combination of nodepool and pod scheduling constraints.
+            properties:
+              disruption:
+                default:
+                  consolidateAfter: 0s
+                description: Disruption contains the parameters that relate to Karpenter's
+                  disruption logic
+                properties:
+                  budgets:
+                    default:
+                    - nodes: 10%
+                    description: |-
+                      Budgets is a list of Budgets.
+                      If there are multiple active budgets, Karpenter uses
+                      the most restrictive value. If left undefined,
+                      this will default to one budget with a value to 10%.
+                    items:
+                      description: |-
+                        Budget defines when Karpenter will restrict the
+                        number of Node Claims that can be terminating simultaneously.
+                      properties:
+                        duration:
+                          description: |-
+                            Duration determines how long a Budget is active since each Schedule hit.
+                            Only minutes and hours are accepted, as cron does not work in seconds.
+                            If omitted, the budget is always active.
+                            This is required if Schedule is set.
+                            This regex has an optional 0s at the end since the duration.String() always adds
+                            a 0s at the end.
+                          pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                          type: string
+                        nodes:
+                          default: 10%
+                          description: |-
+                            Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                            that can be terminating at once. This is calculated by counting nodes that
+                            have a deletion timestamp set, or are actively being deleted by Karpenter.
+                            This field is required when specifying a budget.
+                            This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                            checking for int nodes for IntOrString nodes.
+                            Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                          pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                          type: string
+                        reasons:
+                          description: |-
+                            Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                            Otherwise, this will apply to each reason defined.
+                            allowed reasons are Underutilized, Empty, and Drifted.
+                          items:
+                            description: DisruptionReason defines valid reasons for
+                              disruption budgets.
+                            enum:
+                            - Underutilized
+                            - Empty
+                            - Drifted
+                            type: string
+                          maxItems: 50
+                          type: array
+                        schedule:
+                          description: |-
+                            Schedule specifies when a budget begins being active, following
+                            the upstream cronjob syntax. If omitted, the budget is always active.
+                            Timezones are not supported.
+                            This field is required if Duration is set.
+                          pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                          type: string
+                      required:
+                      - nodes
+                      type: object
+                    maxItems: 50
+                    type: array
+                    x-kubernetes-validations:
+                    - message: '''schedule'' must be set with ''duration'''
+                      rule: self.all(x, has(x.schedule) == has(x.duration))
+                  consolidateAfter:
+                    description: |-
+                      ConsolidateAfter is the duration the controller will wait
+                      before attempting to terminate nodes that are underutilized.
+                      Refer to ConsolidationPolicy for how underutilization is considered.
+                      When replicas is set, ConsolidateAfter is simply ignored
+                    pattern: ^(([0-9]+(s|m|h))+|Never)$
+                    type: string
+                  consolidationPolicy:
+                    default: WhenEmptyOrUnderutilized
+                    description: |-
+                      ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                      algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                      When replicas is set, ConsolidationPolicy is simply ignored
+                    enum:
+                    - WhenEmpty
+                    - WhenEmptyOrUnderutilized
+                    type: string
+                required:
+                - consolidateAfter
+                type: object
+              limits:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: |-
+                  Limits define a set of bounds for provisioning capacity.
+                  Limits other than limits.nodes is not supported when replicas is set.
+                type: object
+              replicas:
+                description: |-
+                  Replicas is the desired number of nodes for the NodePool. When specified, the NodePool will
+                  maintain this fixed number of replicas rather than scaling based on pod demand.
+                  When replicas is set:
+                    - The following fields are ignored:
+                        * disruption.consolidationPolicy
+                        * disruption.consolidateAfter
+                    - Only limits.nodes is supported; other resource limits (e.g., CPU, memory) must not be specified.
+                    - Weight is not supported.
+                  Note: This field is alpha.
+                format: int64
+                minimum: 0
+                type: integer
+              template:
+                description: |-
+                  Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                  NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                properties:
+                  metadata:
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                      NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                      users are not able to set resource requests in the NodePool.
+                    properties:
+                      expireAfter:
+                        default: 720h
+                        description: |-
+                          ExpireAfter is the duration the controller will wait
+                          before terminating a node, measured from when the node is created. This
+                          is useful to implement features like eventually consistent node upgrade,
+                          memory leak protection, and disruption testing.
+                        pattern: ^(([0-9]+(s|m|h))+|Never)$
+                        type: string
+                      nodeClassRef:
+                        description: NodeClassRef is a reference to an object that
+                          defines provider specific configuration
+                        properties:
+                          group:
+                            description: API version of the referent
+                            pattern: ^[^/]*$
+                            type: string
+                            x-kubernetes-validations:
+                            - message: group may not be empty
+                              rule: self != ''
+                          kind:
+                            description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                            type: string
+                            x-kubernetes-validations:
+                            - message: kind may not be empty
+                              rule: self != ''
+                          name:
+                            description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                            type: string
+                            x-kubernetes-validations:
+                            - message: name may not be empty
+                              rule: self != ''
+                        required:
+                        - group
+                        - kind
+                        - name
+                        type: object
+                        x-kubernetes-validations:
+                        - message: nodeClassRef.group is immutable
+                          rule: self.group == oldSelf.group
+                        - message: nodeClassRef.kind is immutable
+                          rule: self.kind == oldSelf.kind
+                      requirements:
+                        description: Requirements are layered with GetLabels and applied
+                          to every node.
+                        items:
+                          description: |-
+                            A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
+                            and minValues that represent the requirement to have at least that many values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies
+                                to.
+                              type: string
+                            minValues:
+                              description: |-
+                                This field is ALPHA and can be dropped or replaced at any time
+                                MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                              maximum: 50
+                              minimum: 1
+                              type: integer
+                            operator:
+                              description: |-
+                                Represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: |-
+                                An array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. If the operator is Gt or Lt, the values
+                                array must have a single element, which will be interpreted as an integer.
+                                This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        maxItems: 100
+                        type: array
+                        x-kubernetes-validations:
+                        - message: requirements with operator 'In' must have a value
+                            defined
+                          rule: 'self.all(x, x.operator == ''In'' ? x.values.size()
+                            != 0 : true)'
+                        - message: requirements operator 'Gt' or 'Lt' must have a
+                            single positive integer value
+                          rule: 'self.all(x, (x.operator == ''Gt'' || x.operator ==
+                            ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >=
+                            0) : true)'
+                        - message: requirements with 'minValues' must have at least
+                            that many values specified in the 'values' field
+                          rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues))
+                            ? x.values.size() >= x.minValues : true)'
+                      startupTaints:
+                        description: |-
+                          StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                          within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                          daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                          purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which
+                                the taint was added.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                      taints:
+                        description: Taints will be applied to the NodeClaim's node.
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which
+                                the taint was added.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                      terminationGracePeriod:
+                        description: |-
+                          TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                          Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                          This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                          When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                          Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                          If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                          that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                          The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                          If left undefined, the controller will wait indefinitely for pods to be drained.
+                        pattern: ^([0-9]+(s|m|h))+$
+                        type: string
+                    required:
+                    - nodeClassRef
+                    - requirements
+                    type: object
+                required:
+                - spec
+                type: object
+              weight:
+                description: |-
+                  Weight is the priority given to the nodepool during scheduling. A higher
+                  numerical weight indicates that this nodepool will be ordered
+                  ahead of other nodepools with lower weights. A nodepool with no weight
+                  will be treated as if it is a nodepool with a weight of 0.
+                  Weight is not supported when replicas is set.
+                format: int32
+                maximum: 100
+                minimum: 1
+                type: integer
+            required:
+            - template
+            type: object
+            x-kubernetes-validations:
+            - message: Cannot transition NodePool between static (replicas set) and
+                dynamic (replicas unset) provisioning modes
+              rule: has(self.replicas) == has(oldSelf.replicas)
+            - message: only 'limits.nodes' is supported on static NodePools
+              rule: '!has(self.replicas) || (!has(self.limits) || size(self.limits)
+                == 0 || (size(self.limits) == 1 && ''nodes'' in self.limits))'
+            - message: '''weight'' is not supported on static NodePools'
+              rule: '!has(self.replicas) || !has(self.weight)'
+          status:
+            description: NodePoolStatus defines the observed state of NodePool
+            properties:
+              conditions:
+                description: Conditions contains signals for health and readiness
+                items:
+                  description: Condition aliases the upstream type and adds additional
+                    helper methods
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              nodeClassObservedGeneration:
+                description: |-
+                  NodeClassObservedGeneration represents the observed nodeClass generation for referenced nodeClass. If this does not match
+                  the actual NodeClass Generation, NodeRegistrationHealthy status condition on the NodePool will be reset
+                format: int64
+                type: integer
+              nodes:
+                default: 0
+                description: Nodes is the count of nodes associated with this NodePool
+                format: int64
+                type: integer
+              resources:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Resources is the list of resources that have been provisioned.
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.nodes
+      status: {}

--- a/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
+++ b/charts/karpenter-crd/templates/karpenter.sh_nodepools.yaml
@@ -12,515 +12,538 @@ spec:
   group: karpenter.sh
   names:
     categories:
-    - karpenter
+      - karpenter
     kind: NodePool
     listKind: NodePoolList
     plural: nodepools
     singular: nodepool
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.template.spec.nodeClassRef.name
-      name: NodeClass
-      type: string
-    - jsonPath: .status.nodes
-      name: Nodes
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .spec.weight
-      name: Weight
-      priority: 1
-      type: integer
-    - jsonPath: .status.resources.cpu
-      name: CPU
-      priority: 1
-      type: string
-    - jsonPath: .status.resources.memory
-      name: Memory
-      priority: 1
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: NodePool is the Schema for the NodePools API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: |-
-              NodePoolSpec is the top level nodepool specification. Nodepools
-              launch nodes in response to pods that are unschedulable. A single nodepool
-              is capable of managing a diverse set of nodes. Node properties are determined
-              from a combination of nodepool and pod scheduling constraints.
-            properties:
-              disruption:
-                default:
-                  consolidateAfter: 0s
-                description: Disruption contains the parameters that relate to Karpenter's
-                  disruption logic
-                properties:
-                  budgets:
-                    default:
-                    - nodes: 10%
-                    description: |-
-                      Budgets is a list of Budgets.
-                      If there are multiple active budgets, Karpenter uses
-                      the most restrictive value. If left undefined,
-                      this will default to one budget with a value to 10%.
-                    items:
-                      description: |-
-                        Budget defines when Karpenter will restrict the
-                        number of Node Claims that can be terminating simultaneously.
-                      properties:
-                        duration:
-                          description: |-
-                            Duration determines how long a Budget is active since each Schedule hit.
-                            Only minutes and hours are accepted, as cron does not work in seconds.
-                            If omitted, the budget is always active.
-                            This is required if Schedule is set.
-                            This regex has an optional 0s at the end since the duration.String() always adds
-                            a 0s at the end.
-                          pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
-                          type: string
-                        nodes:
-                          default: 10%
-                          description: |-
-                            Nodes dictates the maximum number of NodeClaims owned by this NodePool
-                            that can be terminating at once. This is calculated by counting nodes that
-                            have a deletion timestamp set, or are actively being deleted by Karpenter.
-                            This field is required when specifying a budget.
-                            This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
-                            checking for int nodes for IntOrString nodes.
-                            Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
-                          pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
-                          type: string
-                        reasons:
-                          description: |-
-                            Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
-                            Otherwise, this will apply to each reason defined.
-                            allowed reasons are Underutilized, Empty, and Drifted.
-                          items:
-                            description: DisruptionReason defines valid reasons for
-                              disruption budgets.
-                            enum:
-                            - Underutilized
-                            - Empty
-                            - Drifted
-                            type: string
-                          maxItems: 50
-                          type: array
-                        schedule:
-                          description: |-
-                            Schedule specifies when a budget begins being active, following
-                            the upstream cronjob syntax. If omitted, the budget is always active.
-                            Timezones are not supported.
-                            This field is required if Duration is set.
-                          pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
-                          type: string
-                      required:
-                      - nodes
-                      type: object
-                    maxItems: 50
-                    type: array
-                    x-kubernetes-validations:
-                    - message: '''schedule'' must be set with ''duration'''
-                      rule: self.all(x, has(x.schedule) == has(x.duration))
-                  consolidateAfter:
-                    description: |-
-                      ConsolidateAfter is the duration the controller will wait
-                      before attempting to terminate nodes that are underutilized.
-                      Refer to ConsolidationPolicy for how underutilization is considered.
-                      When replicas is set, ConsolidateAfter is simply ignored
-                    pattern: ^(([0-9]+(s|m|h))+|Never)$
-                    type: string
-                  consolidationPolicy:
-                    default: WhenEmptyOrUnderutilized
-                    description: |-
-                      ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
-                      algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
-                      When replicas is set, ConsolidationPolicy is simply ignored
-                    enum:
-                    - WhenEmpty
-                    - WhenEmptyOrUnderutilized
-                    type: string
-                required:
-                - consolidateAfter
-                type: object
-              limits:
-                additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                description: |-
-                  Limits define a set of bounds for provisioning capacity.
-                  Limits other than limits.nodes is not supported when replicas is set.
-                type: object
-              replicas:
-                description: |-
-                  Replicas is the desired number of nodes for the NodePool. When specified, the NodePool will
-                  maintain this fixed number of replicas rather than scaling based on pod demand.
-                  When replicas is set:
-                    - The following fields are ignored:
-                        * disruption.consolidationPolicy
-                        * disruption.consolidateAfter
-                    - Only limits.nodes is supported; other resource limits (e.g., CPU, memory) must not be specified.
-                    - Weight is not supported.
-                  Note: This field is alpha.
-                format: int64
-                minimum: 0
-                type: integer
-              template:
-                description: |-
-                  Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
-                  NodeClaims launched from this NodePool will often be further constrained than the template specifies.
-                properties:
-                  metadata:
-                    properties:
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        description: |-
-                          Annotations is an unstructured key value map stored with a resource that may be
-                          set by external tools to store and retrieve arbitrary metadata. They are not
-                          queryable and should be preserved when modifying objects.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
-                        type: object
-                      labels:
-                        additionalProperties:
-                          type: string
-                        description: |-
-                          Map of string keys and values that can be used to organize and categorize
-                          (scope and select) objects. May match selectors of replication controllers
-                          and services.
-                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
-                        type: object
-                    type: object
-                  spec:
-                    description: |-
-                      NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
-                      NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
-                      users are not able to set resource requests in the NodePool.
-                    properties:
-                      expireAfter:
-                        default: 720h
-                        description: |-
-                          ExpireAfter is the duration the controller will wait
-                          before terminating a node, measured from when the node is created. This
-                          is useful to implement features like eventually consistent node upgrade,
-                          memory leak protection, and disruption testing.
-                        pattern: ^(([0-9]+(s|m|h))+|Never)$
-                        type: string
-                      nodeClassRef:
-                        description: NodeClassRef is a reference to an object that
-                          defines provider specific configuration
-                        properties:
-                          group:
-                            description: API version of the referent
-                            pattern: ^[^/]*$
-                            type: string
-                            x-kubernetes-validations:
-                            - message: group may not be empty
-                              rule: self != ''
-                          kind:
-                            description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                            type: string
-                            x-kubernetes-validations:
-                            - message: kind may not be empty
-                              rule: self != ''
-                          name:
-                            description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                            type: string
-                            x-kubernetes-validations:
-                            - message: name may not be empty
-                              rule: self != ''
-                        required:
-                        - group
-                        - kind
-                        - name
-                        type: object
-                        x-kubernetes-validations:
-                        - message: nodeClassRef.group is immutable
-                          rule: self.group == oldSelf.group
-                        - message: nodeClassRef.kind is immutable
-                          rule: self.kind == oldSelf.kind
-                      requirements:
-                        description: Requirements are layered with GetLabels and applied
-                          to every node.
-                        items:
-                          description: |-
-                            A node selector requirement with min values is a selector that contains values, a key, an operator that relates the key and values
-                            and minValues that represent the requirement to have at least that many values.
-                          properties:
-                            key:
-                              description: The label key that the selector applies
-                                to.
-                              type: string
-                            minValues:
-                              description: |-
-                                This field is ALPHA and can be dropped or replaced at any time
-                                MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
-                              maximum: 50
-                              minimum: 1
-                              type: integer
-                            operator:
-                              description: |-
-                                Represents a key's relationship to a set of values.
-                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                              type: string
-                            values:
-                              description: |-
-                                An array of string values. If the operator is In or NotIn,
-                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. If the operator is Gt or Lt, the values
-                                array must have a single element, which will be interpreted as an integer.
-                                This array is replaced during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        maxItems: 100
-                        type: array
-                        x-kubernetes-validations:
-                        - message: requirements with operator 'In' must have a value
-                            defined
-                          rule: 'self.all(x, x.operator == ''In'' ? x.values.size()
-                            != 0 : true)'
-                        - message: requirements operator 'Gt' or 'Lt' must have a
-                            single positive integer value
-                          rule: 'self.all(x, (x.operator == ''Gt'' || x.operator ==
-                            ''Lt'') ? (x.values.size() == 1 && int(x.values[0]) >=
-                            0) : true)'
-                        - message: requirements with 'minValues' must have at least
-                            that many values specified in the 'values' field
-                          rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues))
-                            ? x.values.size() >= x.minValues : true)'
-                      startupTaints:
-                        description: |-
-                          StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
-                          within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
-                          daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
-                          purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
-                        items:
-                          description: |-
-                            The node this Taint is attached to has the "effect" on
-                            any pod that does not tolerate the Taint.
-                          properties:
-                            effect:
-                              description: |-
-                                Required. The effect of the taint on pods
-                                that do not tolerate the taint.
-                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-                              type: string
-                            key:
-                              description: Required. The taint key to be applied to
-                                a node.
-                              type: string
-                            timeAdded:
-                              description: TimeAdded represents the time at which
-                                the taint was added.
-                              format: date-time
-                              type: string
-                            value:
-                              description: The taint value corresponding to the taint
-                                key.
-                              type: string
-                          required:
-                          - effect
-                          - key
-                          type: object
-                        type: array
-                      taints:
-                        description: Taints will be applied to the NodeClaim's node.
-                        items:
-                          description: |-
-                            The node this Taint is attached to has the "effect" on
-                            any pod that does not tolerate the Taint.
-                          properties:
-                            effect:
-                              description: |-
-                                Required. The effect of the taint on pods
-                                that do not tolerate the taint.
-                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
-                              type: string
-                            key:
-                              description: Required. The taint key to be applied to
-                                a node.
-                              type: string
-                            timeAdded:
-                              description: TimeAdded represents the time at which
-                                the taint was added.
-                              format: date-time
-                              type: string
-                            value:
-                              description: The taint value corresponding to the taint
-                                key.
-                              type: string
-                          required:
-                          - effect
-                          - key
-                          type: object
-                        type: array
-                      terminationGracePeriod:
-                        description: |-
-                          TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
-
-                          Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
-
-                          This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
-                          When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
-
-                          Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
-                          If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
-                          that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
-
-                          The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
-                          If left undefined, the controller will wait indefinitely for pods to be drained.
-                        pattern: ^([0-9]+(s|m|h))+$
-                        type: string
-                    required:
-                    - nodeClassRef
-                    - requirements
-                    type: object
-                required:
-                - spec
-                type: object
-              weight:
-                description: |-
-                  Weight is the priority given to the nodepool during scheduling. A higher
-                  numerical weight indicates that this nodepool will be ordered
-                  ahead of other nodepools with lower weights. A nodepool with no weight
-                  will be treated as if it is a nodepool with a weight of 0.
-                  Weight is not supported when replicas is set.
-                format: int32
-                maximum: 100
-                minimum: 1
-                type: integer
-            required:
-            - template
-            type: object
-            x-kubernetes-validations:
-            - message: Cannot transition NodePool between static (replicas set) and
-                dynamic (replicas unset) provisioning modes
-              rule: has(self.replicas) == has(oldSelf.replicas)
-            - message: only 'limits.nodes' is supported on static NodePools
-              rule: '!has(self.replicas) || (!has(self.limits) || size(self.limits)
-                == 0 || (size(self.limits) == 1 && ''nodes'' in self.limits))'
-            - message: '''weight'' is not supported on static NodePools'
-              rule: '!has(self.replicas) || !has(self.weight)'
-          status:
-            description: NodePoolStatus defines the observed state of NodePool
-            properties:
-              conditions:
-                description: Conditions contains signals for health and readiness
-                items:
-                  description: Condition aliases the upstream type and adds additional
-                    helper methods
+    - additionalPrinterColumns:
+        - jsonPath: .spec.template.spec.nodeClassRef.name
+          name: NodeClass
+          type: string
+        - jsonPath: .status.nodes
+          name: Nodes
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.weight
+          name: Weight
+          priority: 1
+          type: integer
+        - jsonPath: .status.resources.cpu
+          name: CPU
+          priority: 1
+          type: string
+        - jsonPath: .status.resources.memory
+          name: Memory
+          priority: 1
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: NodePool is the Schema for the NodePools API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NodePoolSpec is the top level nodepool specification. Nodepools
+                launch nodes in response to pods that are unschedulable. A single nodepool
+                is capable of managing a diverse set of nodes. Node properties are determined
+                from a combination of nodepool and pod scheduling constraints.
+              properties:
+                disruption:
+                  default:
+                    consolidateAfter: 0s
+                  description: Disruption contains the parameters that relate to Karpenter's disruption logic
                   properties:
-                    lastTransitionTime:
+                    budgets:
+                      default:
+                        - nodes: 10%
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
+                        Budgets is a list of Budgets.
+                        If there are multiple active budgets, Karpenter uses
+                        the most restrictive value. If left undefined,
+                        this will default to one budget with a value to 10%.
+                      items:
+                        description: |-
+                          Budget defines when Karpenter will restrict the
+                          number of Node Claims that can be terminating simultaneously.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration determines how long a Budget is active since each Schedule hit.
+                              Only minutes and hours are accepted, as cron does not work in seconds.
+                              If omitted, the budget is always active.
+                              This is required if Schedule is set.
+                              This regex has an optional 0s at the end since the duration.String() always adds
+                              a 0s at the end.
+                            pattern: ^((([0-9]+(h|m))|([0-9]+h[0-9]+m))(0s)?)$
+                            type: string
+                          nodes:
+                            default: 10%
+                            description: |-
+                              Nodes dictates the maximum number of NodeClaims owned by this NodePool
+                              that can be terminating at once. This is calculated by counting nodes that
+                              have a deletion timestamp set, or are actively being deleted by Karpenter.
+                              This field is required when specifying a budget.
+                              This cannot be of type intstr.IntOrString since kubebuilder doesn't support pattern
+                              checking for int nodes for IntOrString nodes.
+                              Ref: https://github.com/kubernetes-sigs/controller-tools/blob/55efe4be40394a288216dab63156b0a64fb82929/pkg/crd/markers/validation.go#L379-L388
+                            pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
+                            type: string
+                          reasons:
+                            description: |-
+                              Reasons is a list of disruption methods that this budget applies to. If Reasons is not set, this budget applies to all methods.
+                              Otherwise, this will apply to each reason defined.
+                              allowed reasons are Underutilized, Empty, and Drifted.
+                            items:
+                              description: DisruptionReason defines valid reasons for disruption budgets.
+                              enum:
+                                - Underutilized
+                                - Empty
+                                - Drifted
+                              type: string
+                            maxItems: 50
+                            type: array
+                          schedule:
+                            description: |-
+                              Schedule specifies when a budget begins being active, following
+                              the upstream cronjob syntax. If omitted, the budget is always active.
+                              Timezones are not supported.
+                              This field is required if Duration is set.
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly))|((.+)\s(.+)\s(.+)\s(.+)\s(.+))$
+                            type: string
+                        required:
+                          - nodes
+                        type: object
+                      maxItems: 50
+                      type: array
+                      x-kubernetes-validations:
+                        - message: '''schedule'' must be set with ''duration'''
+                          rule: self.all(x, has(x.schedule) == has(x.duration))
+                    consolidateAfter:
+                      description: |-
+                        ConsolidateAfter is the duration the controller will wait
+                        before attempting to terminate nodes that are underutilized.
+                        Refer to ConsolidationPolicy for how underutilization is considered.
+                        When replicas is set, ConsolidateAfter is simply ignored
+                      pattern: ^(([0-9]+(s|m|h))+|Never)$
                       type: string
-                    message:
+                    consolidationPolicy:
+                      default: WhenEmptyOrUnderutilized
                       description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
+                        ConsolidationPolicy describes which nodes Karpenter can disrupt through its consolidation
+                        algorithm. This policy defaults to "WhenEmptyOrUnderutilized" if not specified
+                        When replicas is set, ConsolidationPolicy is simply ignored
                       enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        - WhenEmpty
+                        - WhenEmptyOrUnderutilized
                       type: string
                   required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
+                    - consolidateAfter
                   type: object
-                type: array
-              nodeClassObservedGeneration:
-                description: |-
-                  NodeClassObservedGeneration represents the observed nodeClass generation for referenced nodeClass. If this does not match
-                  the actual NodeClass Generation, NodeRegistrationHealthy status condition on the NodePool will be reset
-                format: int64
-                type: integer
-              nodes:
-                default: 0
-                description: Nodes is the count of nodes associated with this NodePool
-                format: int64
-                type: integer
-              resources:
-                additionalProperties:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                description: Resources is the list of resources that have been provisioned.
-                type: object
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      scale:
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.nodes
-      status: {}
+                limits:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: |-
+                    Limits define a set of bounds for provisioning capacity.
+                    Limits other than limits.nodes is not supported when replicas is set.
+                  type: object
+                replicas:
+                  description: |-
+                    Replicas is the desired number of nodes for the NodePool. When specified, the NodePool will
+                    maintain this fixed number of replicas rather than scaling based on pod demand.
+                    When replicas is set:
+                      - The following fields are ignored:
+                          * disruption.consolidationPolicy
+                          * disruption.consolidateAfter
+                      - Only limits.nodes is supported; other resource limits (e.g., CPU, memory) must not be specified.
+                      - Weight is not supported.
+                    Note: This field is alpha.
+                  format: int64
+                  minimum: 0
+                  type: integer
+                template:
+                  description: |-
+                    Template contains the template of possibilities for the provisioning logic to launch a NodeClaim with.
+                    NodeClaims launched from this NodePool will often be further constrained than the template specifies.
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Annotations is an unstructured key value map stored with a resource that may be
+                            set by external tools to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                          description: |-
+                            Map of string keys and values that can be used to organize and categorize
+                            (scope and select) objects. May match selectors of replication controllers
+                            and services.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+                          type: object
+                          maxProperties: 100
+                          x-kubernetes-validations:
+                            - message: label domain "karpenter.sh" is restricted
+                              rule: self.all(x, x in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !x.find("^([^/]+)").endsWith("karpenter.sh"))
+                            - message: label "karpenter.sh/nodepool" is restricted
+                              rule: self.all(x, x != "karpenter.sh/nodepool")
+                            - message: label "kubernetes.io/hostname" is restricted
+                              rule: self.all(x, x != "kubernetes.io/hostname")
+                      type: object
+                    spec:
+                      description: |-
+                        NodeClaimTemplateSpec describes the desired state of the NodeClaim in the Nodepool
+                        NodeClaimTemplateSpec is used in the NodePool's NodeClaimTemplate, with the resource requests omitted since
+                        users are not able to set resource requests in the NodePool.
+                      properties:
+                        expireAfter:
+                          default: 720h
+                          description: |-
+                            ExpireAfter is the duration the controller will wait
+                            before terminating a node, measured from when the node is created. This
+                            is useful to implement features like eventually consistent node upgrade,
+                            memory leak protection, and disruption testing.
+                          pattern: ^(([0-9]+(s|m|h))+|Never)$
+                          type: string
+                        nodeClassRef:
+                          description: NodeClassRef is a reference to an object that defines provider specific configuration
+                          properties:
+                            group:
+                              description: API version of the referent
+                              pattern: ^[^/]*$
+                              type: string
+                              x-kubernetes-validations:
+                                - message: group may not be empty
+                                  rule: self != ''
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: kind may not be empty
+                                  rule: self != ''
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                              x-kubernetes-validations:
+                                - message: name may not be empty
+                                  rule: self != ''
+                          required:
+                            - group
+                            - kind
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: nodeClassRef.group is immutable
+                              rule: self.group == oldSelf.group
+                            - message: nodeClassRef.kind is immutable
+                              rule: self.kind == oldSelf.kind
+                        requirements:
+                          description: Requirements are layered with GetLabels and applied to every node.
+                          items:
+                            description: |-
+                              A node selector requirement is a selector that contains values, a key, an operator that relates the key and values
+                              and minValues that represent the requirement to have at least that many values.
+                            properties:
+                              key:
+                                description: The label key that the selector applies to.
+                                type: string
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                                x-kubernetes-validations:
+                                  - message: label domain "karpenter.sh" is restricted
+                                    rule: self in ["karpenter.sh/capacity-type", "karpenter.sh/nodepool"] || !self.find("^([^/]+)").endsWith("karpenter.sh")
+                                  - message: label "karpenter.sh/nodepool" is restricted
+                                    rule: self != "karpenter.sh/nodepool"
+                                  - message: label "kubernetes.io/hostname" is restricted
+                                    rule: self != "kubernetes.io/hostname"
+                              minValues:
+                                description: |-
+                                  This field is ALPHA and can be dropped or replaced at any time
+                                  MinValues is the minimum number of unique values required to define the flexibility of the specific requirement.
+                                maximum: 50
+                                minimum: 1
+                                type: integer
+                              operator:
+                                description: |-
+                                  Represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, Lt, Gte, and Lte.
+                                enum:
+                                  - Gte
+                                  - Lte
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  - Gt
+                                  - Lt
+                                type: string
+                              values:
+                                description: |-
+                                  An array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. If the operator is Gt, Lt, Gte, or Lte, the values
+                                  array must have a single element, which will be interpreted as an integer.
+                                  This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          maxItems: 100
+                          type: array
+                          x-kubernetes-validations:
+                            - message: requirements with operator 'In' must have a value defined
+                              rule: 'self.all(x, x.operator == ''In'' ? x.values.size() != 0 : true)'
+                            - message: requirements operator 'Gt', 'Lt', 'Gte', or 'Lte' must have a single positive integer value
+                              rule: 'self.all(x, (x.operator == ''Gt'' || x.operator == ''Lt'' || x.operator == ''Gte'' || x.operator == ''Lte'') ? (x.values.size() == 1 && int(x.values[0]) >= 0) : true)'
+                            - message: requirements with 'minValues' must have at least that many values specified in the 'values' field
+                              rule: 'self.all(x, (x.operator == ''In'' && has(x.minValues)) ? x.values.size() >= x.minValues : true)'
+                        startupTaints:
+                          description: |-
+                            StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
+                            within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
+                            daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
+                            purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: TimeAdded represents the time at which the taint was added.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        taints:
+                          description: Taints will be applied to the NodeClaim's node.
+                          items:
+                            description: |-
+                              The node this Taint is attached to has the "effect" on
+                              any pod that does not tolerate the Taint.
+                            properties:
+                              effect:
+                                description: |-
+                                  Required. The effect of the taint on pods
+                                  that do not tolerate the taint.
+                                  Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                                enum:
+                                  - NoSchedule
+                                  - PreferNoSchedule
+                                  - NoExecute
+                              key:
+                                description: Required. The taint key to be applied to a node.
+                                type: string
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                              timeAdded:
+                                description: TimeAdded represents the time at which the taint was added.
+                                format: date-time
+                                type: string
+                              value:
+                                description: The taint value corresponding to the taint key.
+                                type: string
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*(\/))?([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$
+                            required:
+                              - effect
+                              - key
+                            type: object
+                          type: array
+                        terminationGracePeriod:
+                          description: |-
+                            TerminationGracePeriod is the maximum duration the controller will wait before forcefully deleting the pods on a node, measured from when deletion is first initiated.
+
+                            Warning: this feature takes precedence over a Pod's terminationGracePeriodSeconds value, and bypasses any blocked PDBs or the karpenter.sh/do-not-disrupt annotation.
+
+                            This field is intended to be used by cluster administrators to enforce that nodes can be cycled within a given time period.
+                            When set, drifted nodes will begin draining even if there are pods blocking eviction. Draining will respect PDBs and the do-not-disrupt annotation until the TGP is reached.
+
+                            Karpenter will preemptively delete pods so their terminationGracePeriodSeconds align with the node's terminationGracePeriod.
+                            If a pod would be terminated without being granted its full terminationGracePeriodSeconds prior to the node timeout,
+                            that pod will be deleted at T = node timeout - pod terminationGracePeriodSeconds.
+
+                            The feature can also be used to allow maximum time limits for long-running jobs which can delay node termination with preStop hooks.
+                            If left undefined, the controller will wait indefinitely for pods to be drained.
+                          pattern: ^([0-9]+(s|m|h))+$
+                          type: string
+                      required:
+                        - nodeClassRef
+                        - requirements
+                      type: object
+                  required:
+                    - spec
+                  type: object
+                weight:
+                  description: |-
+                    Weight is the priority given to the nodepool during scheduling. A higher
+                    numerical weight indicates that this nodepool will be ordered
+                    ahead of other nodepools with lower weights. A nodepool with no weight
+                    will be treated as if it is a nodepool with a weight of 0.
+                    Weight is not supported when replicas is set.
+                  format: int32
+                  maximum: 100
+                  minimum: 1
+                  type: integer
+              required:
+                - template
+              type: object
+              x-kubernetes-validations:
+                - message: Cannot transition NodePool between static (replicas set) and dynamic (replicas unset) provisioning modes
+                  rule: has(self.replicas) == has(oldSelf.replicas)
+                - message: only 'limits.nodes' is supported on static NodePools
+                  rule: '!has(self.replicas) || (!has(self.limits) || size(self.limits) == 0 || (size(self.limits) == 1 && ''nodes'' in self.limits))'
+                - message: '''weight'' is not supported on static NodePools'
+                  rule: '!has(self.replicas) || !has(self.weight)'
+            status:
+              description: NodePoolStatus defines the observed state of NodePool
+              properties:
+                conditions:
+                  description: Conditions contains signals for health and readiness
+                  items:
+                    description: Condition aliases the upstream type and adds additional helper methods
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                nodeClassObservedGeneration:
+                  description: |-
+                    NodeClassObservedGeneration represents the observed nodeClass generation for referenced nodeClass. If this does not match
+                    the actual NodeClass Generation, NodeRegistrationHealthy status condition on the NodePool will be reset
+                  format: int64
+                  type: integer
+                nodes:
+                  default: 0
+                  description: Nodes is the count of nodes associated with this NodePool
+                  format: int64
+                  type: integer
+                resources:
+                  additionalProperties:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Resources is the list of resources that have been provisioned.
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.nodes
+        status: {}

--- a/charts/karpenter-crd/values.schema.json
+++ b/charts/karpenter-crd/values.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "additionalAnnotations": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Additional annotations added to all CRD resources."
+    }
+  }
+}

--- a/charts/karpenter-crd/values.yaml
+++ b/charts/karpenter-crd/values.yaml
@@ -1,0 +1,2 @@
+# -- Additional annotations to add to all CRD resources.
+additionalAnnotations: {}

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -48,6 +48,10 @@ export REGION=<your-region-or-zone>   # e.g. us-central1 or us-central1-f
 helm repo add karpenter-provider-gcp https://cloudpilot-ai.github.io/karpenter-provider-gcp
 helm repo update
 
+# Install CRDs first (separate chart ensures CRDs are upgraded on helm upgrade)
+helm upgrade --install karpenter-crd karpenter-provider-gcp/karpenter-crd
+
+# Install the controller
 helm upgrade karpenter karpenter-provider-gcp/karpenter --install \
   --namespace karpenter-system --create-namespace \
   --set "controller.settings.projectID=${PROJECT_ID}" \
@@ -113,6 +117,10 @@ helm upgrade karpenter karpenter-provider-gcp/karpenter --install \
 ```
 
 > **Warning:** Service account keys are long-lived credentials. Prefer Workload Identity wherever possible.
+
+## Upgrading
+
+See the [upgrade guide](upgrading.md).
 
 ## Uninstalling
 

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -1,0 +1,30 @@
+# Upgrading
+
+This guide explains how to safely upgrade Karpenter GCP to a new version.
+
+## Standard upgrade procedure
+
+Always upgrade CRDs before the controller. Helm's `helm upgrade` never upgrades CRDs that already exist — the separate `karpenter-crd` chart is the supported mechanism for keeping CRDs current.
+
+```sh
+helm repo update
+
+# 1. Upgrade CRDs
+helm upgrade karpenter-crd karpenter-provider-gcp/karpenter-crd
+
+# 2. Upgrade the controller
+helm upgrade karpenter karpenter-provider-gcp/karpenter \
+  --namespace karpenter-system
+```
+
+If you installed with the single-chart pattern before `karpenter-crd` was available, migrate by installing the CRD chart once:
+
+```sh
+helm upgrade --install karpenter-crd karpenter-provider-gcp/karpenter-crd
+```
+
+Subsequent upgrades use the two-step procedure above.
+
+## Version-specific migration notes
+
+See [MIGRATION.md](../../MIGRATION.md) for migration notes that require manual steps.

--- a/docs/getting-started/upgrading.md
+++ b/docs/getting-started/upgrading.md
@@ -17,7 +17,22 @@ helm upgrade karpenter karpenter-provider-gcp/karpenter \
   --namespace karpenter-system
 ```
 
-If you installed with the single-chart pattern before `karpenter-crd` was available, migrate by installing the CRD chart once:
+If you installed with the single-chart pattern before `karpenter-crd` was available, the in-cluster CRDs are not currently owned by any Helm release. Adopt them into the new `karpenter-crd` release first, so Helm doesn't error with `cannot patch <crd> ... already exists`:
+
+```bash
+for crd in gcenodeclasses.karpenter.k8s.gcp \
+           nodeclaims.karpenter.sh \
+           nodeoverlays.karpenter.sh \
+           nodepools.karpenter.sh; do
+  kubectl annotate crd $crd \
+    meta.helm.sh/release-name=karpenter-crd \
+    meta.helm.sh/release-namespace=karpenter-system \
+    --overwrite
+  kubectl label crd $crd app.kubernetes.io/managed-by=Helm --overwrite
+done
+```
+
+Then install the CRD chart:
 
 ```sh
 helm upgrade --install karpenter-crd karpenter-provider-gcp/karpenter-crd

--- a/hack/e2e-deploy.sh
+++ b/hack/e2e-deploy.sh
@@ -42,6 +42,13 @@ IMAGE_REF="$(
 )"
 log "Image: ${IMAGE_REF}"
 
+log "Installing/upgrading karpenter-crd chart..."
+helm upgrade --install karpenter-crd "${REPO_ROOT}/charts/karpenter-crd" \
+  --namespace karpenter-system \
+  --create-namespace \
+  --wait \
+  --timeout 2m
+
 log "Deploying karpenter via Helm..."
 helm upgrade --install karpenter "${REPO_ROOT}/charts/karpenter" \
   --namespace karpenter-system \

--- a/hack/mutation/crd_annotations.sh
+++ b/hack/mutation/crd_annotations.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# Inject the additionalAnnotations Helm template block into each CRD template.
+# The block is inserted after the first "  annotations:" line found in each file.
+for crd in charts/karpenter-crd/templates/*.yaml; do
+    awk '
+        {print}
+        /  annotations:/ && !n {
+            print "    {{- with .Values.additionalAnnotations }}"
+            print "    {{- toYaml . | nindent 4 }}"
+            print "    {{- end }}"
+            n++
+        }
+    ' "$crd" > "$crd.new" && mv "$crd.new" "$crd"
+done

--- a/hack/update-generated.sh
+++ b/hack/update-generated.sh
@@ -14,6 +14,11 @@ controller-gen crd paths=./pkg/apis/v1alpha1/... output:crd:dir=./charts/karpent
 KARPENTER_CRD_DIR=vendor/sigs.k8s.io/karpenter/pkg/apis/crds
 cp "${KARPENTER_CRD_DIR}"/*.yaml ./charts/karpenter/crds/
 
+# Sync CRDs to karpenter-crd chart with additionalAnnotations support
+rm -f charts/karpenter-crd/templates/*.yaml
+cp charts/karpenter/crds/*.yaml charts/karpenter-crd/templates/
+hack/mutation/crd_annotations.sh
+
 # Update generated code
 export REPO_ROOT=$(pwd)
 export GOPATH="${REPO_ROOT}/_go"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a separate `karpenter-crd` Helm chart that manages CRD lifecycle independently from the controller chart. This is the same pattern used by karpenter-provider-aws.

**Why separate charts?**
- `helm upgrade karpenter` (controller chart) does not upgrade CRDs in the `crds/` directory — Helm only applies those on `helm install`
- Putting CRDs in a separate chart's `templates/` directory ensures `helm upgrade karpenter-crd` keeps CRDs up to date
- Making `karpenter-crd` a Helm dependency of `karpenter` would cause `helm uninstall karpenter` to cascade-delete all CRDs, destroying all NodePool and NodeClaim resources

**What's included:**
- `charts/karpenter-crd/` — new chart with CRDs in `templates/`, `additionalAnnotations` value (for ArgoCD `sync-options` etc.), JSON schema validation
- `hack/mutation/crd_annotations.sh` — injects the `additionalAnnotations` Helm block into each CRD template (matching AWS's approach)
- `hack/update-generated.sh` — syncs CRDs into `karpenter-crd` templates on every `make update`; cleans templates dir first to remove stale CRDs
- `Makefile` — `chart-lint` and `update` targets cover both charts
- Release workflow — packages and publishes both charts; restore step uses awk instead of Python to parse the Helm index
- e2e deploy script — installs `karpenter-crd` before the controller
- Docs — two-chart install pattern in `installation.md`; dedicated `upgrading.md`

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)

#### Special notes for your reviewer:

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.
- CRD sync follows the same awk-based pattern as [karpenter-provider-aws](https://github.com/aws/karpenter-provider-aws/blob/main/hack/mutation/crd_annotations.sh)

#### Does this PR introduce a user-facing change?

```release-note
Added `karpenter-crd` Helm chart for independent CRD lifecycle management. Install CRDs separately with `helm upgrade --install karpenter-crd karpenter-provider-gcp/karpenter-crd` before upgrading the controller chart.
```