### PR TITLE
docs: Document ServiceMonitor for Prometheus Operator integration

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -68,6 +68,27 @@ helm install karpenter karpenter-gcp/karpenter \
   ...
 ```
 
+## Prometheus Operator Integration
+
+Enable automatic metric scraping with a ServiceMonitor when using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator):
+
+```bash
+helm install karpenter karpenter-gcp/karpenter \
+  --set serviceMonitor.enabled=true \
+  ...
+```
+
+The ServiceMonitor requires the Prometheus Operator CRDs (`monitoring.coreos.com/v1`) to be installed in your cluster.
+
+Add labels to match your Prometheus instance's selector:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: prometheus
+```
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -119,3 +140,9 @@ helm install karpenter karpenter-gcp/karpenter \
 | serviceAccount.automount | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor for Prometheus Operator scraping. Requires the Prometheus Operator CRDs to be installed (`monitoring.coreos.com/v1`). |
+| serviceMonitor.additionalLabels | object | `{}` | Additional labels to apply to the ServiceMonitor. Use this to match Prometheus Operator label selectors. |
+| serviceMonitor.relabelings | array | `[]` | Relabelings for the `http-metrics` endpoint. See [Prometheus relabel_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config). |
+| serviceMonitor.metricRelabelings | array | `[]` | Metric relabelings for the `http-metrics` endpoint. See [Prometheus metric_relabel_configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs). |
+| serviceMonitor.endpointConfig | object | `{}` | Additional configuration for the `http-metrics` endpoint. See [Prometheus Operator Endpoint API](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#endpoint). |
+| serviceMonitor.sampleLimit | int/null | `null` | Per-scrape sample limit. If more samples are present after metric relabeling, the scrape is treated as failed. `0` or `null` means no limit. |

--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -68,6 +68,27 @@ helm install karpenter karpenter-gcp/karpenter \
   ...
 ```
 
+## Prometheus Operator Integration
+
+Enable automatic metric scraping with a ServiceMonitor when using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator):
+
+```bash
+helm install karpenter karpenter-gcp/karpenter \
+  --set serviceMonitor.enabled=true \
+  ...
+```
+
+The ServiceMonitor requires the Prometheus Operator CRDs (`monitoring.coreos.com/v1`) to be installed in your cluster.
+
+Add labels to match your Prometheus instance's selector:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: prometheus
+```
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -68,27 +68,6 @@ helm install karpenter karpenter-gcp/karpenter \
   ...
 ```
 
-## Prometheus Operator Integration
-
-Enable automatic metric scraping with a ServiceMonitor when using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator):
-
-```bash
-helm install karpenter karpenter-gcp/karpenter \
-  --set serviceMonitor.enabled=true \
-  ...
-```
-
-The ServiceMonitor requires the Prometheus Operator CRDs (`monitoring.coreos.com/v1`) to be installed in your cluster.
-
-Add labels to match your Prometheus instance's selector:
-
-```yaml
-serviceMonitor:
-  enabled: true
-  additionalLabels:
-    release: prometheus
-```
-
 ## Values
 
 | Key | Type | Default | Description |
@@ -140,9 +119,3 @@ serviceMonitor:
 | serviceAccount.automount | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
-| serviceMonitor.enabled | bool | `false` | Whether to create a ServiceMonitor for Prometheus Operator scraping. Requires the Prometheus Operator CRDs to be installed (`monitoring.coreos.com/v1`). |
-| serviceMonitor.additionalLabels | object | `{}` | Additional labels to apply to the ServiceMonitor. Use this to match Prometheus Operator label selectors. |
-| serviceMonitor.relabelings | array | `[]` | Relabelings for the `http-metrics` endpoint. See [Prometheus relabel_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config). |
-| serviceMonitor.metricRelabelings | array | `[]` | Metric relabelings for the `http-metrics` endpoint. See [Prometheus metric_relabel_configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs). |
-| serviceMonitor.endpointConfig | object | `{}` | Additional configuration for the `http-metrics` endpoint. See [Prometheus Operator Endpoint API](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#endpoint). |
-| serviceMonitor.sampleLimit | int/null | `null` | Per-scrape sample limit. If more samples are present after metric relabeling, the scrape is treated as failed. `0` or `null` means no limit. |

--- a/charts/karpenter/README.md.gotmpl
+++ b/charts/karpenter/README.md.gotmpl
@@ -68,4 +68,25 @@ helm install karpenter karpenter-gcp/karpenter \
   ...
 ```
 
+## Prometheus Operator Integration
+
+Enable automatic metric scraping with a ServiceMonitor when using the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator):
+
+```bash
+helm install karpenter karpenter-gcp/karpenter \
+  --set serviceMonitor.enabled=true \
+  ...
+```
+
+The ServiceMonitor requires the Prometheus Operator CRDs (`monitoring.coreos.com/v1`) to be installed in your cluster.
+
+Add labels to match your Prometheus instance's selector:
+
+```yaml
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: prometheus
+```
+
 {{ template "chart.valuesSection" . }}


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/1ebd37b7-00a0-495f-8bc1-d3c442e3e22d)

Documents the new serviceMonitor Helm values added in PR #317 that enable automatic metric scraping with the Prometheus Operator. Includes a usage section with examples and reference documentation for all configuration options (enabled, additionalLabels, relabelings, metricRelabelings, endpointConfig, sampleLimit).

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #317: feat(chart): add ServiceMonitor for Prometheus Operator scraping](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/317)

---

_Tip: Leave inline comments with `@Promptless` on suggestion diffs in the [Promptless dashboard](https://app.gopromptless.ai/suggestions) for targeted refinements 💬_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Prometheus Operator Integration" section to `README.md.gotmpl` with usage examples for enabling a ServiceMonitor. However, the referenced implementation (`serviceMonitor.*` values and a ServiceMonitor template from PR #317) is not yet present in the chart, meaning the docs describe features that silently have no effect if merged before PR #317.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge until PR #317 (the ServiceMonitor implementation) is merged first.

The sole changed file is documentation referencing chart values and a Kubernetes resource entirely absent from the codebase. Merging in this order means the published README instructs users to set values that are silently ignored.

charts/karpenter/README.md.gotmpl — depends on implementation changes from PR #317 that are not yet merged.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| charts/karpenter/README.md.gotmpl | Adds a Prometheus Operator Integration section with usage examples for serviceMonitor values, but the referenced implementation from PR #317 is not yet present in the chart. |

</details>

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acharts%2Fkarpenter%2FREADME.md.gotmpl%3A71-90%0A**Implementation%20not%20yet%20merged**%0A%0AThe%20documentation%20references%20%60serviceMonitor.*%60%20values%20%28%60serviceMonitor.enabled%60%2C%20%60serviceMonitor.additionalLabels%60%29%20and%20a%20ServiceMonitor%20template%2C%20but%20neither%20%60values.yaml%60%20nor%20any%20file%20under%20%60charts%2Fkarpenter%2Ftemplates%2F%60%20currently%20contains%20the%20ServiceMonitor%20implementation%20%E2%80%94%20there%20is%20no%20%60servicemonitor.yaml%60%20template%20and%20no%20%60serviceMonitor%60%20key%20in%20%60values.yaml%60.%20If%20this%20PR%20is%20merged%20before%20PR%20%23317%2C%20users%20who%20follow%20the%20docs%20and%20run%20%60helm%20install%20...%20--set%20serviceMonitor.enabled%3Dtrue%60%20will%20silently%20set%20an%20unknown%20value%20with%20no%20effect%2C%20and%20no%20%60ServiceMonitor%60%20resource%20will%20be%20created.%0A%0A&pr=318&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acharts%2Fkarpenter%2FREADME.md.gotmpl%3A71-90%0A**Implementation%20not%20yet%20merged**%0A%0AThe%20documentation%20references%20%60serviceMonitor.*%60%20values%20%28%60serviceMonitor.enabled%60%2C%20%60serviceMonitor.additionalLabels%60%29%20and%20a%20ServiceMonitor%20template%2C%20but%20neither%20%60values.yaml%60%20nor%20any%20file%20under%20%60charts%2Fkarpenter%2Ftemplates%2F%60%20currently%20contains%20the%20ServiceMonitor%20implementation%20%E2%80%94%20there%20is%20no%20%60servicemonitor.yaml%60%20template%20and%20no%20%60serviceMonitor%60%20key%20in%20%60values.yaml%60.%20If%20this%20PR%20is%20merged%20before%20PR%20%23317%2C%20users%20who%20follow%20the%20docs%20and%20run%20%60helm%20install%20...%20--set%20serviceMonitor.enabled%3Dtrue%60%20will%20silently%20set%20an%20unknown%20value%20with%20no%20effect%2C%20and%20no%20%60ServiceMonitor%60%20resource%20will%20be%20created.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=318&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22promptless%2Fdocument-servicemonitor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22promptless%2Fdocument-servicemonitor%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acharts%2Fkarpenter%2FREADME.md.gotmpl%3A71-90%0A**Implementation%20not%20yet%20merged**%0A%0AThe%20documentation%20references%20%60serviceMonitor.*%60%20values%20%28%60serviceMonitor.enabled%60%2C%20%60serviceMonitor.additionalLabels%60%29%20and%20a%20ServiceMonitor%20template%2C%20but%20neither%20%60values.yaml%60%20nor%20any%20file%20under%20%60charts%2Fkarpenter%2Ftemplates%2F%60%20currently%20contains%20the%20ServiceMonitor%20implementation%20%E2%80%94%20there%20is%20no%20%60servicemonitor.yaml%60%20template%20and%20no%20%60serviceMonitor%60%20key%20in%20%60values.yaml%60.%20If%20this%20PR%20is%20merged%20before%20PR%20%23317%2C%20users%20who%20follow%20the%20docs%20and%20run%20%60helm%20install%20...%20--set%20serviceMonitor.enabled%3Dtrue%60%20will%20silently%20set%20an%20unknown%20value%20with%20no%20effect%2C%20and%20no%20%60ServiceMonitor%60%20resource%20will%20be%20created.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Move ServiceMonitor docs to template fil..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/56ec5018593ecd833a8159e72660d554518c363b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31449989)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->