### PR TITLE
docs: introduce proposal template and contributor process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,12 @@ Additional labels (applied directly, not via /kind):
 
 #### What this PR does / why we need it:
 
+#### Related proposal (if applicable):
+<!--
+Link the proposal this PR implements, e.g. proposals/0001-short-title.md
+Leave blank if this PR does not correspond to a design proposal.
+-->
+
 #### Which issue(s) this PR fixes:
 <!--
 *Automatically closes linked issue when PR is merged.

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,9 +5,11 @@ on:
     branches: ["main"]
     paths:
       - "docs/**"
+      - "proposals/**"
   pull_request:
     paths:
       - "docs/**"
+      - "proposals/**"
 
 jobs:
   lint:
@@ -22,7 +24,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install mdox
-        run: go install github.com/bwplotka/mdox@latest
+        run: go install github.com/bwplotka/mdox@v0.9.0
 
       - name: Lint markdown
         run: make docs-lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributing
+
 # Design Proposals
 
 For significant changes — architectural redesigns, new API fields, operator-visible behaviour changes, or multi-phase work — opening a proposal before writing code helps align on the approach early and produces a useful design record.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,44 @@
+# Design Proposals
+
+For significant changes — architectural redesigns, new API fields, operator-visible behaviour changes, or multi-phase work — opening a proposal before writing code helps align on the approach early and produces a useful design record.
+
+## When to write a proposal
+
+Write a proposal when your change involves any of the following:
+
+- Architectural redesign or replacement of a major subsystem
+- New `GCENodeClass` fields, new CRDs, or changes to existing API fields
+- Multi-phase implementation spanning several PRs
+- Changes that require operator action on upgrade (new required config, migration steps)
+- Large changes from external contributors (strongly encouraged)
+
+A proposal is **not required** for bug fixes, small flag additions, doc-only changes, or refactors that do not change observable behaviour.
+
+## How to submit a proposal
+
+1. Copy [`proposals/0000-template.md`](proposals/0000-template.md) to `proposals/NNNN-short-title.md`, where `NNNN` is the next available four-digit number.
+2. Fill in all **required** sections (Summary, Motivation, Proposal). Optional sections can be omitted or marked N/A.
+3. Open a draft PR with the proposal. The `Status` field should be `Draft` while the approach is still being formed. Update it to `Provisional` when you are ready for initial feedback.
+4. Iterate in review. When the approach is agreed by maintainers, update `Status` to `Implementable`.
+5. Implementation PRs reference the proposal via the "Related proposal" field in the PR template.
+
+Proposals are reviewed by project maintainers via GitHub PR review. Assign the PR for review or mention `@cloudpilot-ai/karpenter-gcp` when the proposal is ready for feedback.
+
+## Status values
+
+| Status | Meaning |
+|--------|---------|
+| `Draft` | Work in progress, not ready for review |
+| `Provisional` | Ready for feedback, approach not yet agreed |
+| `Implementable` | Approach agreed; implementation may proceed |
+| `Implemented` | Fully implemented and merged |
+| `Deferred` | Accepted but not currently scheduled |
+| `Rejected` | Reviewed and rejected |
+| `Withdrawn` | Author withdrew the proposal |
+| `Replaced` | Superseded by a newer proposal (include link) |
+
+---
+
 # Development
 
 This doc explains how to set up a development environment so you can get started contributing to this project

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ KARPENTER_CORE_DIR = $(shell go list -m -f '{{ .Dir }}' sigs.k8s.io/karpenter)
 help: ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-presubmit: verify-codegen verify chart-lint ut-test ## Run all steps in the developer loop
+presubmit: verify-codegen verify chart-lint ut-test docs-lint ## Run all steps in the developer loop
 
 toolchain: ## Install developer toolchain
 	./hack/toolchain.sh
@@ -59,7 +59,7 @@ verify: ## Verify code. Includes linting, formatting, etc
 	golangci-lint run --new-from-rev=origin/main --timeout=20m
 	git diff --exit-code || (echo "golangci-lint reformatted files above — stage and commit them" && exit 1)
 
-DOCS_FILES = $(shell find docs -name "*.md" ! -path "docs/reference/*")
+DOCS_FILES = $(shell find docs proposals -name "*.md" ! -path "docs/reference/*" 2>/dev/null)
 
 docs-lint: ## Check docs markdown formatting (excludes generated reference docs)
 	mdox fmt --check $(DOCS_FILES)
@@ -180,7 +180,7 @@ codegen: ## Auto generate files based on GCP APIs
 crds: ## Apply CRDs
 	kubectl apply -f charts/karpenter/crds/
 
-.PHONY: help presubmit run ut-test require-project-id e2e-setup e2e-tests e2e-test e2e-teardown e2e-check-clean e2e-deploy coverage update update-pricing verify-codegen verify image apply delete toolchain tidy download
+.PHONY: help presubmit run ut-test require-project-id e2e-setup e2e-tests e2e-test e2e-teardown e2e-check-clean e2e-deploy coverage update update-pricing verify-codegen verify image apply delete toolchain tidy download docs-lint docs-fix
 
 define newline
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Karpenter improves the efficiency and cost of running workloads on Kubernetes cl
 
 ## Documentation
 
-See [`docs/`](docs/) for installation, configuration, networking, troubleshooting, and contributing guides.
+See [`docs/`](docs/) for installation, configuration, networking, troubleshooting, and contributing guides. See [`proposals/`](proposals/) for accepted and in-progress design proposals.
 
 ## Release notes / upgrades
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,3 +65,4 @@ Key capabilities:
 - [Slack](https://cloudpilotaicommunity.slack.com/archives/C093V65481H)
 - [Discord](https://discord.gg/WxFWc87QWr)
 - [GitHub Issues](https://github.com/cloudpilot-ai/karpenter-provider-gcp/issues)
+- [Design proposals](../proposals/) — accepted and in-progress architectural proposals

--- a/proposals/0000-template.md
+++ b/proposals/0000-template.md
@@ -1,0 +1,131 @@
+# Proposal: [Title]
+
+- **Status**: Draft
+- **Authors**: @username
+- **Created**: YYYY-MM-DD
+- **Related Issues**: [#NNN](https://github.com/cloudpilot-ai/karpenter-provider-gcp/issues/NNN)
+
+<!-- Usage: copy this file to proposals/NNNN-short-title.md (NNNN = next available four-digit number).
+     Required sections: Summary, Motivation, Proposal.
+     For architectural proposals, include Alternatives Considered.
+     For operational changes, include Migration and Acceptance Criteria.
+     Omit any optional section that does not apply to your proposal. -->
+
+---
+
+## Summary
+
+[2–3 paragraphs describing what this proposal changes and why. Be specific enough that a reader unfamiliar with the codebase can understand the problem and the proposed solution.]
+
+---
+
+## Motivation
+
+### Problem Statement
+
+[Describe the current state and what is broken, missing, or painful. Include error messages, user-visible symptoms, or code excerpts where relevant.]
+
+### Goals
+
+- Goal 1
+- Goal 2
+
+### Non-Goals
+
+- Non-goal 1
+
+---
+
+## Proposal
+
+### Overview
+
+[High-level description of the proposed solution. A before/after comparison or short diagram is useful here.]
+
+### Design Details
+
+[Detailed description of the implementation. Cover data flow, algorithm choices, API shapes, key invariants, and any external dependencies.]
+
+---
+
+## Risks and Mitigations
+
+<!-- Optional — omit for small proposals -->
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| ...  | ...        | ...    | ...        |
+
+---
+
+## Test Plan
+
+<!-- Optional — omit for small proposals -->
+
+### Unit Tests
+
+- Test case 1
+- Test case 2
+
+### E2E / Integration Tests
+
+- Scenario 1
+
+---
+
+## Acceptance Criteria
+
+<!-- Optional -->
+
+The feature is complete when:
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+---
+
+## Implementation Phases
+
+<!-- Optional — omit for single-phase changes -->
+
+### Phase 1 — [Name]
+
+[Description]
+
+### Phase 2 — [Name]
+
+[Description]
+
+---
+
+## Migration
+
+<!-- Optional — omit if no operator action is required on upgrade -->
+
+[Steps operators must take when upgrading. Include exact commands.]
+
+---
+
+## Alternatives Considered
+
+<!-- Optional but recommended for architectural proposals -->
+
+### [Alternative name]
+
+[Description and why it was rejected.]
+
+---
+
+## Future Direction
+
+<!-- Optional -->
+
+[Follow-on work explicitly out of scope for this proposal but enabled by it.]
+
+---
+
+## Open Questions
+
+<!-- Optional — track unresolved questions during drafting; mark resolved inline -->
+
+1. **[Question]**: [Answer, or "Open".]


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Introduces a formal proposal template and lightweight proposal process.
The system is supplementary — recommended for architectural changes and large external contributions, not required for bug fixes or small refactors.

- `proposals/0000-template.md` — Kubernetes-KEP-style template with required sections (Summary, Motivation, Proposal) and optional sections clearly marked; includes usage guidance comment and status lifecycle
- `CONTRIBUTING.md` — new "Design Proposals" section covering when to write, 5-step submission process, status values, and reviewer guidance
- `README.md`, `docs/index.md` — link to `proposals/` directory
- `.github/PULL_REQUEST_TEMPLATE.md` — optional "Related proposal" field added
- `Makefile` — `docs-lint` added to `presubmit`; `DOCS_FILES` extended to include `proposals/`; `docs-lint` and `docs-fix` added to `.PHONY`
- `.github/workflows/docs.yaml` — pin `mdox` to `v0.9.0` (was `@latest`, which could diverge from `toolchain.sh`)

#### Related proposal (if applicable):

N/A — this PR introduces the proposal process itself.

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

The template mirrors the structure already used by `proposals/0001-replace-karpenter-managed-bootstrap-pools.md` (on the in-flight #263 branch). This PR is independent of #263 and can merge in either order.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Introduces a formal proposal process: a KEP-style `proposals/0000-template.md`, a "Design Proposals" section in `CONTRIBUTING.md` with status lifecycle and submission steps, and links from `README.md` and `docs/index.md`.
- CI and tooling are wired up correctly: `docs.yaml` now triggers on `proposals/**`, `mdox` is pinned to `v0.9.0` (matching `toolchain.sh`), `DOCS_FILES` includes `proposals/`, and `docs-lint` is added to `presubmit`.
- Only minor issue: `# Design Proposals` and `# Development` are both H1 headings under the new `# Contributing` root rather than H2 subsections, which diverges from standard Markdown heading hierarchy.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — documentation-only change with no behavioral impact.

All findings are P2 style suggestions. The CI wiring (mdox pin, DOCS_FILES extension, workflow path triggers) is correct and consistent. No logic, security, or runtime concerns are present.

CONTRIBUTING.md — minor H1/H2 heading hierarchy; otherwise no file requires special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/PULL_REQUEST_TEMPLATE.md | Adds optional "Related proposal" field with clear inline comment; clean addition. |
| .github/workflows/docs.yaml | Adds `proposals/**` to trigger paths and pins mdox to v0.9.0 (matching toolchain.sh); consistent and correct. |
| CONTRIBUTING.md | Adds Design Proposals section and top-level Contributing heading; minor heading hierarchy issue (Design Proposals and Development are H1 siblings rather than H2 subsections). |
| Makefile | Extends DOCS_FILES to include proposals/, adds docs-lint to presubmit, and adds docs-lint/docs-fix to .PHONY; all correct. |
| proposals/0000-template.md | Well-structured KEP-style template with clearly marked required vs optional sections; usage comment and status lifecycle are helpful. |
| README.md | Adds a sentence linking to proposals/ directory; clean change. |
| docs/index.md | Adds Design proposals link using a relative ../proposals/ path; works correctly on GitHub and no docs-site generator is present. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Contributor identifies significant change] --> B{Proposal required?}
    B -- "Bug fix / small refactor" --> C[Open implementation PR directly]
    B -- "Arch change / new API / multi-phase" --> D[Copy proposals/0000-template.md\nto proposals/NNNN-short-title.md]
    D --> E[Open Draft PR\nStatus: Draft]
    E --> F[Ready for feedback?\nStatus: Provisional]
    F --> G{Maintainer review}
    G -- Agree --> H[Status: Implementable]
    G -- Reject --> I[Status: Rejected / Withdrawn]
    H --> J[Implementation PRs\nreference proposal via PR template]
    J --> K[Status: Implemented]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACONTRIBUTING.md%3A1-4%0A**Heading%20hierarchy%3A%20H1%20siblings%20instead%20of%20nested%20sections**%0A%0A%60%23%20Design%20Proposals%60%20and%20%60%23%20Development%60%20are%20both%20top-level%20%28%60%23%60%29%20headings%20sitting%20under%20the%20new%20%60%23%20Contributing%60%20root.%20Standard%20Markdown%20convention%20treats%20a%20single%20%60%23%60%20heading%20as%20the%20document%20title%2C%20with%20subsequent%20sections%20as%20%60%23%23%60.%20As-is%2C%20any%20doc-site%20renderer%20or%20linter%20that%20enforces%20heading%20levels%20%28e.g.%20%60markdownlint%20MD001%60%29%20will%20flag%20that%20two%20H1s%20appear%20after%20the%20document%20title.%20Promoting%20them%20both%20to%20H2%20would%20fix%20the%20hierarchy%20without%20changing%20visible%20prose.%0A%0A&pr=333&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACONTRIBUTING.md%3A1-4%0A**Heading%20hierarchy%3A%20H1%20siblings%20instead%20of%20nested%20sections**%0A%0A%60%23%20Design%20Proposals%60%20and%20%60%23%20Development%60%20are%20both%20top-level%20%28%60%23%60%29%20headings%20sitting%20under%20the%20new%20%60%23%20Contributing%60%20root.%20Standard%20Markdown%20convention%20treats%20a%20single%20%60%23%60%20heading%20as%20the%20document%20title%2C%20with%20subsequent%20sections%20as%20%60%23%23%60.%20As-is%2C%20any%20doc-site%20renderer%20or%20linter%20that%20enforces%20heading%20levels%20%28e.g.%20%60markdownlint%20MD001%60%29%20will%20flag%20that%20two%20H1s%20appear%20after%20the%20document%20title.%20Promoting%20them%20both%20to%20H2%20would%20fix%20the%20hierarchy%20without%20changing%20visible%20prose.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=333&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22feat%2Fproposals-template%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fproposals-template%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACONTRIBUTING.md%3A1-4%0A**Heading%20hierarchy%3A%20H1%20siblings%20instead%20of%20nested%20sections**%0A%0A%60%23%20Design%20Proposals%60%20and%20%60%23%20Development%60%20are%20both%20top-level%20%28%60%23%60%29%20headings%20sitting%20under%20the%20new%20%60%23%20Contributing%60%20root.%20Standard%20Markdown%20convention%20treats%20a%20single%20%60%23%60%20heading%20as%20the%20document%20title%2C%20with%20subsequent%20sections%20as%20%60%23%23%60.%20As-is%2C%20any%20doc-site%20renderer%20or%20linter%20that%20enforces%20heading%20levels%20%28e.g.%20%60markdownlint%20MD001%60%29%20will%20flag%20that%20two%20H1s%20appear%20after%20the%20document%20title.%20Promoting%20them%20both%20to%20H2%20would%20fix%20the%20hierarchy%20without%20changing%20visible%20prose.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["docs: add top-level Contributing heading..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/45f2385da9bd18cf9c88ae9319a8a11a376d06ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31847098)</sub>

<!-- /greptile_comment -->