### PR TITLE
fix(imagefamily): exclude cgpv1 COS images from auto-selection

### DIFF
--- a/pkg/providers/imagefamily/containeroptimizedos.go
+++ b/pkg/providers/imagefamily/containeroptimizedos.go
@@ -101,8 +101,10 @@ func isUsableCOSImage(img *compute.Image) bool {
 			return false
 		}
 	}
-	// Exclude arm64 and specialised variants.
-	for _, skip := range []string{"arm64", "kmod", "nvda", "gvisor", "-test"} {
+	// Exclude arm64 and specialised variants. Exclude cgpv1 (cgroup v1) images:
+	// GKE 1.29+ clusters run cgroup v2 by default and the GKE 1.29+ kubelet
+	// sets --fail-cgroupv1=true, so cgpv1 images cause an immediate kubelet crash.
+	for _, skip := range []string{"arm64", "kmod", "nvda", "gvisor", "-test", "cgpv1"} {
 		if strings.Contains(img.Name, skip) {
 			return false
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`resolveLatestCOSImage` (introduced in #280) queries the `gke-node-images` project for the most recently published non-deprecated COS image. Google recently published `-cgpv1-` (cgroup v1) image variants for GKE 1.35; these have higher patch version numbers and sort first. GKE 1.29+ kubelet sets `--fail-cgroupv1=true`, so a cgpv1 image causes an immediate kubelet crash — the VM launches but the node never registers with the cluster.

Fix: add `"cgpv1"` to the exclusion list in `isUsableCOSImage`.

Verified via e2e tests — before the fix all COS provisioning specs timed out at 10m with nodes stuck at `Launched=True, Registered=Unknown`; after the fix nodes register within ~90s and all COS specs pass.

#### Which issue(s) this PR fixes:

Fixes #310

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)

#### Special notes for your reviewer:

- This fix is also included in #307 (v0.3.0 release prep branch).
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Adds `"cgpv1"` to the `isUsableCOSImage` exclusion list to prevent cgroup-v1 GKE images (published for GKE 1.35) from being auto-selected; these cause an immediate kubelet crash on GKE 1.29+ clusters where `--fail-cgroupv1=true` is set.
- The fix is a one-line targeted change with a well-documented inline comment explaining the rationale.
- The existing unit test `TestResolveLatestCOSImage_ExcludesSpecialisedVariants` was not updated to include a `cgpv1` fixture image, leaving the new exclusion without direct unit test coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — minimal, well-justified one-line fix to an exclusion list with a clear inline rationale and e2e verification.

The change is a targeted single-string addition to an existing exclusion list, directly addressing a real production breakage. No regressions are possible from this change, and the PR description includes e2e evidence. The only gap is a missing unit test case for the new entry, which is P2.

pkg/providers/imagefamily/containeroptimizedos_test.go — the specialised-variant exclusion test should be updated to cover cgpv1.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/providers/imagefamily/containeroptimizedos.go | Adds "cgpv1" to the isUsableCOSImage exclusion list with a clear explanatory comment; logic is correct and minimal. Unit test for specialised-variant exclusion is not updated to cover the new entry. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveLatestCOSImage] --> B[GCP Images.List with version filter]
    B --> C{isUsableCOSImage?}
    C -->|img.Deprecated == DEPRECATED/OBSOLETE/DELETED| D[skip]
    C -->|name contains arm64, kmod, nvda, gvisor, -test| D
    C -->|name contains cgpv1 NEW| D
    C -->|passes all checks| E[add to candidates]
    E --> F[sort by CreationTimestamp desc]
    F --> G[return newest candidate]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apkg%2Fproviders%2Fimagefamily%2Fcontaineroptimizedos.go%3A107%0A**Missing%20unit%20test%20for%20new%20exclusion**%0A%0A%60TestResolveLatestCOSImage_ExcludesSpecialisedVariants%60%20covers%20%60arm64%60%2C%20%60nvda%60%2C%20%60kmod%60%2C%20and%20%60-test%60%2C%20but%20no%20test%20case%20exercises%20the%20newly%20added%20%60cgpv1%60%20skip%20entry.%20Without%20it%2C%20a%20future%20refactor%20could%20silently%20re-introduce%20the%20bug.%20Consider%20adding%20a%20%60cgpv1%60%20image%20entry%20%28e.g.%20%60gke-1351-gke1396004-cos-cgpv1-125-19216-104-126-c-pre%60%29%20to%20that%20test's%20fixture%20alongside%20the%20existing%20specialised%20variants%2C%20expecting%20the%20fallback%20non-%60cgpv1%60%20image%20to%20be%20selected.%0A%0A&pr=309&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apkg%2Fproviders%2Fimagefamily%2Fcontaineroptimizedos.go%3A107%0A**Missing%20unit%20test%20for%20new%20exclusion**%0A%0A%60TestResolveLatestCOSImage_ExcludesSpecialisedVariants%60%20covers%20%60arm64%60%2C%20%60nvda%60%2C%20%60kmod%60%2C%20and%20%60-test%60%2C%20but%20no%20test%20case%20exercises%20the%20newly%20added%20%60cgpv1%60%20skip%20entry.%20Without%20it%2C%20a%20future%20refactor%20could%20silently%20re-introduce%20the%20bug.%20Consider%20adding%20a%20%60cgpv1%60%20image%20entry%20%28e.g.%20%60gke-1351-gke1396004-cos-cgpv1-125-19216-104-126-c-pre%60%29%20to%20that%20test's%20fixture%20alongside%20the%20existing%20specialised%20variants%2C%20expecting%20the%20fallback%20non-%60cgpv1%60%20image%20to%20be%20selected.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=309&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22fix%2Fcgpv1-cos-image%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcgpv1-cos-image%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apkg%2Fproviders%2Fimagefamily%2Fcontaineroptimizedos.go%3A107%0A**Missing%20unit%20test%20for%20new%20exclusion**%0A%0A%60TestResolveLatestCOSImage_ExcludesSpecialisedVariants%60%20covers%20%60arm64%60%2C%20%60nvda%60%2C%20%60kmod%60%2C%20and%20%60-test%60%2C%20but%20no%20test%20case%20exercises%20the%20newly%20added%20%60cgpv1%60%20skip%20entry.%20Without%20it%2C%20a%20future%20refactor%20could%20silently%20re-introduce%20the%20bug.%20Consider%20adding%20a%20%60cgpv1%60%20image%20entry%20%28e.g.%20%60gke-1351-gke1396004-cos-cgpv1-125-19216-104-126-c-pre%60%29%20to%20that%20test's%20fixture%20alongside%20the%20existing%20specialised%20variants%2C%20expecting%20the%20fallback%20non-%60cgpv1%60%20image%20to%20be%20selected.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(imagefamily): exclude cgpv1 COS imag..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/8c87f2ede08647373dda16d4534d6f47cf517710) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31192421)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->