### PR TITLE
chore: add release.yml changelog template and clean up PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,11 +37,3 @@ Fixes #
 #### Special notes for your reviewer:
 
 #### Does this PR introduce a user-facing change?
-<!--
-If no, just write "NONE" in the release-note block below.
-If yes, a release note is required:
-Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
--->
-```release-note
-
-```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,6 +33,7 @@ Fixes #
 #### Docs and examples
 
 - [ ] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
+- [ ] `MIGRATION.md` updated (or this PR does not require any migration steps)
 
 #### Special notes for your reviewer:
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes
+      labels:
+        - kind api-change
+    - title: New Features
+      labels:
+        - kind feature
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+        - kind failing-test
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Maintenance
+      labels:
+        - chore
+        - cleanup
+        - test


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Adds `.github/release.yml` to categorize auto-generated release notes by PR label when running `gh release create --generate-notes`. PRs are grouped into Breaking Changes, New Features, Bug Fixes, Documentation, and Maintenance; dependabot PRs are excluded.
- Removes the `release-note` freeform block from the PR template — it is redundant since we generate release notes from PR titles and labels via the GitHub CLI.

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)

#### Special notes for your reviewer:

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

#### Does this PR introduce a user-facing change?