### PR TITLE
fix(cloudprovider): handle empty providerID in Delete (cherry-pick for v0.3.3)

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -231,6 +231,10 @@ func (c *CloudProvider) resolveNodeClassFromNodePool(ctx context.Context, nodePo
 
 func (c *CloudProvider) Delete(ctx context.Context, nodeClaim *karpv1.NodeClaim) error {
 	providerID := nodeClaim.Status.ProviderID
+	if providerID == "" {
+		// No instance was ever created (e.g. every Create attempt hit STOCKOUT).
+		return cloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("nodeclaim has no providerID"))
+	}
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("id", providerID))
 	return c.instanceProvider.Delete(ctx, providerID)
 }

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package cloudprovider
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	karpcloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/instance"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
@@ -62,6 +65,19 @@ func TestInstanceToNodeClaim_AbsentClusterLocationLabelNotInvented(t *testing.T)
 	_, hasLabel := nc.Labels[utils.LabelClusterLocationKey]
 	require.False(t, hasLabel,
 		"NodeClaim built from a label-less instance must not carry cluster-location; GC skip depends on its absence")
+}
+
+func TestDelete_ReturnsNodeClaimNotFoundWhenProviderIDEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Without the guard in Delete, the call reaches parseGCEProviderID("") which errors,
+	// causing karpenter to retry termination forever so the finalizer never clears.
+	nc := &karpv1.NodeClaim{Status: karpv1.NodeClaimStatus{ProviderID: ""}}
+
+	err := (&CloudProvider{}).Delete(context.Background(), nc)
+
+	require.True(t, karpcloudprovider.IsNodeClaimNotFoundError(err),
+		"empty providerID must signal NotFound so karpenter clears the finalizer; got %v", err)
 }
 
 func TestRepairPolicies_NPDConditionsPolarity(t *testing.T) {

--- a/test/pkg/environment/helpers.go
+++ b/test/pkg/environment/helpers.go
@@ -63,7 +63,7 @@ type TestCase struct {
 	InstanceTypes []string
 	// ImageFamily selects the OS image family for the NodeClass.
 	// Defaults to ContainerOptimizedOS when empty.
-	ImageFamily string
+	ImageFamily         string
 	ConsolidationPolicy string // defaults to WhenEmptyOrUnderutilized when empty
 }
 


### PR DESCRIPTION
Cherry-pick of #335 onto `release-0.3` for the v0.3.3 patch release.

**What changed:** Short-circuits `CloudProvider.Delete` when `Status.ProviderID == ""` and returns `NodeClaimNotFoundError`, so karpenter clears the `karpenter.sh/termination` finalizer instead of looping forever on a parse error.

/kind bug

**Special notes for your reviewer:**
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This cherry-pick adds a short-circuit guard in `CloudProvider.Delete` that returns `NodeClaimNotFoundError` when `Status.ProviderID` is empty, preventing an infinite termination-retry loop when a `NodeClaim` never had a GCE instance created (e.g. repeated STOCKOUT). A matching unit test and a minor whitespace fix in the test helpers are also included.

- **`pkg/cloudprovider/cloudprovider.go`**: Four-line guard at the top of `Delete` returns `NodeClaimNotFoundError` for empty `providerID`, allowing Karpenter to clear the `karpenter.sh/termination` finalizer cleanly.
- **`pkg/cloudprovider/cloudprovider_test.go`**: New `TestDelete_ReturnsNodeClaimNotFoundWhenProviderIDEmpty` unit test exercises the guard directly on a zero-value `CloudProvider`.
- **`test/pkg/environment/helpers.go`**: Whitespace-only alignment fix with no behavioural change.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is a minimal, well-tested guard that prevents an infinite termination loop and has no side effects on the normal deletion path.

The fix is a four-line early-return that only activates when ProviderID is empty, leaving all existing behaviour untouched. The new unit test exercises the guard correctly — calling Delete on a zero-value CloudProvider is valid because the guard short-circuits before any uninitialised field is accessed. No subtle edge cases were identified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/cloudprovider/cloudprovider.go | Adds empty-providerID guard at the top of Delete; returns NodeClaimNotFoundError to unblock finalizer removal. Minimal, correct, and well-targeted change. |
| pkg/cloudprovider/cloudprovider_test.go | Adds a focused unit test that calls Delete on a zero-value CloudProvider with an empty ProviderID and asserts NodeClaimNotFoundError is returned. Test is correct; the guard short-circuits before any nil-dereference on uninitialised fields. |
| test/pkg/environment/helpers.go | Whitespace alignment fix only; no behavioural change. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant K as Karpenter Core
    participant CP as CloudProvider.Delete
    participant IP as instanceProvider.Delete

    K->>CP: Delete(nodeClaim)
    alt "providerID == "" (NEW GUARD)"
        CP-->>K: NodeClaimNotFoundError
        K->>K: Clear karpenter.sh/termination finalizer
    else "providerID != """
        CP->>IP: Delete(ctx, providerID)
        IP-->>CP: result
        CP-->>K: result
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test: align ImageFamily field in TestCas..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/f7579fb69c32684107a5db1c18b2e40794c99161) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31981901)</sub>

<!-- /greptile_comment -->