### PR TITLE
fix(dependabot): enable vendor mode for go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    vendor: true
     ignore:
       - dependency-name: "k8s.io/*"
     groups:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The project uses a `vendor/` directory, but Dependabot was running without `vendor: true`, so it only updated `go.mod`/`go.sum` and left `vendor/` stale. A PR with inconsistent `go.mod` + `vendor/` would break the build, so Dependabot's backend silently skipped PR creation even when updates were available (the `command:version` discovery job posted `create_pull_request` with a 204 but no PR ever appeared).

Adding `vendor: true` tells Dependabot to also run `go mod vendor` and include the vendor changes in the PR.

Observed in: https://github.com/cloudpilot-ai/karpenter-provider-gcp/actions/runs/25686945640

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

No — CI/Dependabot configuration only.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Adds `vendor: true` to the `gomod` Dependabot configuration so that dependency-update PRs also run `go mod vendor` and keep the `vendor/` directory in sync with `go.mod`/`go.sum`.
- Without this flag, Dependabot's consistency check detected a mismatch between `go.mod` and `vendor/`, causing it to silently skip PR creation despite a successful `create_pull_request` response (HTTP 204).
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-line config change that correctly enables vendor mode for Dependabot go module updates.

The change is minimal, well-scoped, and directly matches the documented Dependabot `vendor` option for Go modules. It resolves a real, observed failure (silent PR-skipping) with no risk to production code.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds `vendor: true` to the gomod Dependabot entry so dependency PRs include `go mod vendor` changes alongside `go.mod`/`go.sum` updates, fixing silent PR-creation failures. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dependabot): enable vendor mode for ..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/af865eba7a7297cdfec114a11db044b5255aae23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31635014)</sub>

<!-- /greptile_comment -->