### PR TITLE
proposal(0002): GKE release channel awareness for image selection

### DIFF
--- a/proposals/0002-release-channel-awareness.md
+++ b/proposals/0002-release-channel-awareness.md
@@ -1,0 +1,411 @@
+# Proposal: GKE Release Channel Awareness for Image Selection
+
+- **Status**: In Review
+- **Authors**: @dm3ch
+- **Created**: 2026-05-12
+- **Related Issues**: [#330](https://github.com/cloudpilot-ai/karpenter-provider-gcp/issues/330)
+
+---
+
+## TL;DR
+
+```yaml
+# Follow the cluster's enrolled channel — recommended starting point
+imageSelectorTerms:
+  - channel: cluster
+    family: ContainerOptimizedOS
+
+# Pin to a specific COS version — replaces alias: ContainerOptimizedOS@125.19216.104.126
+imageSelectorTerms:
+  - family: ContainerOptimizedOS
+    version: "125.19216.104.126"
+
+# Ubuntu 24.04 latest — replaces alias: Ubuntu@latest
+imageSelectorTerms:
+  - family: Ubuntu2404
+    version: latest
+```
+
+Pair `channel:` terms with a disruption budget to control when node replacement happens after a GKE build promotion.
+
+---
+
+## Summary
+
+After PR #280 introduced catalog-based image resolution, Karpenter selects the newest non-deprecated GKE OS image for the cluster's current Kubernetes version. This is correct for basic operation, but ignores GKE release channels (RAPID, REGULAR, STABLE, EXTENDED).
+
+For COS images, different channels are validated against different GKE build numbers even on the same Kubernetes patch version. STABLE receives a build only after it has soaked in RAPID and REGULAR. With catalog-based selection Karpenter may assign a newly-published build to a STABLE cluster immediately — before it has been promoted to STABLE — defeating the operational purpose of being on that channel.
+
+This proposal introduces three new structured fields in `ImageSelectorTerm` — `family`, `channel`, and `version` — that together replace the existing `alias` compound field:
+
+- `family + channel` is a **live reference**: resolves to whichever build GKE currently promotes for the named channel. When GKE promotes a new build, existing nodes are marked Drifted and replaced according to configured disruption budgets.
+- `family + version` is a **static pin**: resolves to a fixed, named image. Nodes never drift due to image changes.
+- `family + version: latest` is a **latest reference**: picks the newest image for the cluster's current Kubernetes version, equivalent to the current `alias: *@latest` behaviour without channel awareness.
+
+**`alias` is soft-deprecated as of this proposal.** All existing `alias:` and `id:` configurations continue to work. A future major release will remove the `alias` field once all use cases are covered by `family + channel` and `family + version`. See [Deprecation Path](#alias-deprecation-path).
+
+> **Note:** `channel: stable` resolves to GKE's most-soaked build for the cluster's Kubernetes minor version. Because STABLE trails RAPID by weeks, `channel: stable` will typically resolve to an **older** build number than `version: latest` on the same cluster. This is intentional: STABLE's value is its validation history, not its age.
+
+### Relationship to PR #263 and #280
+
+PR #263 eliminated the dependency on NodePool instance templates as a bootstrap source. PR #280 introduced catalog-based image resolution, gaining independence from pool lifecycle. This proposal reconstructs channel-level image knowledge using a different public API (`getServerConfig`) rather than reverting to pool dependency — gaining channel awareness without sacrificing the progress made in #263 and #280.
+
+---
+
+## Motivation
+
+### Problem Statement
+
+GKE release channels promote OS images in order: RAPID → REGULAR → STABLE → EXTENDED. Each channel has a distinct GKE build number for a given Kubernetes patch version, visible in `getServerConfig`:
+
+```
+RAPID    defaultVersion = 1.35.3-gke.1737000   ← newest, least soaked
+REGULAR  defaultVersion = 1.35.3-gke.1389000
+STABLE   defaultVersion = 1.34.6-gke.1068000   ← most soaked, production-recommended
+EXTENDED defaultVersion = 1.35.3-gke.1389000
+```
+
+Karpenter currently ignores these build numbers and picks the newest non-deprecated image for the cluster's Kubernetes version. A STABLE cluster may receive a build that was published hours ago and has only been tested in RAPID.
+
+### What Public APIs Expose
+
+**`getServerConfig` (GKE Container API)** returns per-channel `defaultVersion` and `validVersions`. The GKE build number in `defaultVersion` maps directly to COS image catalog entries — confirmed by cross-referencing live API output:
+
+```
+defaultVersion = 1.35.3-gke.1737000
+→ catalog: gke-1353-gke1737000-cos-125-19216-220-130-c-pre   ← RAPID
+
+defaultVersion = 1.34.6-gke.1068000
+→ catalog: gke-1346-gke1068000-cos-125-19216-220-72-c-pre    ← STABLE
+```
+
+Conversion: `"{major}.{minor}.{patch}-gke.{build}"` → filter `gke-{major}{minor}{patch}-gke{build}-*`
+
+**There is no channel-to-image mapping in any other public API.** Exhaustive audit confirmed: GCE Compute image labels, image families, image descriptions, and GCS release buckets carry no channel information.
+
+### Ubuntu Does Not Support Release Channel Differentiation
+
+Ubuntu GKE images (`ubuntu-gke-2404-{minor}-amd64-v{date}`) use date-based versioning and do not encode a GKE build number. There is no per-channel Ubuntu image distinction in any public GCP API — all channels on the same Kubernetes minor version share the same Ubuntu image pool.
+
+**This is a hard limitation of the GKE public API, not a design choice.** The `channel` field is therefore only supported for `family: ContainerOptimizedOS` in this proposal. Ubuntu images are selected using `family: Ubuntu2404` or `family: Ubuntu2204` with `version: latest` (automatic) or a date pin (e.g. `version: "v20260416"`). Ubuntu channel support may be added in a future proposal if GKE surfaces per-channel Ubuntu image metadata.
+
+---
+
+## Proposal
+
+### Static vs Live References: The Core Semantic Distinction
+
+| Type                       | Example                                                          | Behaviour                                                                          |
+|----------------------------|------------------------------------------------------------------|------------------------------------------------------------------------------------|
+| **Version pin**            | `family: ContainerOptimizedOS`<br>`version: "125.19216.104.126"` | Fixed image. Nodes never drift from image changes.                                 |
+| **Latest reference**       | `family: Ubuntu2404`<br>`version: latest`                        | Newest image for cluster's K8s version. No channel awareness.                      |
+| **Live channel reference** | `family: ContainerOptimizedOS`<br>`channel: stable`              | Resolves to GKE's current STABLE build. Nodes drift when GKE promotes a new build. |
+
+### API Change: New `family`, `channel`, and `version` Fields in `ImageSelectorTerm`
+
+Three new optional fields are added alongside the unchanged `id` and the now-deprecated `alias`:
+
+> **`alias` is deprecated.** New configurations should use `family + channel` or `family + version` instead. The `alias` field will be removed in a future major release. See the [Deprecation Path](#alias-deprecation-path) section for migration guidance.
+
+```yaml
+imageSelectorTerms:
+  # Channel-following (live reference, COS only)
+  - family: ContainerOptimizedOS
+    channel: stable       # rapid | regular | stable | extended | cluster
+
+  # COS version pin (static)
+  - family: ContainerOptimizedOS
+    version: "125.19216.104.126"
+
+  # Ubuntu 24.04 latest
+  - family: Ubuntu2404
+    version: latest
+
+  # Ubuntu 22.04 pinned to a specific date build
+  - family: Ubuntu2204
+    version: "v20260416"
+
+  # Raw image ID — unchanged
+  - id: projects/gke-node-images/global/images/gke-1351-gke1396004-cos-125-19216-104-126-c-pre
+```
+
+| `channel` value | Image version resolved                                                          |
+|-----------------|---------------------------------------------------------------------------------|
+| `rapid`         | `RAPID.defaultVersion` build number                                             |
+| `regular`       | `REGULAR.defaultVersion` build number                                           |
+| `stable`        | `STABLE.defaultVersion` build number                                            |
+| `extended`      | `EXTENDED.defaultVersion` build number                                          |
+| `cluster`       | Reads `cluster.ReleaseChannel.Channel` then resolves as the named channel above |
+
+**`family` enum:**
+
+| `family` value         | OS           | Notes                                                                   |
+|------------------------|--------------|-------------------------------------------------------------------------|
+| `ContainerOptimizedOS` | COS          | Supports `channel` and `version`                                        |
+| `Ubuntu2404`           | Ubuntu 24.04 | Supports `version` only; `channel` not supported                        |
+| `Ubuntu2204`           | Ubuntu 22.04 | Supports `version` only; `channel` not supported                        |
+| `Ubuntu`               | —            | **Deprecated.** Rejected at admission; use `Ubuntu2404` or `Ubuntu2204` |
+
+**`version` field values by family:**
+
+| `family`               | `version: latest`                           | Version pin format            | Example pin         |
+|------------------------|---------------------------------------------|-------------------------------|---------------------|
+| `ContainerOptimizedOS` | Newest COS for cluster's K8s version        | `milestone.build.build.build` | `125.19216.104.126` |
+| `Ubuntu2404`           | Newest Ubuntu 24.04 for cluster's K8s minor | `vYYYYMMDD`                   | `v20260416`         |
+| `Ubuntu2204`           | Newest Ubuntu 22.04 for cluster's K8s minor | `vYYYYMMDD`                   | `v20231201`         |
+
+**Per-term CEL validation rules** (evaluated in order; first failure wins):
+
+```
+// 1. family requires channel or version (not standalone)
+rule: "!has(self.family) || has(self.channel) || has(self.version)"
+message: "family requires either channel or version to be set"
+
+// 2. channel and version each require family
+rule: "!(has(self.channel) || has(self.version)) || has(self.family)"
+message: "channel and version require family to be set"
+
+// 3. channel and version are mutually exclusive
+rule: "!(has(self.channel) && has(self.version))"
+message: "channel and version cannot both be set"
+
+// 4. channel is only valid for ContainerOptimizedOS
+rule: "!has(self.channel) || self.family == 'ContainerOptimizedOS'"
+message: "channel is only supported for family ContainerOptimizedOS"
+
+// 5. exactly one selection mode per term: alias, id, or family-based
+rule: "(has(self.alias) ? 1 : 0) + (has(self.id) ? 1 : 0) + (has(self.family) ? 1 : 0) == 1"
+message: "exactly one of alias, id, or family (with channel or version) must be set"
+
+// 6. ContainerOptimizedOS version format
+rule: "!has(self.version) || self.family != 'ContainerOptimizedOS' || self.version == 'latest' || self.version.matches('^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$')"
+message: "ContainerOptimizedOS version must be 'latest' or 'milestone.build.build.build' (e.g. '125.19216.104.126')"
+
+// 7. Ubuntu version format
+rule: "!has(self.version) || !(self.family in ['Ubuntu2204', 'Ubuntu2404']) || self.version == 'latest' || self.version.matches('^v[0-9]{8}$')"
+message: "Ubuntu version must be 'latest' or 'vYYYYMMDD' (e.g. 'v20260416')"
+
+// 8. family: Ubuntu is not valid — require explicit release
+rule: "!has(self.family) || self.family != 'Ubuntu'"
+message: "family 'Ubuntu' is not valid; use Ubuntu2404 for Ubuntu 24.04 or Ubuntu2204 for Ubuntu 22.04"
+```
+
+Note: `Family`, `Channel`, and `Version` must be declared `omitempty` in Go structs so that `has()` in CEL correctly distinguishes an absent field from an empty string.
+
+**List-level validation** on `spec.imageSelectorTerms` (applied via `+kubebuilder:validation:XValidations` on the field, where `self` is the list):
+
+```
+// 10. channel: and version: latest are mutually exclusive across the entire list for ContainerOptimizedOS
+rule: "!(self.exists(t, has(t.channel)) && self.exists(t, has(t.family) && t.family == 'ContainerOptimizedOS' && has(t.version) && t.version == 'latest'))"
+message: "channel: and version: latest cannot both appear for ContainerOptimizedOS in the same imageSelectorTerms; channel: is channel-validated, version: latest is channel-agnostic — use only one selection mode per OS family"
+```
+
+This rule is only needed for `ContainerOptimizedOS` because `channel:` is already restricted to that family by per-term rule 5. No equivalent mixing is possible for Ubuntu families.
+
+### Version Resolution Algorithm
+
+The following algorithm resolves a channel name to a GKE build number for catalog filtering. Step 1 is the normal operational path — it applies whenever the cluster and the requested channel are on the same Kubernetes minor version (the common production case). Steps 2–3 cover version-skew scenarios (upgrade windows and cross-channel references).
+
+```
+resolve(channel, cluster_minor):
+  preamble (channel: cluster only):
+    if cluster.ReleaseChannel is nil or UNSPECIFIED:
+      ImagesReady = False
+      error: "cluster has no enrolled release channel (UNSPECIFIED);
+              channel: cluster requires an enrolled channel —
+              enrol the cluster in a release channel or use version: latest explicitly"
+      return
+    channelName = strings.ToUpper(cluster.ReleaseChannel.Channel)
+
+  1. channel.defaultVersion minor == cluster_minor
+     → use defaultVersion build number
+     → COS catalog filter: gke-{k8sKey}-gke{build}-*
+       where k8sKey = major+minor+patch digits (e.g. 1.34.6 → "1346")
+
+  2. minor mismatch (upgrade window or cross-channel reference)
+     → filter channel.validVersions by cluster_minor using semver comparison
+     → pick highest semver match
+     → apply step 1 logic to that version
+
+  3. no validVersions entry matches cluster_minor
+     → ImagesReady = False
+     → error: "channel STABLE has no valid version for cluster minor 1.35;
+               the requested channel may not yet support this Kubernetes minor —
+               switch to a channel that does, or use version: latest"
+```
+
+The preamble runs before step 1 because an UNSPECIFIED cluster has no channel name to look up in `getServerConfig` — it cannot naturally fall through the algorithm. Step 3 covers only the case where a named channel exists in `getServerConfig` but has no `validVersions` entry matching the cluster's Kubernetes minor. Both are operator configuration errors; silent fallback would mask the misconfiguration. `version: latest` is always available as an explicit opt-in for channel-agnostic selection.
+
+`validVersions` must be compared using semver, not lexicographic order (`1.34.10 > 1.34.9` in semver; the reverse holds lexicographically).
+
+**Channel name normalization:** `cluster.ReleaseChannel.Channel` from the GKE API uses uppercase (`"STABLE"`, `"RAPID"`). The `channel:` YAML field uses lowercase. Internally, all channel name comparisons use uppercase after normalizing the YAML value with `strings.ToUpper`. The `ServerConfig.Channels[].Channel` field from `getServerConfig` is also uppercase, so the comparison is consistent throughout.
+
+If `defaultVersion` is empty or unparseable, the controller falls through to step 2 and attempts resolution from `validVersions`. This treats a missing `defaultVersion` as a minor-mismatch case rather than a hard failure — if `validVersions` contains a matching entry the resolution still succeeds. Only if step 2 also finds no match does step 3 fire.
+
+If `getServerConfig` returns a non-error response but with an empty or missing `channels` list, or if the requested channel name is not present in the list, the controller sets `ImagesReady = False` with message `"channel <name> not found in getServerConfig response"` and retries.
+
+### Drift and Disruption Budget Integration
+
+When GKE promotes a new build for a channel, `getServerConfig` returns a new `defaultVersion`. After the 30-minute cache expires, the `GCENodeClass` controller re-resolves images and, if the resolved image changed, updates `Status.Images`. Karpenter's drift detector then marks nodes whose running image no longer matches. Replacement follows configured disruption budgets.
+
+> **Restart behaviour:** If the Karpenter controller is restarted shortly after GKE promotes a new build (e.g., during a Karpenter upgrade), it starts with an empty cache, immediately fetches `getServerConfig`, and may mark all `channel:`-selected nodes as Drifted in a single reconcile pass. Disruption budgets cap the blast radius — this is the primary reason to pair `channel:` terms with a budget.
+
+The same drift sequence occurs when the cluster's enrolled channel changes at the GKE level (e.g., the cluster is migrated from RAPID to STABLE). With `channel: cluster`, the next `GetClusterConfig()` cache expiry causes Karpenter to resolve images for the new channel — which may differ from the current nodes' images. This is expected behaviour, but operators should be aware that a GKE-side channel change will trigger node replacement on Karpenter's next reconcile cycle without any change to the `GCENodeClass`.
+
+**Typical operational week with `channel: cluster` on a STABLE cluster:**
+
+```
+Monday:    operator sets channel: cluster; nodes use build gke1068000
+Tuesday:   GKE promotes build gke1089000 to STABLE
+Tue +30m:  cache expires; Karpenter resolves gke1089000; Status.Images updated
+Tue +31m:  drift detector marks nodes as Drifted
+Thursday:  nodes replaced during maintenance window per disruption budget
+Next week: no GKE promotion → no image change → no drift → quiet
+```
+
+**Restrict replacement to a maintenance window:**
+
+```yaml
+disruption:
+  budgets:
+    - nodes: "10"
+      reasons: [Drifted]
+      schedule: "0 15 * * 2-4"   # Tue–Thu 15:00 UTC
+      duration: 20m
+```
+
+**Receive new channel images but never trigger explicit drift eviction** (nodes rotate gradually through consolidation and expiration):
+
+```yaml
+disruption:
+  budgets:
+    - nodes: "0"
+      reasons: [Drifted]
+```
+
+### `getServerConfig` Caching
+
+30-minute TTL per controller restart. Channel version assignments change at most once per weekly GKE release cycle; a 30-minute lag carries no correctness risk (old images remain valid; running nodes are unaffected).
+
+`GetClusterConfig()` (used by `channel: cluster`) is cached independently with its own 30-minute TTL. The two caches may expire at different times; a brief inconsistency (stale channel name + fresh server config) is harmless — it resolves on the next reconcile cycle.
+
+If `GetServerConfig()` fails (network error, VPC Service Controls restriction), the controller sets `ImagesReady = False` and retries. If `GetClusterConfig()` fails specifically for `channel: cluster`, the controller also sets `ImagesReady = False` — without a cluster config the channel name cannot be resolved, so the failure is surfaced rather than silently degraded.
+
+### COS Exact-Match Filter
+
+When the resolved version carries a GKE build number, the catalog query uses an exact-build filter:
+
+```
+name=gke-1346-gke1068000-*    ← channel-exact build (step 1)
+```
+
+If the catalog returns no images (publication delay or regional propagation gap), the controller sets `ImagesReady = False` and retries on the next reconcile cycle. There is no silent fallback to the version-prefix filter (`name=gke-1346-*`): that fallback would pick whatever build is newest in the catalog — potentially a RAPID build that has never soaked in STABLE — violating the channel isolation guarantee that is the core purpose of this feature.
+
+**Trade-off**: A brief `ImagesReady = False` window (typically seconds to a few minutes while the build propagates to the regional catalog) blocks new node provisioning until the exact build appears. This is preferable to silently provisioning nodes on the wrong channel's image.
+
+### GPU and arm64 Variants
+
+The same build-number filter applies to GPU and arm64 images. The existing suffix-expansion logic in `containeroptimizedos.go` (which appends `-arm64` and `-gpu` qualifiers) is unchanged; the build-number prefix selects the correct channel-validated variant automatically.
+
+---
+
+## `alias` Deprecation Path
+
+The `alias` field is a compound string that encodes two semantically different operations — version pinning (`@125.19216.104.126`) and live selection (`@latest`) — in a single field. This conflation makes it harder to validate, document, and extend. The structured `family + channel / version` API introduced by this proposal covers every `alias` use case with explicit, independently-validated fields.
+
+**`alias` is soft-deprecated as of this proposal.** It remains functional and will continue to work. All existing `GCENodeClass` resources using `alias:` or `id:` terms pass all new per-term and list-level CEL rules without any changes — the new rules were designed to be strictly additive. The field will be marked deprecated via a `// Deprecated:` Go doc comment on the struct field (the standard kubebuilder mechanism; there is no first-class CRD field-deprecation marker) and a controller log warning on use, in a future minor release. Removal is deferred to a future major release.
+
+The migration from `alias` to structured fields requires no behavioral change for pinned versions; for `@latest`, the structured equivalent is `version: latest` (identical semantics) or `channel: cluster` (upgraded semantics — gains channel awareness).
+
+| Deprecated config                               | Structured equivalent                                            | Notes                                                                    |
+|-------------------------------------------------|------------------------------------------------------------------|--------------------------------------------------------------------------|
+| `alias: ContainerOptimizedOS@latest`            | `family: ContainerOptimizedOS`<br>`version: latest`              | Exact semantic equivalent                                                |
+| `alias: ContainerOptimizedOS@latest`            | `family: ContainerOptimizedOS`<br>`channel: cluster`             | **Recommended upgrade** — gains channel-aware image selection            |
+| `alias: ContainerOptimizedOS@125.19216.104.126` | `family: ContainerOptimizedOS`<br>`version: "125.19216.104.126"` | Exact equivalent; resolves to same image                                 |
+| `alias: Ubuntu@latest`                          | `family: Ubuntu2404`<br>`version: latest`                        | Exact equivalent; `Ubuntu2404` is the current GKE default Ubuntu release |
+| `alias: Ubuntu@v20260416`                       | `family: Ubuntu2404`<br>`version: "v20260416"`                   | Exact equivalent; use `Ubuntu2204` if the pin targets a 22.04 build      |
+| `family: Ubuntu` (bare, without release)        | `family: Ubuntu2404` or `family: Ubuntu2204`                     | Rejected at admission — specify the Ubuntu release explicitly            |
+
+**Recommended migration path:** Replace `alias: ContainerOptimizedOS@latest` with `family: ContainerOptimizedOS, channel: cluster` and add a maintenance-window disruption budget. For pinned COS versions and Ubuntu, the migration is a mechanical substitution with no behavioral change. Ubuntu users should verify which release (22.04 or 24.04) their existing images target before substituting the `family` value.
+
+---
+
+## Observability
+
+`GCENodeClass.Status.Images` is populated with resolved image URLs as normal. `Status.Conditions.ImagesReady` message records the resolution path taken.
+
+> **Implementation note (initial release):** The exact-format messages below reflect the intended steady-state observability surface. The initial implementation surfaces the key error phrases listed below as error strings returned from `imagefamily.Provider.List()`, which the GCENodeClass controller forwards to the `ImagesReady` condition. Two planned messages are not yet produced in the initial release:
+> 1. **Normal success path** (`"resolved channel STABLE build gke1068000 → ..."`) — not yet emitted; only error paths produce condition messages. Adding success-path logging to the controller is tracked as a follow-up.
+> 2. **Ubuntu version-pin catalog miss** (`"Ubuntu2404: image version v20260416 not found in catalog"`) — not yet a named error; a pinned Ubuntu image that does not exist in the catalog is silently filtered by `filterExistingImages`, resulting in an empty `Status.Images` list and a generic `ImagesReady = False`. A specific error message requires explicit catalog lookup for the pinned date, which is deferred to a follow-up.
+>
+> All error paths (channel resolution failure, UNSPECIFIED cluster, `GetServerConfig` failure, channel not in server config) produce condition messages containing the key phrases listed in the table. The functional behavior (correct images on success; `ImagesReady = False` on failure) is identical for all cases in the initial release.
+
+| Situation                                       | Status.Conditions.ImagesReady message (key phrases required)                                                                                        |
+|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| Normal — exact build found                      | `ContainerOptimizedOS: resolved channel STABLE build gke1068000 → gke-1346-gke1068000-cos-...` *(follow-up)*                                        |
+| Exact build not in catalog (propagation delay)  | `ContainerOptimizedOS: build gke1068000 not yet in catalog; retrying until propagation completes` — `ImagesReady = False`                           |
+| Step 3 — explicit channel, no minor match       | `ContainerOptimizedOS: channel STABLE has no valid version for cluster minor 1.35; the requested channel may not yet support this Kubernetes minor` |
+| `channel: cluster` on UNSPECIFIED cluster       | `ContainerOptimizedOS: cluster has no enrolled release channel (UNSPECIFIED); channel: cluster requires an enrolled channel`                        |
+| `GetServerConfig` failure                       | `getServerConfig failed: <error>; image resolution suspended`                                                                                       |
+| `GetClusterConfig` failure (`channel: cluster`) | `GetClusterConfig failed: <error>; image resolution suspended`                                                                                      |
+| Channel name not in server config               | `channel STABLE not found in getServerConfig response; image resolution suspended`                                                                  |
+| Ubuntu version pin not in catalog               | `Ubuntu2404: image version v20260416 not found in catalog; check that the version exists for cluster minor 1.35` *(follow-up)*                      |
+
+---
+
+## Implementation Plan
+
+| File                                                | Change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `pkg/providers/gke/gke.go`                          | Add `GetServerConfig()` + 30-min cache; add `ResolveVersionForChannel(sc, channelName, clusterVersion string) (string, error)` with semver-correct `validVersions` chain, empty-`defaultVersion` guard, and channel-not-found error; normalize channel names to uppercase; handle nil `cluster.ReleaseChannel` as UNSPECIFIED                                                                                                                                                                                                                                                                                                                                                           |
+| `pkg/apis/v1alpha1/gcenodeclass.go`                 | **Update existing list-level rule first** — the current `imageSelectorTerms` field carries `rule="self.all(x, has(x.alias)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `pkg/providers/imagefamily/image.go`                | Add `resolveImageFromChannel()` and `resolveImageFromVersion()` dispatchers. Dispatch order: iterate over all `imageSelectorTerms`; for each term dispatch based on which selection field is set (`alias`, `id`, or `family`); collect results per-term and union them into `Status.Images` — terms are ORed, matching existing Karpenter selector semantics. A single list may mix `alias`, `id`, and `family` terms; there is no priority between term types. The `Alias()` helper returns nil when no `alias` term is present — the dispatch loop must not assume a non-nil alias. Call `ResolveVersionForChannel` for channel terms; pass resolved version to COS/Ubuntu providers. |
+| `pkg/providers/imagefamily/containeroptimizedos.go` | Add exact-build-number filter path for channel resolution; add version-pin lookup path for `family + version`; return `ImagesReady = False` (no version-prefix fallback) when exact build is not in catalog; include resolution path in `Status.Conditions` message                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `pkg/providers/imagefamily/ubuntu.go`               | Dispatch on `family: Ubuntu2404` and `family: Ubuntu2204`; add version-pin lookup path; resolve correct image project prefix per release (`ubuntu-gke-2404-*` vs `ubuntu-gke-2204-*`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `pkg/operator/operator.go`                          | Wire `gkeProvider` into image provider (if not already present)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| CRD schema                                          | Regenerate after struct changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+
+No changes needed to `nodepooltemplate.go`. After PR #263 lands, `resolveNodePoolName()` is removed from `instance.go` entirely (that function was the other code path that required `ImageFamily()` to return a known value); no further `instance.go` changes are needed for this proposal.
+
+---
+
+## Non-Goals (explicit)
+
+- **Ubuntu channel differentiation**: not possible with current GKE public APIs; `channel` field is COS-only in this proposal. Ubuntu 22.04 and 24.04 are distinct `family` values (`Ubuntu2204`, `Ubuntu2404`) but share the same image pool per K8s minor within each release.
+- **Per-NodePool channel differentiation**: a single `GCENodeClass` applies one channel resolution to all NodePools that reference it. Operators needing different channels for different workloads use separate `GCENodeClass` objects.
+- **Automatic channel migration pre-fetch**: `channel: cluster` reflects the cluster's enrolled channel at resolution time; it does not pre-fetch images before a pending channel change.
+- **GKE Autopilot clusters**: karpenter-provider-gcp does not support Autopilot clusters (Autopilot manages its own node pool lifecycle). This non-goal is listed for completeness.
+- **`alias` removal**: this proposal soft-deprecates `alias` but does not remove it. Removal is deferred to a future major release to allow operators time to migrate.
+
+---
+
+## Alternatives Considered
+
+### Extend `alias` string with `@stable`, `@rapid` etc.
+
+`alias: ContainerOptimizedOS@stable` — minimal API surface but conflates two semantically different operations: version pinning (`@125.19216.104.126`, static) and channel following (`@stable`, live). The structured `family + channel / version` approach makes the static/live distinction visible in the schema, enables independent CEL validation per field type, and provides a clean path to deprecating the `alias` string entirely.
+
+### Allow `channel` for Ubuntu with documented limitation
+
+Allowing `channel: stable, family: Ubuntu2404` with a warning in `Status.Conditions` when channels share the same K8s minor was considered. Rejected because it creates an API that appears to do more than it does. Ubuntu users use `family: Ubuntu2404, version: latest` until the GKE API exposes per-channel Ubuntu differentiation.
+
+### Single `Ubuntu` family value with separate `release` field
+
+```yaml
+family: Ubuntu
+release: "24.04"
+```
+
+A dedicated `release` field alongside `family` keeps `family` broad and avoids baking the release version into the enum. Rejected because it introduces a field only meaningful for Ubuntu (COS has no equivalent `release` concept), requiring Ubuntu-specific CEL rules. Encoding the release in the `family` value keeps the schema flat — `family` fully identifies the OS, `channel`/`version` select within it. When Ubuntu 26.04 ships it is a new enum value, which is a smaller change than a new field.
+
+### Read image from existing NodePool instance template
+
+Before PR #280, Karpenter read the boot disk image from the source pool's MIG instance template — genuinely channel-aware (the pool reflects exactly what GKE deployed for that channel). This requires an existing pool (the dependency PR #263 eliminated) and couples image resolution to pool lifecycle. Rejected.
+
+### Top-level `spec.imageChannel` field on `GCENodeClass`
+
+Simpler schema but applies one channel to all `imageSelectorTerms`, preventing per-term mixed selection. Rejected in favor of per-term selection.
+
+### Use `upgradeTargetVersion` instead of `defaultVersion`
+
+`ReleaseChannelConfig` in the GKE SDK exposes `upgradeTargetVersion` alongside `defaultVersion`. `upgradeTargetVersion` represents the version the channel is targeting for its next upgrade — it may be ahead of `defaultVersion` and could be used to pre-warm images before a cluster upgrade. Rejected for this proposal: `defaultVersion` reflects what GKE currently deploys for new nodes, which is the correct semantics for image selection. `upgradeTargetVersion` is a future direction if proactive pre-warming becomes a requirement.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Design proposal for GKE release channel awareness in image selection (closes #330).

After PR #280 introduced catalog-based image resolution, Karpenter picks the newest non-deprecated COS image for the cluster's Kubernetes version — ignoring GKE release channels. A STABLE cluster may receive a build that was only just promoted to RAPID.

**Key decisions in the proposal:**

- Introduce three new structured fields in `ImageSelectorTerm`: `family`, `channel`, `version` — replacing the `alias` compound string
  - `family + channel` → live channel reference (drifts when GKE promotes a new build)
  - `family + version: "125..."` → static version pin
  - `family + version: latest` → equivalent to current `alias: *@latest`
- `alias` is soft-deprecated; full migration table included; removal deferred to a future major release
- COS channel resolution uses `getServerConfig.channels[].defaultVersion` build number
- Ubuntu: no channel differentiation available in any public GCP API; `channel` field is COS-only
- Version resolution: `defaultVersion` exact build → `validVersions` filtered by cluster minor → hard fail for explicit channels / `version: latest` fallback for `channel: cluster` on UNSPECIFIED clusters
- 30-minute TTL cache for both `getServerConfig` and `GetClusterConfig`

#### Related proposal (if applicable):

`proposals/0002-release-channel-awareness.md`

#### Which issue(s) this PR fixes:

Closes #330

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [ ] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

Design PR only — `proposals/0002-release-channel-awareness.md` is the sole artifact. Implementation will follow in a separate PR once this design is approved.

Feedback welcome on:
1. `alias` soft-deprecation scope — is this proposal the right place to signal it?
2. `channel: cluster` naming for "follow the cluster's enrolled channel"
3. `version: latest` as the explicit structured replacement for `alias: *@latest`

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a design proposal (`proposals/0002-release-channel-awareness.md`) for GKE release-channel-aware image selection. It introduces three new structured `ImageSelectorTerm` fields — `family`, `channel`, and `version` — to replace the existing `alias` compound string, allowing Karpenter to select COS images validated for a specific GKE release channel (RAPID, REGULAR, STABLE, EXTENDED) rather than always picking the newest catalog build.

- Introduces `family + channel` (live channel reference), `family + version: pin` (static), and `family + version: latest` (channel-agnostic latest), with eight per-term and one list-level CEL validation rules, plus a migration table for existing `alias:` configurations.
- Adds `GetServerConfig()` with a 30-minute TTL cache to resolve channel build numbers, and explicitly removes the catalog version-prefix fallback to preserve channel isolation guarantees.
- Addresses several issues from the previous review round: the UNSPECIFIED-cluster preamble is now a named pre-step, the no-fallback guarantee is now explicit, the list-level rule updating `alias||id` requirement is called out in the implementation table, and dispatch order in `image.go` is fully specified.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change (a single design proposal markdown file); no executable code is modified, so there is no runtime risk.

The change is a design document with no code changes. All previously-flagged issues from earlier review rounds are addressed in this revision. The two remaining findings are documentation clarity nits in the proposal text.

proposals/0002-release-channel-awareness.md — two minor documentation inconsistencies: the CEL rule numbering has a gap at rule 9, and `family: Ubuntu` is labeled Deprecated in the enum table when it is actually rejected at admission.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| proposals/0002-release-channel-awareness.md | New design proposal for GKE release-channel-aware image selection; introduces `family`/`channel`/`version` fields to replace `alias`. Most previously-flagged issues are addressed in this revision. Two minor documentation inconsistencies remain: a missing rule 9 in the CEL numbering sequence and `family: Ubuntu` labeled "Deprecated" when it is actually rejected at admission. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ImageSelectorTerm] --> B{Selection mode}
    B -->|has alias| C[resolveImageFromAlias legacy path]
    B -->|has id| D[resolveImageFromID existing path]
    B -->|has family| E{family + ?}
    E -->|family + channel| F{channel value}
    E -->|family + version: latest| G[Newest image for cluster K8s minor]
    E -->|family + version: pin| H[Exact image, static, no drift]
    F -->|rapid/regular/stable/extended| I[GetServerConfig 30-min TTL cache]
    F -->|cluster| J[GetClusterConfig 30-min TTL cache]
    J --> K{ReleaseChannel UNSPECIFIED?}
    K -->|yes| L[ImagesReady=False hard error]
    K -->|no| I
    I --> M[ResolveVersionForChannel]
    M --> N{Exact build filter gke-k8sKey-gkeBuild-*}
    N -->|found in catalog| O[Status.Images updated]
    N -->|not in catalog| P[ImagesReady=False retry]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aproposals%2F0002-release-channel-awareness.md%3A157-201%0A**CEL%20rule%209%20is%20missing%20from%20the%20numbering%20sequence**%0A%0APer-term%20rules%20are%20numbered%201%E2%80%938%2C%20and%20the%20list-level%20rule%20jumps%20to%20%60%2F%2F%2010%60.%20Rule%209%20is%20never%20defined.%20This%20creates%20a%20gap%20that%20will%20confuse%20implementers%20writing%20tests%20and%20future%20maintainers%20adding%20rules%20%E2%80%94%20it's%20unclear%20whether%20rule%209%20was%20intentionally%20skipped%20%28reserved%29%2C%20accidentally%20omitted%2C%20or%20the%20list-level%20rule%20was%20meant%20to%20be%20numbered%209.%20Either%20fill%20in%20rule%209%20or%20change%20the%20list-level%20rule%20to%20%60%2F%2F%209%60%20and%20update%20any%20references%20to%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Aproposals%2F0002-release-channel-awareness.md%3A140-147%0A**%60family%3A%20Ubuntu%60%20is%20labeled%20%22Deprecated%22%20but%20is%20immediately%20rejected%20at%20admission**%0A%0AThe%20%60family%60%20enum%20table%20marks%20%60Ubuntu%60%20as%20%22Deprecated%2C%22%20which%20conventionally%20means%20%22still%20accepted%20but%20discouraged.%22%20However%2C%20per-term%20CEL%20rule%208%20%28%60!has%28self.family%29%20%7C%7C%20self.family%20!%3D%20'Ubuntu'%60%29%20actively%20rejects%20it%20at%20admission%20with%20a%20hard%20validation%20failure.%20There%20is%20no%20deprecation%20window%20%E2%80%94%20%60family%3A%20Ubuntu%60%20was%20never%20valid%20in%20the%20new%20%60family%60%20field%20and%20will%20never%20be%20accepted.%20Labeling%20it%20%22Deprecated%22%20is%20misleading%3B%20an%20operator%20who%20reads%20the%20table%20and%20tries%20%60family%3A%20Ubuntu%60%20expecting%20a%20warning%20will%20instead%20get%20a%20hard%20admission%20rejection.%20Consider%20changing%20the%20%22Deprecated%22%20label%20to%20%22Not%20valid%22%20or%20%22Blocked%20at%20admission%22%20to%20accurately%20reflect%20the%20enforcement%20behavior.%0A%0A&pr=331&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aproposals%2F0002-release-channel-awareness.md%3A157-201%0A**CEL%20rule%209%20is%20missing%20from%20the%20numbering%20sequence**%0A%0APer-term%20rules%20are%20numbered%201%E2%80%938%2C%20and%20the%20list-level%20rule%20jumps%20to%20%60%2F%2F%2010%60.%20Rule%209%20is%20never%20defined.%20This%20creates%20a%20gap%20that%20will%20confuse%20implementers%20writing%20tests%20and%20future%20maintainers%20adding%20rules%20%E2%80%94%20it's%20unclear%20whether%20rule%209%20was%20intentionally%20skipped%20%28reserved%29%2C%20accidentally%20omitted%2C%20or%20the%20list-level%20rule%20was%20meant%20to%20be%20numbered%209.%20Either%20fill%20in%20rule%209%20or%20change%20the%20list-level%20rule%20to%20%60%2F%2F%209%60%20and%20update%20any%20references%20to%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Aproposals%2F0002-release-channel-awareness.md%3A140-147%0A**%60family%3A%20Ubuntu%60%20is%20labeled%20%22Deprecated%22%20but%20is%20immediately%20rejected%20at%20admission**%0A%0AThe%20%60family%60%20enum%20table%20marks%20%60Ubuntu%60%20as%20%22Deprecated%2C%22%20which%20conventionally%20means%20%22still%20accepted%20but%20discouraged.%22%20However%2C%20per-term%20CEL%20rule%208%20%28%60!has%28self.family%29%20%7C%7C%20self.family%20!%3D%20'Ubuntu'%60%29%20actively%20rejects%20it%20at%20admission%20with%20a%20hard%20validation%20failure.%20There%20is%20no%20deprecation%20window%20%E2%80%94%20%60family%3A%20Ubuntu%60%20was%20never%20valid%20in%20the%20new%20%60family%60%20field%20and%20will%20never%20be%20accepted.%20Labeling%20it%20%22Deprecated%22%20is%20misleading%3B%20an%20operator%20who%20reads%20the%20table%20and%20tries%20%60family%3A%20Ubuntu%60%20expecting%20a%20warning%20will%20instead%20get%20a%20hard%20admission%20rejection.%20Consider%20changing%20the%20%22Deprecated%22%20label%20to%20%22Not%20valid%22%20or%20%22Blocked%20at%20admission%22%20to%20accurately%20reflect%20the%20enforcement%20behavior.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=331&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22feat%2Frelease-channel-support%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Frelease-channel-support%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aproposals%2F0002-release-channel-awareness.md%3A157-201%0A**CEL%20rule%209%20is%20missing%20from%20the%20numbering%20sequence**%0A%0APer-term%20rules%20are%20numbered%201%E2%80%938%2C%20and%20the%20list-level%20rule%20jumps%20to%20%60%2F%2F%2010%60.%20Rule%209%20is%20never%20defined.%20This%20creates%20a%20gap%20that%20will%20confuse%20implementers%20writing%20tests%20and%20future%20maintainers%20adding%20rules%20%E2%80%94%20it's%20unclear%20whether%20rule%209%20was%20intentionally%20skipped%20%28reserved%29%2C%20accidentally%20omitted%2C%20or%20the%20list-level%20rule%20was%20meant%20to%20be%20numbered%209.%20Either%20fill%20in%20rule%209%20or%20change%20the%20list-level%20rule%20to%20%60%2F%2F%209%60%20and%20update%20any%20references%20to%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Aproposals%2F0002-release-channel-awareness.md%3A140-147%0A**%60family%3A%20Ubuntu%60%20is%20labeled%20%22Deprecated%22%20but%20is%20immediately%20rejected%20at%20admission**%0A%0AThe%20%60family%60%20enum%20table%20marks%20%60Ubuntu%60%20as%20%22Deprecated%2C%22%20which%20conventionally%20means%20%22still%20accepted%20but%20discouraged.%22%20However%2C%20per-term%20CEL%20rule%208%20%28%60!has%28self.family%29%20%7C%7C%20self.family%20!%3D%20'Ubuntu'%60%29%20actively%20rejects%20it%20at%20admission%20with%20a%20hard%20validation%20failure.%20There%20is%20no%20deprecation%20window%20%E2%80%94%20%60family%3A%20Ubuntu%60%20was%20never%20valid%20in%20the%20new%20%60family%60%20field%20and%20will%20never%20be%20accepted.%20Labeling%20it%20%22Deprecated%22%20is%20misleading%3B%20an%20operator%20who%20reads%20the%20table%20and%20tries%20%60family%3A%20Ubuntu%60%20expecting%20a%20warning%20will%20instead%20get%20a%20hard%20admission%20rejection.%20Consider%20changing%20the%20%22Deprecated%22%20label%20to%20%22Not%20valid%22%20or%20%22Blocked%20at%20admission%22%20to%20accurately%20reflect%20the%20enforcement%20behavior.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (7): Last reviewed commit: ["proposals: add 0002-release-channel-awar..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/e58f79ae34a4f7dd36ee3205e39820cbcf47f25f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31871658)</sub>

<!-- /greptile_comment -->