### PR TITLE
docs: Add DEFAULT_NODEPOOL_SERVICE_ACCOUNT to settings reference

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -35,13 +35,35 @@ These options configure the controller's runtime behavior.
 
 ## GCP-specific Settings
 
-| Setting            | Env var                      | Helm value                                    | Required | Description                                                                     |
-|--------------------|------------------------------|-----------------------------------------------|----------|---------------------------------------------------------------------------------|
-| Project ID         | `PROJECT_ID`                 | `controller.settings.projectID`               | Yes      | GCP project where nodes are provisioned.                                        |
-| Cluster name       | `CLUSTER_NAME`               | `controller.settings.clusterName`             | Yes      | GKE cluster name. Used to scope instance discovery.                             |
-| Cluster location   | `CLUSTER_LOCATION`           | `controller.settings.clusterLocation`         | Yes      | GKE cluster location (zone or region, e.g. `us-central1-f`).                    |
-| Node location      | `NODE_LOCATION`              | `controller.settings.nodeLocation`            | No       | Override zone for node placement. Defaults to cluster location.                 |
-| VM memory overhead | `VM_MEMORY_OVERHEAD_PERCENT` | `controller.settings.vmMemoryOverheadPercent` | No       | Fraction of node memory reserved for OS/kubelet overhead (e.g. `0.075` = 7.5%). |
+| Setting            | Env var                            | Helm value                                    | Required | Description                                                                     |
+|--------------------|----------------------------------|-----------------------------------------------|----------|---------------------------------------------------------------------------------|
+| Project ID         | `PROJECT_ID`                      | `controller.settings.projectID`               | Yes      | GCP project where nodes are provisioned.                                        |
+| Cluster name       | `CLUSTER_NAME`                    | `controller.settings.clusterName`             | Yes      | GKE cluster name. Used to scope instance discovery.                             |
+| Cluster location   | `CLUSTER_LOCATION`                | `controller.settings.clusterLocation`         | Yes      | GKE cluster location (zone or region, e.g. `us-central1-f`).                    |
+| Node location      | `NODE_LOCATION`                   | `controller.settings.nodeLocation`            | No       | Override zone for node placement. Defaults to cluster location.                 |
+| VM memory overhead | `VM_MEMORY_OVERHEAD_PERCENT`      | `controller.settings.vmMemoryOverheadPercent` | No       | Fraction of node memory reserved for OS/kubelet overhead (e.g. `0.075` = 7.5%). |
+| Default SA         | `DEFAULT_NODEPOOL_SERVICE_ACCOUNT`| `controller.env`                              | No       | Default service account for provisioned nodes (see [Service account resolution](#service-account-resolution)). |
+
+### Service account resolution
+
+Karpenter resolves the service account for provisioned nodes in this order:
+
+1. `spec.serviceAccount` in GCENodeClass (highest priority)
+2. `DEFAULT_NODEPOOL_SERVICE_ACCOUNT` environment variable
+3. Project's Compute Engine default service account (`<project-number>-compute@developer.gserviceaccount.com`)
+
+If none are available, node provisioning fails.
+
+For production clusters, use a dedicated service account with minimal permissions ([`roles/container.nodeServiceAccount`](https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa)). Set `DEFAULT_NODEPOOL_SERVICE_ACCOUNT` or `spec.serviceAccount` accordingly.
+
+Example Helm override:
+
+```yaml
+controller:
+  env:
+    - name: DEFAULT_NODEPOOL_SERVICE_ACCOUNT
+      value: "my-node-sa@my-project.iam.gserviceaccount.com"
+```
 
 ## NodePool Features
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -35,14 +35,14 @@ These options configure the controller's runtime behavior.
 
 ## GCP-specific Settings
 
-| Setting            | Env var                            | Helm value                                    | Required | Description                                                                     |
-|--------------------|----------------------------------|-----------------------------------------------|----------|---------------------------------------------------------------------------------|
-| Project ID         | `PROJECT_ID`                      | `controller.settings.projectID`               | Yes      | GCP project where nodes are provisioned.                                        |
-| Cluster name       | `CLUSTER_NAME`                    | `controller.settings.clusterName`             | Yes      | GKE cluster name. Used to scope instance discovery.                             |
-| Cluster location   | `CLUSTER_LOCATION`                | `controller.settings.clusterLocation`         | Yes      | GKE cluster location (zone or region, e.g. `us-central1-f`).                    |
-| Node location      | `NODE_LOCATION`                   | `controller.settings.nodeLocation`            | No       | Override zone for node placement. Defaults to cluster location.                 |
-| VM memory overhead | `VM_MEMORY_OVERHEAD_PERCENT`      | `controller.settings.vmMemoryOverheadPercent` | No       | Fraction of node memory reserved for OS/kubelet overhead (e.g. `0.075` = 7.5%). |
-| Default SA         | `DEFAULT_NODEPOOL_SERVICE_ACCOUNT`| `controller.env`                              | No       | Default service account for provisioned nodes (see [Service account resolution](#service-account-resolution)). |
+| Setting            | Env var                            | Helm value                                    | Required | Description                                                                                                    |
+|--------------------|------------------------------------|-----------------------------------------------|----------|----------------------------------------------------------------------------------------------------------------|
+| Project ID         | `PROJECT_ID`                       | `controller.settings.projectID`               | Yes      | GCP project where nodes are provisioned.                                                                       |
+| Cluster name       | `CLUSTER_NAME`                     | `controller.settings.clusterName`             | Yes      | GKE cluster name. Used to scope instance discovery.                                                            |
+| Cluster location   | `CLUSTER_LOCATION`                 | `controller.settings.clusterLocation`         | Yes      | GKE cluster location (zone or region, e.g. `us-central1-f`).                                                   |
+| Node location      | `NODE_LOCATION`                    | `controller.settings.nodeLocation`            | No       | Override zone for node placement. Defaults to cluster location.                                                |
+| VM memory overhead | `VM_MEMORY_OVERHEAD_PERCENT`       | `controller.settings.vmMemoryOverheadPercent` | No       | Fraction of node memory reserved for OS/kubelet overhead (e.g. `0.075` = 7.5%).                                |
+| Default SA         | `DEFAULT_NODEPOOL_SERVICE_ACCOUNT` | `controller.env`                              | No       | Default service account for provisioned nodes (see [Service account resolution](#service-account-resolution)). |
 
 ### Service account resolution
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/8074a1db-0568-467b-8a50-b28180084543)

Documents the service account resolution priority chain introduced in PR #283. Adds the DEFAULT_NODEPOOL_SERVICE_ACCOUNT setting to the GCP-specific settings table and a new "Service account resolution" subsection explaining the three-tier priority order.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #283: feat(instance): derive scheduling and SA from capacity type and GCENodeClass, not NodePool template](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/283)

---

_Tip: Worried about broken links? Ask Promptless to find and fix them automatically 🔗_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Adds `DEFAULT_NODEPOOL_SERVICE_ACCOUNT` to the GCP-specific settings table and documents the three-tier service account resolution priority: `spec.serviceAccount` → `DEFAULT_NODEPOOL_SERVICE_ACCOUNT` → Compute Engine default SA. The priority order matches the code in `pkg/providers/instance/instance.go`.
- Includes a Helm example showing how to pass the env var via `controller.env`, along with a security recommendation to use `roles/container.nodeServiceAccount` for production clusters.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — documentation-only change that accurately reflects the code's service account resolution logic.

The documented three-tier priority order (spec.serviceAccount → DEFAULT_NODEPOOL_SERVICE_ACCOUNT → Compute Engine default SA) matches exactly what resolveServiceAccount() implements in instance.go. The failure condition, Helm example, and security recommendation are all correct. No code changes, no behavioral impact.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/settings.md | Adds DEFAULT_NODEPOOL_SERVICE_ACCOUNT row to the GCP settings table and a "Service account resolution" subsection; documented priority chain matches code in instance.go. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Node provisioning request] --> B{spec.serviceAccount\nset in GCENodeClass?}
    B -- Yes --> E[Use spec.serviceAccount]
    B -- No --> C{DEFAULT_NODEPOOL_SERVICE_ACCOUNT\nenv var set?}
    C -- Yes --> F[Use DEFAULT_NODEPOOL_SERVICE_ACCOUNT]
    C -- No --> D{Compute Engine\ndefault SA available\nfor project?}
    D -- Yes --> G[Use project default SA\nproject-number-compute@developer.gserviceaccount.com]
    D -- No --> H[Error: provisioning fails]
    E --> I[Instance created with SA]
    F --> I
    G --> I
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add DEFAULT\_NODEPOOL\_SERVICE\_ACCOU..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/585ca389c1a6d71beb6dda939741373aa4406554) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31776273)</sub>

<!-- /greptile_comment -->