### PR TITLE
fix(ci): add --devel to helm search/pull to preserve pre-release chart versions

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -5,7 +5,6 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
-
 jobs:
   image-publish:
     runs-on: ubuntu-latest
@@ -105,13 +104,13 @@ jobs:
           helm repo add karpenter-gcp "${PAGES_URL}" --force-update
 
           for CHART in karpenter karpenter-crd; do
-            VERSIONS=$(helm search repo "karpenter-gcp/${CHART}" --versions -o json 2>/dev/null | jq -r '.[].version' || true)
+            VERSIONS=$(helm search repo "karpenter-gcp/${CHART}" --versions --devel -o json 2>/dev/null | jq -r '.[].version' || true)
             [ -z "${VERSIONS}" ] && continue
 
             echo "${VERSIONS}" | while read VERSION; do
               if [ ! -f "charts/${CHART}-${VERSION}.tgz" ]; then
                 echo "Pulling ${CHART} ${VERSION}..."
-                helm pull "karpenter-gcp/${CHART}" --version "${VERSION}" --destination charts/ || \
+                helm pull "karpenter-gcp/${CHART}" --version "${VERSION}" --devel --destination charts/ || \
                   echo "WARNING: could not pull ${CHART} ${VERSION}, skipping"
               fi
             done


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`helm search repo --versions` silently excludes pre-release semver versions (e.g. `v0.1.0-rc.0`) unless `--devel` is passed. The same flag is needed on `helm pull`. Without both, the restore step in `package-chart` skips pre-release archives; the count check passes only because the expected set is also missing them, so the broken deploy goes undetected.

Root cause of issue #336: `karpenter-v0.1.0-rc.0.tgz` was dropped from Pages on the v0.3.0 release run. The missing archive has already been restored to Pages separately.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

Fixes #336

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds `--devel` to the `helm search repo` and `helm pull` calls in the `package-chart` restore step so that pre-release semver versions (e.g. `v0.1.0-rc.0`) are no longer silently excluded. Without both flags, the restore loop never pulled pre-release archives, but the count check also never detected the gap because `VERSIONS` itself was missing them.

- `helm search repo ... --versions --devel` now returns pre-release chart versions alongside stable ones.
- `helm pull ... --version \"${VERSION}\" --devel` now successfully pulls those pre-release archives; the existing `ACTUAL < EXPECTED` count check covers them correctly once `--devel` is present on the search.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted two-line fix that closes a silent data-loss gap in the chart-restore step.

Both helm search repo and helm pull now receive --devel, which is exactly what Helm requires to include pre-release semver strings. The existing ACTUAL < EXPECTED count guard automatically covers the newly visible pre-release versions once the search also returns them, so no additional logic changes are needed. Passing --devel alongside an explicit --version that resolves to a stable release is harmless.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-build.yaml | Adds --devel to both helm search repo and helm pull so pre-release semver versions (e.g. rc, alpha) are included when restoring chart archives to Pages |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant WF as release-build workflow
    participant Pages as GitHub Pages (Helm repo)
    participant FS as charts/ directory

    WF->>Pages: helm repo add karpenter-gcp
    WF->>Pages: helm search repo karpenter-gcp/karpenter --versions --devel
    Pages-->>WF: VERSIONS (including pre-release e.g. v0.1.0-rc.0)
    loop Each VERSION
        WF->>FS: "check charts/karpenter-{VERSION}.tgz exists?"
        alt missing
            WF->>Pages: "helm pull --version {VERSION} --devel"
            Pages-->>FS: "karpenter-{VERSION}.tgz"
        end
    end
    WF->>WF: count check ACTUAL vs EXPECTED
    alt "ACTUAL < EXPECTED"
        WF->>WF: exit 1 (abort deploy)
    else all present
        WF->>Pages: helm repo index + deploy
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): add --devel to helm search/pull..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/404c9bf8b24b202328b784ebde7ea43af65f9acb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31988542)</sub>

<!-- /greptile_comment -->