### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## Unreleased
 
+## v0.3.0
+
 ### New features
 
 - Added a garbage-collection controller (`instance.garbagecollection`) that periodically

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,34 +6,9 @@
 
 ### CRDs moved to a separate Helm chart (`karpenter-crd`)
 
-CRDs are now distributed and managed via a dedicated `karpenter-crd` Helm chart, separate from the main `karpenter` chart. This enables independent CRD upgrades without touching the controller.
+CRDs are now managed via a dedicated `karpenter-crd` Helm chart. Users upgrading from v0.2.x must install this chart and, if CRDs were previously installed by the single `karpenter` chart, adopt them into the new release first.
 
-**Action required when upgrading from v0.2.x:**
-
-Install the new chart before upgrading the main chart:
-
-```bash
-helm upgrade --install karpenter-crd oci://ghcr.io/cloudpilot-ai/karpenter-provider-gcp/chart/karpenter-crd \
-  --version 0.3.0 \
-  --namespace karpenter-system \
-  --create-namespace
-```
-
-If your existing CRDs were installed by a previous version of the `karpenter` chart, adopt them into the new release before installing `karpenter-crd`:
-
-```bash
-for crd in gcenodeclasses.karpenter.k8s.gcp nodeclaims.karpenter.sh nodepools.karpenter.sh nodeoverlays.karpenter.sh; do
-  kubectl annotate crd $crd \
-    meta.helm.sh/release-name=karpenter-crd \
-    meta.helm.sh/release-namespace=karpenter-system \
-    --overwrite
-  kubectl label crd $crd \
-    app.kubernetes.io/managed-by=Helm \
-    --overwrite
-done
-```
-
-Then proceed with `helm upgrade karpenter-crd ...` and the regular `karpenter` chart upgrade.
+See [Upgrading](docs/getting-started/upgrading.md) for the full procedure.
 
 ---
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,39 @@
 
 ## v0.3.0
 
+### CRDs moved to a separate Helm chart (`karpenter-crd`)
+
+CRDs are now distributed and managed via a dedicated `karpenter-crd` Helm chart, separate from the main `karpenter` chart. This enables independent CRD upgrades without touching the controller.
+
+**Action required when upgrading from v0.2.x:**
+
+Install the new chart before upgrading the main chart:
+
+```bash
+helm upgrade --install karpenter-crd oci://ghcr.io/cloudpilot-ai/karpenter-provider-gcp/chart/karpenter-crd \
+  --version 0.3.0 \
+  --namespace karpenter-system \
+  --create-namespace
+```
+
+If your existing CRDs were installed by a previous version of the `karpenter` chart, adopt them into the new release before installing `karpenter-crd`:
+
+```bash
+for crd in gcenodeclasses.karpenter.k8s.gcp nodeclaims.karpenter.sh nodepools.karpenter.sh nodeoverlays.karpenter.sh; do
+  kubectl annotate crd $crd \
+    meta.helm.sh/release-name=karpenter-crd \
+    meta.helm.sh/release-namespace=karpenter-system \
+    --overwrite
+  kubectl label crd $crd \
+    app.kubernetes.io/managed-by=Helm \
+    --overwrite
+done
+```
+
+Then proceed with `helm upgrade karpenter-crd ...` and the regular `karpenter` chart upgrade.
+
+---
+
 ### Network config and tags
 
 #### Network interfaces

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,8 +1,12 @@
 # Migration Guide
 
-## Upgrading to vNext — network config and tags
+## Unreleased
 
-### Network interfaces
+## v0.3.0
+
+### Network config and tags
+
+#### Network interfaces
 
 Karpenter now builds the primary network interface from the cluster API (`cluster.NetworkConfig`) instead of copying it from a GKE node pool template. The network, subnetwork, and pod CIDR range are read directly from the cluster.
 
@@ -59,13 +63,13 @@ networkConfig:
 
 **Cluster-level private nodes** (`EnablePrivateNodes: true`) are now detected automatically — no NodeClass override is needed.
 
-### New IAM permission: `container.clusters.get`
+#### New IAM permission: `container.clusters.get`
 
 Karpenter now reads the cluster API at provisioning time (`container.projects.locations.clusters.get`) to derive network configuration. This requires the `container.clusters.get` IAM permission on the Karpenter service account.
 
 **Action required if you use a custom minimal IAM role** (not `roles/container.admin`): add `container.clusters.get` to the role. No action is needed if you use the predefined `roles/container.admin` role, which already includes this permission.
 
-### Network tags
+#### Network tags
 
 Previously, Karpenter merged all tags from the bootstrap node pool template with `spec.networkTags` in NodeClass. Now only two sources are used:
 
@@ -76,9 +80,9 @@ Previously, Karpenter merged all tags from the bootstrap node pool template with
 
 ---
 
-## Upgrading to vNext — GC controller and cluster identity labels
+### GC controller and cluster identity labels
 
-### Background
+#### Background
 
 This release introduces a garbage-collection controller that automatically deletes GCE VM
 instances with no corresponding NodeClaim (orphaned instances that accumulate after missed
@@ -105,7 +109,7 @@ if you want to clean up orphaned instances that may have accumulated before this
 
 ---
 
-### Step 1 (optional) — rotate live nodes
+#### Step 1 (optional) — rotate live nodes
 
 Trigger a rolling replacement of your NodePools so that every replacement instance is
 stamped with `goog-k8s-cluster-location`. After this step, any remaining instance that
@@ -120,7 +124,7 @@ Repeat for each NodePool. Wait for all nodes to finish replacing before proceedi
 
 ---
 
-### Step 2 (optional) — find and delete orphaned instances
+#### Step 2 (optional) — find and delete orphaned instances
 
 List all instances with `goog-k8s-cluster-name` but without `goog-k8s-cluster-location`:
 

--- a/pkg/providers/imagefamily/containeroptimizedos_test.go
+++ b/pkg/providers/imagefamily/containeroptimizedos_test.go
@@ -82,10 +82,12 @@ func TestResolveLatestCOSImage_PicksNewestNonDeprecated(t *testing.T) {
 
 func TestResolveLatestCOSImage_ExcludesSpecialisedVariants(t *testing.T) {
 	images := []*compute.Image{
-		{Name: "gke-1351-gke1396004-cos-arm64-125-19216-104-126-c-pre", CreationTimestamp: "2025-04-10T00:00:00Z"},
-		{Name: "gke-1351-gke1396004-cos-125-19216-104-126-c-nvda", CreationTimestamp: "2025-04-09T00:00:00Z"},
-		{Name: "gke-1351-gke1396004-cos-125-19216-104-126-c-pre-kmod", CreationTimestamp: "2025-04-08T00:00:00Z"},
-		{Name: "gke-1351-gke1396004-cos-125-19216-104-126-c-test", CreationTimestamp: "2025-04-07T00:00:00Z"},
+		{Name: "gke-1351-gke1396004-cos-arm64-125-19216-104-126-c-pre", CreationTimestamp: "2025-04-11T00:00:00Z"},
+		{Name: "gke-1351-gke1396004-cos-125-19216-104-126-c-nvda", CreationTimestamp: "2025-04-10T00:00:00Z"},
+		{Name: "gke-1351-gke1396004-cos-125-19216-104-126-c-pre-kmod", CreationTimestamp: "2025-04-09T00:00:00Z"},
+		{Name: "gke-1351-gke1396004-cos-125-19216-104-126-c-test", CreationTimestamp: "2025-04-08T00:00:00Z"},
+		// cgpv1 (cgroup v1) variant — must be excluded; GKE 1.29+ kubelet sets --fail-cgroupv1=true
+		{Name: "gke-1353-gke1389001-cos-125-19216-220-106-c-cgpv1-pre", CreationTimestamp: "2025-04-07T00:00:00Z"},
 		{Name: "gke-1351-gke1390000-cos-125-19216-100-100-c-pre", CreationTimestamp: "2025-03-01T00:00:00Z"},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind bug

#### What this PR does / why we need it:

Prepares the v0.3.0 release by versioning the accumulated changelog and migration guide entries:

- `CHANGELOG.md`: rename `## Unreleased` → `## v0.3.0`; add empty `## Unreleased` placeholder
- `MIGRATION.md`: consolidate sections into a single `## v0.3.0` block; add note on `karpenter-crd` chart introduction; link to the upgrading guide for the adoption procedure
- **`pkg/providers/imagefamily/containeroptimizedos_test.go`**: add `cgpv1` fixture to `TestResolveLatestCOSImage_ExcludesSpecialisedVariants` to prevent regression (missed unit test in #309 ).

#### Which issue(s) this PR fixes:



#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)

#### Special notes for your reviewer:

- The cgpv1 fix is also in `main` via #309. This PR backports it into the v0.3.0 release branch.
- E2E: all 15 specs across 7 suites passed on commit `9155b95b` (see [run results](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/307#issuecomment-4399199575)).
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Promotes accumulated changelog and migration-guide entries from `## Unreleased` to `## v0.3.0`; adds empty `## Unreleased` placeholders in both docs for future work.
- Adds a `cgpv1` fixture to `TestResolveLatestCOSImage_ExcludesSpecialisedVariants`, verifying that the existing `isUsableCOSImage` fix (which already excludes `\"cgpv1\"` in the skip list of `containeroptimizedos.go`) correctly prevents cgpv1 images from being auto-selected as GKE node images on GKE 1.29+ clusters.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — documentation restructuring is correct and the new test accurately validates the cgpv1 exclusion already present in the implementation.

All three files are clean: CHANGELOG.md and MIGRATION.md are straightforward versioning housekeeping, and the test change correctly adds a regression-test fixture for the cgpv1 bug fix without altering any production logic. No correctness issues found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds empty `## Unreleased` placeholder at the top and promotes previous unreleased content under `## v0.3.0`. |
| MIGRATION.md | Reorganizes two former `## Upgrading to vNext` sections into a single `## v0.3.0` block with `###`/`####` hierarchy; adds `## Unreleased` placeholder and a new CRD chart section. |
| pkg/providers/imagefamily/containeroptimizedos_test.go | Adds a cgpv1 fixture to `TestResolveLatestCOSImage_ExcludesSpecialisedVariants` and bumps surrounding timestamps by 1 day to ensure the new case sorts above the expected result before filtering. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveLatestCOSImage] --> B[buildImageFilter\nversion-prefixed or broad]
    B --> C[GCP Images.List API]
    C --> D{isUsableCOSImage?}
    D -- "Deprecated / OBSOLETE / DELETED" --> E[skip]
    D -- "arm64 / kmod / nvda / gvisor\n-test / cgpv1" --> E
    D -- passes all checks --> F[candidates list]
    F --> G[Sort by CreationTimestamp DESC]
    G --> H[Return newest candidate\nprojects/gke-node-images/global/images/...]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(imagefamily): add cgpv1 exclusion t..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/d8757e1d8d4b8652bfd11416f7d1cef2c85ff6cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31197394)</sub>

<!-- /greptile_comment -->