### PR TITLE
fix(dependabot): fix group/ignore conflict and add github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,35 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    # k8s.io/* are transitive deps driven by karpenter-core/controller-runtime;
+    # never update them in isolation.
     ignore:
       - dependency-name: "k8s.io/*"
     groups:
+      # karpenter-core and controller-runtime must be updated together and
+      # require e2e validation + interface adoption before merging.
       karpenter-core:
+        applies-to: version-updates
         patterns:
           - "sigs.k8s.io/karpenter"
+          - "sigs.k8s.io/controller-runtime"
       go-dependencies:
+        applies-to: version-updates
         patterns:
           - "*"
         exclude-patterns:
           - "sigs.k8s.io/karpenter"
+          - "sigs.k8s.io/controller-runtime"
+          - "k8s.io/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes dependabot silently failing to create version-update PRs.

**Root cause**: the `"*"` pattern in the `go-dependencies` group matched `k8s.io/*` packages that are simultaneously listed in `ignore`. Dependabot cannot reconcile a package being both "in a group" and "ignored" — the discovery job succeeds (updates are found) but PR creation fails silently with no PR appearing.

**Fix**: add `k8s.io/*` to `go-dependencies` `exclude-patterns`, mirroring the `ignore` list.

Additional changes:
- `applies-to: version-updates` on both groups (explicit intent; avoids ambiguity with security update handling)
- `github-actions` ecosystem added — keeps workflow action versions current; no grouping complexity since actions have no vendor directory

Validated on fork (`dm3ch/karpenter-provider-gcp`): the fixed config immediately produced successful dependabot jobs and opened the expected PRs; the origin config reproduced the failure on every run.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.