### PR TITLE
fix(networking): inject cluster-id GCE tag (cherry-pick for v0.3.1)

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -710,7 +710,7 @@ func (p *DefaultProvider) buildInstance(nodeClaim *karpv1.NodeClaim, nodeClass *
 		Metadata:          template.Properties.Metadata,
 		Labels:            p.initializeInstanceLabels(nodeClass),
 		Scheduling:        sched,
-		Tags:              buildInstanceTags(p.clusterName, nodeClass.Spec.NetworkTags),
+		Tags:              buildInstanceTags(p.clusterName, clusterConfig.Id, nodeClass.Spec.NetworkTags),
 		GuestAccelerators: template.Properties.GuestAccelerators,
 	}
 
@@ -978,13 +978,18 @@ func (p *DefaultProvider) belongsToCluster(inst *Instance) bool {
 	return !ok || loc == p.clusterLocation
 }
 
-// buildInstanceTags constructs GCE network tags for a new node.
-// The cluster-wide tag (gke-<clusterName>-node) is always included — GKE's
-// cluster-level firewall rules match on this tag. NodeClass network tags are
-// appended after so callers can extend without replacing cluster routing.
-func buildInstanceTags(clusterName string, networkTags []v1alpha1.NetworkTag) *compute.Tags {
-	items := make([]string, 0, 1+len(networkTags))
+// buildInstanceTags emits the generic gke-<clusterName>-node tag and, when
+// clusterID is at least 8 characters, the cluster-id-bearing
+// gke-<clusterName>-<clusterID[:8]>-node tag (the target of GKE's
+// auto-created cluster firewall rules). NodeClass network tags are appended
+// last. clusterID is normally the 64-char cluster.Id from the Container API;
+// the cluster-id tag is omitted if the API returns a short or empty value.
+func buildInstanceTags(clusterName, clusterID string, networkTags []v1alpha1.NetworkTag) *compute.Tags {
+	items := make([]string, 0, 2+len(networkTags))
 	items = append(items, fmt.Sprintf("gke-%s-node", clusterName))
+	if len(clusterID) >= 8 {
+		items = append(items, fmt.Sprintf("gke-%s-%s-node", clusterName, clusterID[:8]))
+	}
 	for _, t := range networkTags {
 		items = append(items, string(t))
 	}

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -44,21 +44,6 @@ import (
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
 )
 
-func TestBuildInstanceTagsAlwaysIncludesClusterTag(t *testing.T) {
-	tags := buildInstanceTags("my-cluster", nil)
-	require.Contains(t, tags.Items, "gke-my-cluster-node")
-}
-
-func TestBuildInstanceTagsAppendsNodeClassTags(t *testing.T) {
-	tags := buildInstanceTags("my-cluster", []v1alpha1.NetworkTag{"custom-tag", "another"})
-	require.Equal(t, []string{"gke-my-cluster-node", "custom-tag", "another"}, tags.Items)
-}
-
-func TestBuildInstanceTagsNoNodeClassTags(t *testing.T) {
-	tags := buildInstanceTags("prod-cluster", nil)
-	require.Equal(t, []string{"gke-prod-cluster-node"}, tags.Items)
-}
-
 func TestIsInsufficientCapacityErrorMatchesCode(t *testing.T) {
 	t.Parallel()
 
@@ -697,6 +682,7 @@ func TestRenderDiskProperties_MultipleDisksSetProvisioningIndependently(t *testi
 
 func makeCluster(network, subnetwork, podRangeName string, privateNodes bool) *containerv1.Cluster {
 	c := &containerv1.Cluster{
+		Id: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 		NetworkConfig: &containerv1.NetworkConfig{
 			Network:    network,
 			Subnetwork: subnetwork,
@@ -1270,6 +1256,63 @@ func TestBelongsToCluster(t *testing.T) {
 			p := &DefaultProvider{clusterLocation: controllerLocation}
 			inst := &Instance{InstanceID: "test-instance", Labels: tc.labels}
 			require.Equal(t, tc.want, p.belongsToCluster(inst), tc.name)
+		})
+	}
+}
+
+func TestBuildInstanceTags(t *testing.T) {
+	t.Parallel()
+
+	const (
+		clusterName = "my-cluster"
+		clusterID   = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	)
+	clusterWideTag := fmt.Sprintf("gke-%s-node", clusterName)
+	clusterIDTag := fmt.Sprintf("gke-%s-%s-node", clusterName, clusterID[:8])
+
+	tests := []struct {
+		name        string
+		clusterID   string
+		networkTags []v1alpha1.NetworkTag
+		want        []string
+	}{
+		{
+			name:        "emits both cluster-wide and cluster-id-bearing tags when no NodeClass tags",
+			clusterID:   clusterID,
+			networkTags: nil,
+			want:        []string{clusterWideTag, clusterIDTag},
+		},
+		{
+			name:        "appends NodeClass tags after cluster-derived tags",
+			clusterID:   clusterID,
+			networkTags: []v1alpha1.NetworkTag{"frontend-pool", "high-mem"},
+			want:        []string{clusterWideTag, clusterIDTag, "frontend-pool", "high-mem"},
+		},
+		{
+			name:        "de-dupes NodeClass tag that collides with cluster-wide tag",
+			clusterID:   clusterID,
+			networkTags: []v1alpha1.NetworkTag{v1alpha1.NetworkTag(clusterWideTag), "extra"},
+			want:        []string{clusterWideTag, clusterIDTag, "extra"},
+		},
+		{
+			name:        "omits cluster-id-bearing tag when clusterID is empty",
+			clusterID:   "",
+			networkTags: nil,
+			want:        []string{clusterWideTag},
+		},
+		{
+			name:        "omits cluster-id-bearing tag when clusterID is shorter than 8 chars",
+			clusterID:   "abc1234",
+			networkTags: nil,
+			want:        []string{clusterWideTag},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tags := buildInstanceTags(clusterName, tt.clusterID, tt.networkTags)
+			require.Equal(t, tt.want, tags.Items)
 		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Cherry-pick of #314 onto `release-0.3` for the v0.3.1 patch release.

PR #284 introduced a regression in v0.3.0: the cluster-id-bearing GCE network tag (`gke-<cluster>-<clusterID[:8]>-node`) was dropped. GKE auto-creates firewall rules targeting that exact tag to allow control-plane → kubelet traffic on TCP 10250. Without it, `kubectl logs`, `kubectl exec`, `kubectl port-forward`, and metrics-server fail silently on Karpenter-managed nodes.

Commits cherry-picked:
- `efa7ca8d` — inject cluster-id-bearing tag at instance creation
- `4c567112` — guard against short/empty clusterID

#### Which issue(s) this PR fixes:

Fixes #315

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)

#### Special notes for your reviewer:

- Cherry-pick of #314; e2e already ran against the source commit (`4c567112`) — all 15 specs passed. No additional e2e run needed.
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a regression introduced in v0.3.0 where Karpenter-managed nodes were missing the cluster-id GCE network tag required for GKE control-plane → kubelet firewall rules, causing `kubectl logs/exec/port-forward` and metrics-server to fail.
```

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Fixes a regression from v0.3.0 where the `gke-<clusterName>-<clusterID[:8]>-node` GCE network tag was missing from Karpenter-managed nodes, breaking GKE firewall rules for control-plane → kubelet traffic (TCP 10250) and causing `kubectl logs/exec/port-forward` and metrics-server failures.
- `buildInstanceTags` now accepts `clusterID` (sourced from `clusterConfig.Id`) and emits the cluster-id-bearing tag only when the ID is at least 8 characters; `lo.Uniq` deduplicates the final tag list.
- Test coverage is updated with a parallel table-driven suite that validates both the happy path and the short/empty clusterID guard cases.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — targeted one-line fix with a proper guard, no regressions introduced.

The change is minimal and well-scoped: a single new parameter threaded through one function, guarded against short/empty IDs, and deduplicated via `lo.Uniq`. The fix directly restores a tag that GKE's own firewall rules depend on. Tests are comprehensive, covering happy path, deduplication, and both edge-case guards. No security or data-loss risk introduced.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/providers/instance/instance.go | Adds `clusterID` parameter to `buildInstanceTags` and injects the `gke-<clusterName>-<clusterID[:8]>-node` tag when clusterID is at least 8 chars; uses `lo.Uniq` to deduplicate. |
| pkg/providers/instance/instance_test.go | Replaces three narrow unit tests with a comprehensive parallel table-driven test covering cluster-id tag injection, NodeClass tag appending, deduplication, and empty/short clusterID guards. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant KP as Karpenter Provider
    participant GKE as Container API
    participant CE as Compute Engine

    KP->>GKE: GetCluster()
    GKE-->>KP: clusterConfig (with Id)
    KP->>KP: buildInstanceTags(clusterName, clusterConfig.Id, networkTags)
    note over KP: Always adds gke-{clusterName}-node<br/>If len(clusterID) >= 8:<br/>  adds gke-{clusterName}-{clusterID[:8]}-node<br/>Appends NodeClass tags<br/>lo.Uniq deduplicates
    KP->>CE: "CreateInstance(tags=[cluster-wide, cluster-id, nodeclass-tags])"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(networking): guard cluster-id tag ag..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/9be502333116cc72e67043407e0aeb01b1e4d561) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31257634)</sub>

<!-- /greptile_comment -->