### PR TITLE
fix(networking): inject cluster-id-bearing GCE tag so GKE auto-firewall rules cover karpenter nodes

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -710,7 +710,7 @@ func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *
 		Metadata:          template.Properties.Metadata,
 		Labels:            p.initializeInstanceLabels(nodeClass),
 		Scheduling:        sched,
-		Tags:              buildInstanceTags(p.clusterName, nodeClass.Spec.NetworkTags),
+		Tags:              buildInstanceTags(p.clusterName, clusterConfig.Id, nodeClass.Spec.NetworkTags),
 		GuestAccelerators: template.Properties.GuestAccelerators,
 	}
 
@@ -978,13 +978,15 @@ func (p *DefaultProvider) belongsToCluster(inst *Instance) bool {
 	return !ok || loc == p.clusterLocation
 }
 
-// buildInstanceTags constructs GCE network tags for a new node.
-// The cluster-wide tag (gke-<clusterName>-node) is always included — GKE's
-// cluster-level firewall rules match on this tag. NodeClass network tags are
-// appended after so callers can extend without replacing cluster routing.
-func buildInstanceTags(clusterName string, networkTags []v1alpha1.NetworkTag) *compute.Tags {
-	items := make([]string, 0, 1+len(networkTags))
+// buildInstanceTags emits both the generic gke-<clusterName>-node tag and the
+// cluster-id-bearing gke-<clusterName>-<clusterID[:8]>-node tag (the latter
+// is the target of GKE's auto-created cluster firewall rules), then appends
+// any NodeClass network tags. clusterID must be the 64-char cluster.Id from
+// the Container API.
+func buildInstanceTags(clusterName, clusterID string, networkTags []v1alpha1.NetworkTag) *compute.Tags {
+	items := make([]string, 0, 2+len(networkTags))
 	items = append(items, fmt.Sprintf("gke-%s-node", clusterName))
+	items = append(items, fmt.Sprintf("gke-%s-%s-node", clusterName, clusterID[:8]))
 	for _, t := range networkTags {
 		items = append(items, string(t))
 	}

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -978,15 +978,18 @@ func (p *DefaultProvider) belongsToCluster(inst *Instance) bool {
 	return !ok || loc == p.clusterLocation
 }
 
-// buildInstanceTags emits both the generic gke-<clusterName>-node tag and the
-// cluster-id-bearing gke-<clusterName>-<clusterID[:8]>-node tag (the latter
-// is the target of GKE's auto-created cluster firewall rules), then appends
-// any NodeClass network tags. clusterID must be the 64-char cluster.Id from
-// the Container API.
+// buildInstanceTags emits the generic gke-<clusterName>-node tag and, when
+// clusterID is at least 8 characters, the cluster-id-bearing
+// gke-<clusterName>-<clusterID[:8]>-node tag (the target of GKE's
+// auto-created cluster firewall rules). NodeClass network tags are appended
+// last. clusterID is normally the 64-char cluster.Id from the Container API;
+// the cluster-id tag is omitted if the API returns a short or empty value.
 func buildInstanceTags(clusterName, clusterID string, networkTags []v1alpha1.NetworkTag) *compute.Tags {
 	items := make([]string, 0, 2+len(networkTags))
 	items = append(items, fmt.Sprintf("gke-%s-node", clusterName))
-	items = append(items, fmt.Sprintf("gke-%s-%s-node", clusterName, clusterID[:8]))
+	if len(clusterID) >= 8 {
+		items = append(items, fmt.Sprintf("gke-%s-%s-node", clusterName, clusterID[:8]))
+	}
 	for _, t := range networkTags {
 		items = append(items, string(t))
 	}

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -44,21 +44,6 @@ import (
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
 )
 
-func TestBuildInstanceTagsAlwaysIncludesClusterTag(t *testing.T) {
-	tags := buildInstanceTags("my-cluster", nil)
-	require.Contains(t, tags.Items, "gke-my-cluster-node")
-}
-
-func TestBuildInstanceTagsAppendsNodeClassTags(t *testing.T) {
-	tags := buildInstanceTags("my-cluster", []v1alpha1.NetworkTag{"custom-tag", "another"})
-	require.Equal(t, []string{"gke-my-cluster-node", "custom-tag", "another"}, tags.Items)
-}
-
-func TestBuildInstanceTagsNoNodeClassTags(t *testing.T) {
-	tags := buildInstanceTags("prod-cluster", nil)
-	require.Equal(t, []string{"gke-prod-cluster-node"}, tags.Items)
-}
-
 func TestIsInsufficientCapacityErrorMatchesCode(t *testing.T) {
 	t.Parallel()
 
@@ -697,6 +682,7 @@ func TestRenderDiskProperties_MultipleDisksSetProvisioningIndependently(t *testi
 
 func makeCluster(network, subnetwork, podRangeName string, privateNodes bool) *containerv1.Cluster {
 	c := &containerv1.Cluster{
+		Id: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 		NetworkConfig: &containerv1.NetworkConfig{
 			Network:    network,
 			Subnetwork: subnetwork,
@@ -1270,6 +1256,47 @@ func TestBelongsToCluster(t *testing.T) {
 			p := &DefaultProvider{clusterLocation: controllerLocation}
 			inst := &Instance{InstanceID: "test-instance", Labels: tc.labels}
 			require.Equal(t, tc.want, p.belongsToCluster(inst), tc.name)
+		})
+	}
+}
+
+func TestBuildInstanceTags(t *testing.T) {
+	t.Parallel()
+
+	const (
+		clusterName = "my-cluster"
+		clusterID   = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	)
+	clusterWideTag := fmt.Sprintf("gke-%s-node", clusterName)
+	clusterIDTag := fmt.Sprintf("gke-%s-%s-node", clusterName, clusterID[:8])
+
+	tests := []struct {
+		name        string
+		networkTags []v1alpha1.NetworkTag
+		want        []string
+	}{
+		{
+			name:        "emits both cluster-wide and cluster-id-bearing tags when no NodeClass tags",
+			networkTags: nil,
+			want:        []string{clusterWideTag, clusterIDTag},
+		},
+		{
+			name:        "appends NodeClass tags after cluster-derived tags",
+			networkTags: []v1alpha1.NetworkTag{"frontend-pool", "high-mem"},
+			want:        []string{clusterWideTag, clusterIDTag, "frontend-pool", "high-mem"},
+		},
+		{
+			name:        "de-dupes NodeClass tag that collides with cluster-wide tag",
+			networkTags: []v1alpha1.NetworkTag{v1alpha1.NetworkTag(clusterWideTag), "extra"},
+			want:        []string{clusterWideTag, clusterIDTag, "extra"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tags := buildInstanceTags(clusterName, clusterID, tt.networkTags)
+			require.Equal(t, tt.want, tags.Items)
 		})
 	}
 }

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -1272,30 +1272,46 @@ func TestBuildInstanceTags(t *testing.T) {
 
 	tests := []struct {
 		name        string
+		clusterID   string
 		networkTags []v1alpha1.NetworkTag
 		want        []string
 	}{
 		{
 			name:        "emits both cluster-wide and cluster-id-bearing tags when no NodeClass tags",
+			clusterID:   clusterID,
 			networkTags: nil,
 			want:        []string{clusterWideTag, clusterIDTag},
 		},
 		{
 			name:        "appends NodeClass tags after cluster-derived tags",
+			clusterID:   clusterID,
 			networkTags: []v1alpha1.NetworkTag{"frontend-pool", "high-mem"},
 			want:        []string{clusterWideTag, clusterIDTag, "frontend-pool", "high-mem"},
 		},
 		{
 			name:        "de-dupes NodeClass tag that collides with cluster-wide tag",
+			clusterID:   clusterID,
 			networkTags: []v1alpha1.NetworkTag{v1alpha1.NetworkTag(clusterWideTag), "extra"},
 			want:        []string{clusterWideTag, clusterIDTag, "extra"},
+		},
+		{
+			name:        "omits cluster-id-bearing tag when clusterID is empty",
+			clusterID:   "",
+			networkTags: nil,
+			want:        []string{clusterWideTag},
+		},
+		{
+			name:        "omits cluster-id-bearing tag when clusterID is shorter than 8 chars",
+			clusterID:   "abc1234",
+			networkTags: nil,
+			want:        []string{clusterWideTag},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			tags := buildInstanceTags(clusterName, clusterID, tt.networkTags)
+			tags := buildInstanceTags(clusterName, tt.clusterID, tt.networkTags)
 			require.Equal(t, tt.want, tags.Items)
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Restores the cluster-id-bearing GCE tag (`gke-<clusterName>-<id[:8]>-node`) that pre-#284 `buildInstanceTags` got incidentally via the bootstrap node pool template.

GKE auto-creates firewall rules ([cluster firewall rules docs](https://cloud.google.com/kubernetes-engine/docs/concepts/firewall-rules#cluster-fws)) targeting this tag (`-all`, `-vms`, `-inkubelet`, `-exkubelet`). Without it, kubelet (TCP 10250) is unreachable from the control plane, and `kubectl logs/exec/port-forward` plus metrics-server scraping silently break on every karpenter-provisioned node.

**Symptom:** `kubectl logs <pod>` against pods on karpenter-provisioned nodes fails with `dial tcp <node-ip>:10250: i/o timeout`. `kubectl top node <karpenter-node>` returns "nodemetrics not found." Pods themselves report `Ready` and run normally; only the kubelet API path from the control plane is broken.

**Fix:** The cluster's `Id` (a 64-char hex string) is already fetched via `gkeProvider.GetClusterConfig(ctx)` and threaded into `buildInstance` as `clusterConfig.Id`. This change passes it one more level into `buildInstanceTags` and appends the cluster-id-bearing tag.

Changes:
- `pkg/providers/instance/instance.go`:
  - `buildInstanceTags(clusterName, clusterID, networkTags)`: accepts the cluster ID; appends `gke-<clusterName>-<clusterID[:8]>-node`. Function comment corrected (current comment claims "GKE's cluster-level firewall rules match on this tag" referring to the hash-less tag, which is inaccurate).
  - `buildInstance` caller now passes `clusterConfig.Id`.
- `pkg/providers/instance/instance_test.go`: new `TestBuildInstanceTags` table-test verifying both tags are emitted and `networkTags` are preserved and de-duped. The three older `TestBuildInstanceTags*` functions are removed since they called the prior 2-arg signature; their scenarios are now subsumed by the table-driven test. The `makeCluster` test fixture gains a placeholder `Id` so existing tests that exercise `buildInstance` continue to pass.

/fix https://github.com/cloudpilot-ai/karpenter-provider-gcp/issues/315

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)

#### Does this PR introduce a user-facing change?
None

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Restores the cluster-id-bearing GCE tag (`gke-<clusterName>-<clusterID[:8]>-node`) that was lost in #284, fixing kubelet reachability from the control plane on Karpenter-provisioned nodes (broken `kubectl logs/exec`, metrics-server).
- `buildInstanceTags` now accepts a third `clusterID` parameter and emits the id-bearing tag only when `len(clusterID) >= 8`, safely skipping it for empty/short API responses.
- Old single-scenario tests are replaced by a table-driven `TestBuildInstanceTags` covering both tags, NodeClass tag appending, de-dup, and short/empty ID edge cases.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted two-file fix with appropriate guard, no regressions found.

The previous P1 (unguarded clusterID slice) was addressed in the latest commit via the len(clusterID) >= 8 guard. The logic is straightforward, tests are comprehensive, and the change is minimal in scope.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/providers/instance/instance.go | Adds clusterID parameter to buildInstanceTags, appends cluster-id-bearing GCE tag with a safe len >= 8 guard; no logic issues found. |
| pkg/providers/instance/instance_test.go | Replaces three narrow unit tests with a comprehensive table-driven test; adds 64-char placeholder Id to makeCluster fixture so existing buildInstance tests continue to compile and pass. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant BP as buildInstance
    participant BT as buildInstanceTags
    participant GCE as GCE API

    BP->>BP: "clusterConfig = gkeProvider.GetClusterConfig(ctx)"
    BP->>BT: buildInstanceTags(clusterName, clusterConfig.Id, networkTags)
    BT->>BT: "append "gke-{clusterName}-node""
    alt "len(clusterID) >= 8"
        BT->>BT: "append "gke-{clusterName}-{clusterID[:8]}-node""
    else short/empty clusterID
        BT->>BT: skip cluster-id-bearing tag
    end
    BT->>BT: append NodeClass networkTags
    BT->>BT: lo.Uniq(items)
    BT-->>BP: "*compute.Tags"
    BP->>GCE: CreateInstance(... Tags: ...)
    Note over GCE: GKE firewall rules targeting<br/>gke-{clusterName}-{id[:8]}-node<br/>now cover the new node
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(networking): guard cluster-id tag ag..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/4c567112b027fb048713195265e1ba1a40ea1758) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31251154)</sub>

<!-- /greptile_comment -->