### PR TITLE
fix(cloudprovider): handle empty providerID in Delete

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -231,6 +231,10 @@ func (c *CloudProvider) resolveNodeClassFromNodePool(ctx context.Context, nodePo
 
 func (c *CloudProvider) Delete(ctx context.Context, nodeClaim *karpv1.NodeClaim) error {
 	providerID := nodeClaim.Status.ProviderID
+	if providerID == "" {
+		// No instance was ever created (e.g. every Create attempt hit STOCKOUT).
+		return cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("nodeclaim has no providerID"))
+	}
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("id", providerID))
 	return c.instanceProvider.Delete(ctx, providerID)
 }

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package cloudprovider
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	karpcloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instance"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
@@ -62,6 +65,19 @@ func TestInstanceToNodeClaim_AbsentClusterLocationLabelNotInvented(t *testing.T)
 	_, hasLabel := nc.Labels[utils.LabelClusterLocationKey]
 	require.False(t, hasLabel,
 		"NodeClaim built from a label-less instance must not carry cluster-location; GC skip depends on its absence")
+}
+
+func TestDelete_ReturnsNodeClaimNotFoundWhenProviderIDEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Without the guard in Delete, the call reaches parseGCEProviderID("") which errors,
+	// causing karpenter to retry termination forever so the finalizer never clears.
+	nc := &karpv1.NodeClaim{Status: karpv1.NodeClaimStatus{ProviderID: ""}}
+
+	err := (&CloudProvider{}).Delete(context.Background(), nc)
+
+	require.True(t, karpcloudprovider.IsNodeClaimNotFoundError(err),
+		"empty providerID must signal NotFound so karpenter clears the finalizer; got %v", err)
 }
 
 func TestRepairPolicies_NPDConditionsPolarity(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Short-circuits `CloudProvider.Delete` when `Status.ProviderID == ""` and returns `NodeClaimNotFoundError` so karpenter clears the `karpenter.sh/termination` finalizer instead of looping forever on a parse error.

Mirrors the convention used in [pkg/providers/instance/instance.go](https://github.com/cloudpilot-ai/karpenter-provider-gcp/blob/main/pkg/providers/instance/instance.go#L1120) for "instance gone, signal NotFound, finalizer clears".

#### Which issue(s) this PR fixes:

Fixes #334

#### Special notes for your reviewer:

Validated end-to-end on a GKE cluster with the fix:
- `kubectl delete nodeclaim` of a stuck NodeClaim completes within seconds (next reconcile).
- karpenter's `nodeclaim.lifecycle` registration timeout auto-cleans stuck NodeClaims (verified at T+15min).

#### Does this PR introduce a user-facing change?

No