### PR TITLE
feat(chart): add ServiceMonitor for Prometheus Operator scraping

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -119,3 +119,10 @@ helm install karpenter karpenter-gcp/karpenter \
 | serviceAccount.automount | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| serviceMonitor.additionalLabels | object | `{}` | Additional labels for the ServiceMonitor. |
+| serviceMonitor.enabled | bool | `false` | Specifies whether a ServiceMonitor should be created. |
+| serviceMonitor.interval | string | `""` | Scrape interval for the `http-metrics` endpoint. Empty string uses the Prometheus operator's default (typically 30s). |
+| serviceMonitor.metricRelabelings | list | `[]` | Metric relabelings for the `http-metrics` endpoint on the ServiceMonitor. For more details on metric relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs |
+| serviceMonitor.relabelings | list | `[]` | Relabelings for the `http-metrics` endpoint on the ServiceMonitor. For more details on relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config |
+| serviceMonitor.sampleLimit | string | `nil` | Specifies the sampleLimit for prometheus scrapes. Per-scrape limit on the number of scraped samples that will be accepted. If more than this number of samples are present after metric relabeling the entire scrape will be treated as failed. 0 means no limit. |
+| serviceMonitor.scrapeTimeout | string | `""` | Scrape timeout for the `http-metrics` endpoint. Empty string uses the Prometheus operator's default (typically 10s). |

--- a/charts/karpenter/templates/servicemonitor.yaml
+++ b/charts/karpenter/templates/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "karpenter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "karpenter.labels" . | nindent 4 }}
+  {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.additionalAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "karpenter.selectorLabels" . | nindent 6 }}
+  {{- if not (eq .Values.serviceMonitor.sampleLimit nil) }}
+  sampleLimit: {{ .Values.serviceMonitor.sampleLimit }}
+  {{- end }}
+  endpoints:
+    - port: http-metrics
+      path: /metrics
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- with .Values.serviceMonitor.endpointConfig }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end -}}

--- a/charts/karpenter/templates/servicemonitor.yaml
+++ b/charts/karpenter/templates/servicemonitor.yaml
@@ -26,13 +26,13 @@ spec:
   endpoints:
     - port: http-metrics
       path: /metrics
-      {{- with .Values.serviceMonitor.relabelings }}
+      {{- if and .Values.serviceMonitor.relabelings (not (hasKey .Values.serviceMonitor.endpointConfig "relabelings")) }}
       relabelings:
-        {{- toYaml . | nindent 6 }}
+        {{- toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
-      {{- with .Values.serviceMonitor.metricRelabelings }}
+      {{- if and .Values.serviceMonitor.metricRelabelings (not (hasKey .Values.serviceMonitor.endpointConfig "metricRelabelings")) }}
       metricRelabelings:
-        {{- toYaml . | nindent 6 }}
+        {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
       {{- end }}
     {{- with .Values.serviceMonitor.endpointConfig }}
       {{- toYaml . | nindent 6 }}

--- a/charts/karpenter/templates/servicemonitor.yaml
+++ b/charts/karpenter/templates/servicemonitor.yaml
@@ -26,15 +26,18 @@ spec:
   endpoints:
     - port: http-metrics
       path: /metrics
-      {{- if and .Values.serviceMonitor.relabelings (not (hasKey .Values.serviceMonitor.endpointConfig "relabelings")) }}
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
       relabelings:
-        {{- toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- if and .Values.serviceMonitor.metricRelabelings (not (hasKey .Values.serviceMonitor.endpointConfig "metricRelabelings")) }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
       metricRelabelings:
-        {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
-    {{- with .Values.serviceMonitor.endpointConfig }}
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
 {{- end -}}

--- a/charts/karpenter/values.schema.json
+++ b/charts/karpenter/values.schema.json
@@ -71,6 +71,46 @@
         }
       }
     },
+    "serviceMonitor": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Configuration for the optional Prometheus Operator ServiceMonitor.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether to create a ServiceMonitor for Prometheus Operator scraping.",
+          "default": false
+        },
+        "additionalLabels": {
+          "type": "object",
+          "description": "Additional labels to apply to the ServiceMonitor.",
+          "default": {}
+        },
+        "relabelings": {
+          "type": "array",
+          "description": "Relabelings for the http-metrics endpoint on the ServiceMonitor.",
+          "default": []
+        },
+        "metricRelabelings": {
+          "type": "array",
+          "description": "Metric relabelings for the http-metrics endpoint on the ServiceMonitor.",
+          "default": []
+        },
+        "endpointConfig": {
+          "type": "object",
+          "description": "Configuration applied to the http-metrics endpoint of the ServiceMonitor.",
+          "default": {}
+        },
+        "sampleLimit": {
+          "oneOf": [
+            { "type": "null" },
+            { "type": "integer", "minimum": 0 }
+          ],
+          "description": "Per-scrape sample limit. 0 or null means no limit.",
+          "default": null
+        }
+      }
+    },
     "serviceAccount": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/karpenter/values.schema.json
+++ b/charts/karpenter/values.schema.json
@@ -86,6 +86,16 @@
           "description": "Additional labels to apply to the ServiceMonitor.",
           "default": {}
         },
+        "interval": {
+          "type": "string",
+          "description": "Scrape interval for the http-metrics endpoint. Empty uses the Prometheus operator default.",
+          "default": ""
+        },
+        "scrapeTimeout": {
+          "type": "string",
+          "description": "Scrape timeout for the http-metrics endpoint. Empty uses the Prometheus operator default.",
+          "default": ""
+        },
         "relabelings": {
           "type": "array",
           "description": "Relabelings for the http-metrics endpoint on the ServiceMonitor.",
@@ -95,11 +105,6 @@
           "type": "array",
           "description": "Metric relabelings for the http-metrics endpoint on the ServiceMonitor.",
           "default": []
-        },
-        "endpointConfig": {
-          "type": "object",
-          "description": "Configuration applied to the http-metrics endpoint of the ServiceMonitor.",
-          "default": {}
         },
         "sampleLimit": {
           "oneOf": [

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -38,16 +38,16 @@ serviceMonitor:
   enabled: false
   # -- Additional labels for the ServiceMonitor.
   additionalLabels: {}
+  # -- Scrape interval for the `http-metrics` endpoint. Empty string uses the Prometheus operator's default (typically 30s).
+  interval: ""
+  # -- Scrape timeout for the `http-metrics` endpoint. Empty string uses the Prometheus operator's default (typically 10s).
+  scrapeTimeout: ""
   # -- Relabelings for the `http-metrics` endpoint on the ServiceMonitor.
   # For more details on relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
   relabelings: []
   # -- Metric relabelings for the `http-metrics` endpoint on the ServiceMonitor.
   # For more details on metric relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
   metricRelabelings: []
-  # -- Configuration on `http-metrics` endpoint for the ServiceMonitor.
-  # Not to be used to add additional endpoints.
-  # See the Prometheus operator documentation for configurable fields https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#endpoint
-  endpointConfig: {}
   # -- Specifies the sampleLimit for prometheus scrapes.
   # Per-scrape limit on the number of scraped samples that will be accepted.
   # If more than this number of samples are present after metric relabeling

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -33,6 +33,27 @@ imagePullSecrets: []
 podDisruptionBudget:
   minAvailable: 1
 
+serviceMonitor:
+  # -- Specifies whether a ServiceMonitor should be created.
+  enabled: false
+  # -- Additional labels for the ServiceMonitor.
+  additionalLabels: {}
+  # -- Relabelings for the `http-metrics` endpoint on the ServiceMonitor.
+  # For more details on relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+  relabelings: []
+  # -- Metric relabelings for the `http-metrics` endpoint on the ServiceMonitor.
+  # For more details on metric relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+  metricRelabelings: []
+  # -- Configuration on `http-metrics` endpoint for the ServiceMonitor.
+  # Not to be used to add additional endpoints.
+  # See the Prometheus operator documentation for configurable fields https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#endpoint
+  endpointConfig: {}
+  # -- Specifies the sampleLimit for prometheus scrapes.
+  # Per-scrape limit on the number of scraped samples that will be accepted.
+  # If more than this number of samples are present after metric relabeling
+  # the entire scrape will be treated as failed. 0 means no limit.
+  sampleLimit: null
+
 controller:
   replicaCount: 2
   revisionHistoryLimit: 10


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds an opt-in `ServiceMonitor` template (gated on `serviceMonitor.enabled` AND on the `monitoring.coreos.com/v1` API being available) so Prometheus Operator clusters can scrape karpenter's existing `/metrics` endpoint without an out-of-band manifest. Disabled by default; no behavioral change on existing installations.

The values surface intentionally diverges from the AWS karpenter chart: explicit typed fields (`interval`, `scrapeTimeout`, `relabelings`, `metricRelabelings`, `sampleLimit`) instead of an `endpointConfig` arbitrary-shape escape hatch. Keeps consistency with this chart's `additionalProperties: false` strict-schema convention.

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)

#### Special notes for your reviewer:

`helm template` verified across three cases:
- Default (`serviceMonitor.enabled=false`): no ServiceMonitor emitted.
- `serviceMonitor.enabled=true` with `monitoring.coreos.com/v1` API available: ServiceMonitor emitted; `spec.selector` matches the chart's `Service`, `endpoints[0]` targets `http-metrics` / `/metrics`, `additionalLabels` merge in correctly.
- `serviceMonitor.enabled=true` without the CRD: no ServiceMonitor emitted.

#### Does this PR introduce a user-facing change?

```release-note
chart: Add opt-in `serviceMonitor` block. Disabled by default.
```