### PR TITLE
Revert "fix(dependabot): enable vendor mode for go modules"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    vendor: true
     ignore:
       - dependency-name: "k8s.io/*"
     groups:


### PR DESCRIPTION
Reverts cloudpilot-ai/karpenter-provider-gcp#322 as it leads to https://github.com/dependabot/dependabot-core/issues/8948#issuecomment-2522129687

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Reverts the `vendor: true` option from the `gomod` dependabot configuration (`.github/dependabot.yml`), which was added in PR #322 to enable vendor mode for Go module updates.
- The revert is justified by a known dependabot-core bug ([dependabot/dependabot-core#8948](https://github.com/dependabot/dependabot-core/issues/8948)) that causes failures when vendor mode is enabled for Go modules.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — single-line config revert with a clear, referenced upstream justification.

The change is a minimal, well-justified revert of a single configuration option. The upstream bug reference confirms the motivation, there is no logic, no code path, and no security implication involved.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Removes `vendor: true` from the gomod ecosystem block, reverting PR #322 due to a known upstream dependabot-core bug with vendor mode. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot scheduled run] --> B{gomod ecosystem}
    B --> C[Resolve dependencies via go.mod / go.sum]
    C --> D{vendor: true present?}
    D -- "Yes (PR #322, reverted)" --> E[Vendor mode enabled\n⚠️ triggers dependabot-core bug #8948]
    E --> F[Dependabot update fails]
    D -- "No (this PR)" --> G[Standard module resolution]
    G --> H[Dependabot opens update PRs successfully]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;fix(dependabot): enable vendor m..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/6b7ed9f250a3387f03575c2df4072d278dd761dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31654434)</sub>

<!-- /greptile_comment -->