### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" 
+    directory: "/" 
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/" 
     schedule:
       interval: "weekly"
+     groups:
+      karpenter-core:
+        patterns:
+          - "sigs.k8s.io/karpenter"
+      go-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "sigs.k8s.io/karpenter"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/" 
     schedule:
       interval: "weekly"
-     groups:
+    groups:
       karpenter-core:
         patterns:
           - "sigs.k8s.io/karpenter"


### PR DESCRIPTION
Adds in dependabot file

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Adds `.github/dependabot.yml` to enable automated weekly Go module updates, with a dedicated group for `sigs.k8s.io/karpenter` and a catch-all group for all other Go dependencies.
- The `groups:` key on line 12 is indented with 5 spaces instead of 4, placing it outside any valid YAML nesting level — GitHub will fail to parse the file and no updates will be triggered until this is fixed.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the one-character indentation error; no functional code is changed.

Single P1 indentation issue that prevents the file from being parsed by GitHub, but it only affects CI automation — no application code is touched. Easy one-line fix.

.github/dependabot.yml — fix `groups:` indentation from 5 spaces to 4 spaces.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | New Dependabot config for Go modules with grouping rules, but has a YAML indentation error on the `groups` key (5 spaces instead of 4) that will cause GitHub to reject the file. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot Weekly Schedule] --> B{Go Module Updates}
    B --> C[Group: karpenter-core\nsigs.k8s.io/karpenter]
    B --> D[Group: go-dependencies\nAll other Go deps\nexcluding sigs.k8s.io/karpenter]
    C --> E[Open PR for karpenter updates]
    D --> F[Open PR for other dep updates]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fdependabot.yml%3A12%0A**Invalid%20YAML%20indentation%20on%20%60groups%60%20key**%0A%0A%60groups%3A%60%20is%20indented%20with%205%20spaces%2C%20which%20doesn't%20align%20with%20any%20valid%20YAML%20nesting%20level%20in%20this%20block.%20Sibling%20keys%20%60directory%3A%60%20and%20%60schedule%3A%60%20use%204%20spaces.%20This%20makes%20the%20file%20structurally%20invalid%20%E2%80%94%20GitHub%20will%20reject%20it%20and%20no%20automated%20updates%20will%20run.%0A%0A%60%60%60suggestion%0A%20%20%20%20groups%3A%0A%60%60%60%0A%0A&pr=306&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fdependabot.yml%3A12%0A**Invalid%20YAML%20indentation%20on%20%60groups%60%20key**%0A%0A%60groups%3A%60%20is%20indented%20with%205%20spaces%2C%20which%20doesn't%20align%20with%20any%20valid%20YAML%20nesting%20level%20in%20this%20block.%20Sibling%20keys%20%60directory%3A%60%20and%20%60schedule%3A%60%20use%204%20spaces.%20This%20makes%20the%20file%20structurally%20invalid%20%E2%80%94%20GitHub%20will%20reject%20it%20and%20no%20automated%20updates%20will%20run.%0A%0A%60%60%60suggestion%0A%20%20%20%20groups%3A%0A%60%60%60%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=306&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22feat-intro-dependabot%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat-intro-dependabot%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fdependabot.yml%3A12%0A**Invalid%20YAML%20indentation%20on%20%60groups%60%20key**%0A%0A%60groups%3A%60%20is%20indented%20with%205%20spaces%2C%20which%20doesn't%20align%20with%20any%20valid%20YAML%20nesting%20level%20in%20this%20block.%20Sibling%20keys%20%60directory%3A%60%20and%20%60schedule%3A%60%20use%204%20spaces.%20This%20makes%20the%20file%20structurally%20invalid%20%E2%80%94%20GitHub%20will%20reject%20it%20and%20no%20automated%20updates%20will%20run.%0A%0A%60%60%60suggestion%0A%20%20%20%20groups%3A%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Update .github/dependabot.yml"](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/45a1974ed342469f01f1e5aba64c7aa6ae30971b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31586796)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->