### PR TITLE
fix(chart): allow staticCapacity and nodeRepair in values.schema.json

### DIFF
--- a/charts/karpenter/values.schema.json
+++ b/charts/karpenter/values.schema.json
@@ -220,6 +220,16 @@
               "type": "boolean",
               "description": "Enable NodeOverlay (alpha). Allows node overlay to influence scheduling decisions.",
               "default": false
+            },
+            "nodeRepair": {
+              "type": "boolean",
+              "description": "Enable nodeRepair (alpha). When enabled, Karpenter replaces nodes that fail GKE Node Problem Detector health conditions.",
+              "default": false
+            },
+            "staticCapacity": {
+              "type": "boolean",
+              "description": "Enable staticCapacity (alpha). When enabled, NodePools with spec.replicas maintain a fixed number of nodes regardless of pod demand.",
+              "default": false
             }
           }
         },


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`controller.featureGates` defaults `staticCapacity` and `nodeRepair` to `false` in `values.yaml`, but the schema's `additionalProperties: false` rejects them. As a result, every install fails before templates render:

```
Error: values don't meet the specifications of the schema(s):
- controller.featureGates: Additional property nodeRepair is not allowed
- controller.featureGates: Additional property staticCapacity is not allowed
```

This PR adds the two missing schema entries mirroring the existing `nodeOverlay` style.

#### Does this PR introduce a user-facing change?

```release-note
fix(chart): allow staticCapacity and nodeRepair feature gates in values.schema.json so the chart's own defaults validate.
```
