### PR TITLE
fix(dependabot): remove invalid vendor option for gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    vendor: true
     ignore:
       - dependency-name: "k8s.io/*"
     groups:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Removes the `vendor: true` property added in #322. This option is not part of Dependabot's schema for the `gomod` ecosystem and causes a config parse error:

> The property '#/updates/0/' contains additional properties ["vendor"] outside of the schema when none are allowed

Dependabot handles Go vendor directories automatically without explicit configuration.

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

No — CI/Dependabot configuration only.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Removes the invalid `vendor: true` property from `.github/dependabot.yml`'s `gomod` ecosystem entry, which was causing a Dependabot schema validation error introduced in #322.
- No functional change to update behavior; Dependabot handles Go vendor directories automatically for `gomod`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-line config fix with no functional side-effects.

The change is a one-line removal of a property that is explicitly invalid per Dependabot's schema. The remaining config is well-formed, and no logic or runtime behavior is affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Removes the invalid `vendor: true` property from the `gomod` ecosystem entry; the remaining config is well-formed and correct. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot parses dependabot.yml] --> B{Schema valid?}
    B -- "Before PR (vendor: true present)" --> C[Schema error — unknown property\nDependabot skips gomod updates]
    B -- "After PR (vendor: true removed)" --> D[Schema valid\nDependabot runs weekly gomod updates]
    D --> E[Ignores k8s.io/* deps]
    D --> F[Groups: karpenter-core & go-dependencies]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dependabot): remove invalid vendor o..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/6578d43b3f45a6a3a7078fea4a81911f51245655) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31637662)</sub>

<!-- /greptile_comment -->