### PR TITLE
fix(dependabot): ignore k8s.io/* packages to prevent update failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,12 @@
 
 version: 2
 updates:
-  - package-ecosystem: "gomod" 
-    directory: "/" 
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "k8s.io/*"
     groups:
       karpenter-core:
         patterns:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Dependabot was failing when trying to independently upgrade `k8s.io/api` — newer versions (v0.36+) remove packages like `autoscaling/v2beta1`, `autoscaling/v2beta2`, and `scheduling/v1alpha1`, which `k8s.io/client-go` at the current version still imports. This causes a `dependency_file_not_resolvable` error every Dependabot run.

The fix adds an `ignore` rule for `k8s.io/*` in `dependabot.yml`. These packages are tightly coupled to `sigs.k8s.io/karpenter` and must be upgraded together as a coordinated set — they cannot be safely bumped in isolation.

Failing run: https://github.com/cloudpilot-ai/karpenter-provider-gcp/actions/runs/25679089291/job/75385295363

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

No — CI/Dependabot configuration only.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Adds a Dependabot `ignore` rule for `k8s.io/*` packages to prevent `dependency_file_not_resolvable` failures caused by Dependabot independently upgrading `k8s.io/api` to v0.36+, which removes packages still required by the current `k8s.io/client-go`.
- The `k8s.io/*` packages must be upgraded in lockstep with `sigs.k8s.io/karpenter`; the ignore rule is the correct approach to stop Dependabot from proposing isolated bumps.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it is a targeted CI config fix with no production code impact.

The change is a single-line addition of a well-scoped Dependabot ignore rule. The rationale is clearly documented and technically sound. No logic, security, or correctness concerns apply to this config-only change.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds `ignore` rule for `k8s.io/*` to prevent Dependabot from independently upgrading tightly-coupled k8s packages; also removes trailing whitespace on two existing lines. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot weekly run] --> B{Package ecosystem: gomod}
    B --> C{Is dependency k8s.io/*?}
    C -- Yes --> D[Ignored — no PR raised]
    C -- No --> E{Matches karpenter-core group?\nsigs.k8s.io/karpenter}
    E -- Yes --> F[Grouped PR: karpenter-core]
    E -- No --> G[Grouped PR: go-dependencies]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dependabot): ignore k8s.io/\* package..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/403763a348df15d4873a22479a77d47951b6dcdf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31631358)</sub>

<!-- /greptile_comment -->