### PR TITLE
fix: replace deprecated swag.String/StringValue with lo.ToPtr/FromPtr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	cloud.google.com/go/container v1.45.0
 	github.com/aws/aws-sdk-go v1.55.7
 	github.com/awslabs/operatorpkg v0.0.0-20251222193911-34e9a1898737
-	github.com/go-openapi/swag v0.25.4
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
@@ -48,6 +47,7 @@ require (
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.4 // indirect
 	github.com/go-openapi/jsonreference v0.21.4 // indirect
+	github.com/go-openapi/swag v0.25.4 // indirect
 	github.com/go-openapi/swag/cmdutils v0.25.4 // indirect
 	github.com/go-openapi/swag/conv v0.25.4 // indirect
 	github.com/go-openapi/swag/fileutils v0.25.4 // indirect

--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -22,7 +22,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/go-openapi/swag"
 	"github.com/samber/lo"
 	"google.golang.org/api/compute/v1"
 	"gopkg.in/yaml.v3"
@@ -50,7 +49,7 @@ func GetClusterName(metadata *compute.Metadata) (string, error) {
 	if len(clusterNameEntry) != 1 {
 		return "", errors.New("cluster name label not found")
 	}
-	clusterName := swag.StringValue(clusterNameEntry[0].Value)
+	clusterName := lo.FromPtr(clusterNameEntry[0].Value)
 	if clusterName == "" {
 		return "", errors.New("cluster name label is empty")
 	}
@@ -68,7 +67,7 @@ func RenderKubeletConfigMetadata(metaData *compute.Metadata, instanceType *cloud
 	memoryMB := fmt.Sprintf("%dMi", instanceType.Overhead.KubeReserved.Memory().Value()/(1024*1024))
 	ephemeralStorage := instanceType.Overhead.KubeReserved.StorageEphemeral().String()
 
-	configStr := swag.StringValue(targetEntry.Value)
+	configStr := lo.FromPtr(targetEntry.Value)
 	if configStr == "" {
 		return errors.New("kubelet-config metadata is empty")
 	}
@@ -106,7 +105,7 @@ func RenderKubeletConfigMetadata(metaData *compute.Metadata, instanceType *cloud
 		return fmt.Errorf("failed to marshal updated kubelet-config YAML: %w", err)
 	}
 
-	targetEntry.Value = swag.String(string(updatedYAML))
+	targetEntry.Value = lo.ToPtr(string(updatedYAML))
 	metaData.Items[index] = targetEntry
 
 	return nil
@@ -120,7 +119,7 @@ func RemoveGKEBuiltinLabels(metadata *compute.Metadata, nodePoolName string) err
 			continue
 		}
 
-		item.Value = swag.String(strings.ReplaceAll(swag.StringValue(item.Value), nodePoolLabelEntry, ""))
+		item.Value = lo.ToPtr(strings.ReplaceAll(lo.FromPtr(item.Value), nodePoolLabelEntry, ""))
 	}
 	return nil
 }
@@ -138,8 +137,8 @@ func SetMaxPodsPerNode(metadata *compute.Metadata, nodeClass *v1alpha1.GCENodeCl
 		if !ok || index == -1 {
 			return fmt.Errorf("%s metadata not found", key)
 		}
-		targetEntry.Value = swag.String(maxPodsPerNodeRegex.ReplaceAllString(*targetEntry.Value, maxPodsPerNode))
-		targetEntry.Value = swag.String(maxPodsRegex.ReplaceAllString(*targetEntry.Value, maxPodsStr))
+		targetEntry.Value = lo.ToPtr(maxPodsPerNodeRegex.ReplaceAllString(*targetEntry.Value, maxPodsPerNode))
+		targetEntry.Value = lo.ToPtr(maxPodsRegex.ReplaceAllString(*targetEntry.Value, maxPodsStr))
 
 		metadata.Items[index] = targetEntry
 	}
@@ -157,7 +156,7 @@ func SetProvisioningModel(metadata *compute.Metadata, model string) error {
 		if !ok || index == -1 {
 			return fmt.Errorf("%s metadata not found", key)
 		}
-		targetEntry.Value = swag.String(gkeProvisioningRegex.ReplaceAllString(*targetEntry.Value, gkeProvisioning))
+		targetEntry.Value = lo.ToPtr(gkeProvisioningRegex.ReplaceAllString(*targetEntry.Value, gkeProvisioning))
 
 		metadata.Items[index] = targetEntry
 	}
@@ -170,7 +169,7 @@ func PatchUnregisteredTaints(metadata *compute.Metadata) error {
 	// Remove nodePoolLabelEntry from kube-labels and kube-env
 	for _, item := range metadata.Items {
 		if item.Key == "kube-env" {
-			kubeEnv := swag.StringValue(item.Value)
+			kubeEnv := lo.FromPtr(item.Value)
 
 			lines := strings.Split(kubeEnv, "\n")
 			for i, line := range lines {
@@ -183,7 +182,7 @@ func PatchUnregisteredTaints(metadata *compute.Metadata) error {
 				}
 			}
 			// Rejoin the updated lines into a single string
-			item.Value = swag.String(strings.Join(lines, "\n"))
+			item.Value = lo.ToPtr(strings.Join(lines, "\n"))
 		}
 	}
 
@@ -236,7 +235,7 @@ func PatchKubeEnvForInstanceType(metadata *compute.Metadata, instanceType *cloud
 		if item.Key != "kube-env" {
 			continue
 		}
-		kubeEnv := swag.StringValue(item.Value)
+		kubeEnv := lo.FromPtr(item.Value)
 		if kubeEnv == "" {
 			return fmt.Errorf("kube-env metadata is empty")
 		}
@@ -250,7 +249,7 @@ func PatchKubeEnvForInstanceType(metadata *compute.Metadata, instanceType *cloud
 		}
 
 		if updated != kubeEnv {
-			item.Value = swag.String(updated)
+			item.Value = lo.ToPtr(updated)
 		}
 	}
 
@@ -283,7 +282,7 @@ func AppendNodeClaimLabel(nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENo
 				// Append the nodeclaim label to kube-labels
 				labelString = append(labelString, fmt.Sprintf("%s=%s", k, v))
 			}
-			item.Value = swag.String(*item.Value + "," + strings.Join(labelString, ","))
+			item.Value = lo.ToPtr(*item.Value + "," + strings.Join(labelString, ","))
 		}
 	}
 }
@@ -292,7 +291,7 @@ func AppendRegisteredLabel(metadata *compute.Metadata) {
 	// Add registered label in metadata
 	for _, item := range metadata.Items {
 		if item.Key == "kube-labels" {
-			item.Value = swag.String(*item.Value + "," + RegisteredLabel)
+			item.Value = lo.ToPtr(*item.Value + "," + RegisteredLabel)
 		}
 	}
 }
@@ -316,13 +315,13 @@ func AppendSecondaryBootDisks(projectID string, nodeClass *v1alpha1.GCENodeClass
 		for _, item := range metadata.Items {
 			if item.Key == "kube-env" {
 				// Add SECONDARY_BOOT_DISKS: /mnt/disks/gke-secondary-disks/DISK_IMAGE_NAME
-				kubeEnv := swag.StringValue(item.Value)
+				kubeEnv := lo.FromPtr(item.Value)
 				lines := strings.Split(kubeEnv, "\n")
 				lines = append(lines, fmt.Sprintf("SECONDARY_BOOT_DISKS: /mnt/disks/gke-secondary-disks/%s", deviceName))
-				item.Value = swag.String(strings.Join(lines, "\n"))
+				item.Value = lo.ToPtr(strings.Join(lines, "\n"))
 			}
 			if item.Key == "kube-labels" {
-				item.Value = swag.String(*item.Value + "," + secondaryBootDiskLabel(name, projectID, disk.SecondaryBootMode))
+				item.Value = lo.ToPtr(*item.Value + "," + secondaryBootDiskLabel(name, projectID, disk.SecondaryBootMode))
 			}
 		}
 	}
@@ -366,14 +365,14 @@ func ApplyCustomMetadata(metadata *compute.Metadata, customMetadata map[string]s
 
 		if ok && index != -1 {
 			// Key exists, append the value with comma separator
-			targetEntry.Value = swag.String(*targetEntry.Value + "," + value)
+			targetEntry.Value = lo.ToPtr(*targetEntry.Value + "," + value)
 			metadata.Items[index] = targetEntry
 			continue
 		}
 		// Key doesn't exist, create a new metadata item
 		newItem := &compute.MetadataItems{
 			Key:   key,
-			Value: swag.String(value),
+			Value: lo.ToPtr(value),
 		}
 		metadata.Items = append(metadata.Items, newItem)
 	}

--- a/pkg/providers/metadata/utils_test.go
+++ b/pkg/providers/metadata/utils_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-openapi/swag"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/compute/v1"
@@ -48,7 +47,7 @@ func TestNoPatchKubeEnv(t *testing.T) {
 
 	require.NoError(t, PatchKubeEnvForInstanceType(meta, it))
 
-	got := swag.StringValue(meta.Items[0].Value)
+	got := lo.FromPtr(meta.Items[0].Value)
 	require.NotContains(t, got, "kubernetes-server-linux-arm64.tar.gz")
 	require.NotContains(t, got, "kubernetes-server-linux-amd64.tar.gz")
 	require.NotContains(t, got, "cloud.google.com/machine-family=c4a")
@@ -61,7 +60,7 @@ func TestPatchKubeEnvForInstanceType_ARM64(t *testing.T) {
 		Items: []*compute.MetadataItems{
 			{
 				Key: "kube-env",
-				Value: swag.String(`SERVER_BINARY_TAR_URL:
+				Value: lo.ToPtr(`SERVER_BINARY_TAR_URL:
   https://storage.googleapis.com/gke-release-eu/kubernetes/release/v1.34.3-gke.1444000/kubernetes-server-linux-amd64.tar.gz,
   https://storage.googleapis.com/gke-release/kubernetes/release/v1.34.3-gke.1444000/kubernetes-server-linux-amd64.tar.gz,
   https://storage.googleapis.com/gke-release-asia/kubernetes/release/v1.34.3-gke.1444000/kubernetes-server-linux-amd64.tar.gz
@@ -82,7 +81,7 @@ KUBELET_ARGS: cloud.google.com/machine-family=e2, arch=amd64; --v=2
 
 	require.NoError(t, PatchKubeEnvForInstanceType(meta, it))
 
-	got := swag.StringValue(meta.Items[0].Value)
+	got := lo.FromPtr(meta.Items[0].Value)
 	// SERVER_BINARY_TAR_URL is left unchanged; the arch-native node pool template carries the correct URL and hash.
 	require.Contains(t, got, "kubernetes-server-linux-amd64.tar.gz")
 	require.Contains(t, got, "cloud.google.com/machine-family=c4a")
@@ -95,7 +94,7 @@ func TestPatchKubeEnvForInstanceType_AMD64(t *testing.T) {
 		Items: []*compute.MetadataItems{
 			{
 				Key: "kube-env",
-				Value: swag.String(`SERVER_BINARY_TAR_URL:
+				Value: lo.ToPtr(`SERVER_BINARY_TAR_URL:
   https://storage.googleapis.com/gke-release/kubernetes/release/v1.34.3-gke.1444000/kubernetes-server-linux-arm64.tar.gz
 AUTOSCALER_ENV_VARS: cloud.google.com/machine-family=c4a, arch=arm64;
 KUBELET_ARGS: cloud.google.com/machine-family=c4a, arch=arm64;
@@ -114,7 +113,7 @@ KUBELET_ARGS: cloud.google.com/machine-family=c4a, arch=arm64;
 
 	require.NoError(t, PatchKubeEnvForInstanceType(meta, it))
 
-	got := swag.StringValue(meta.Items[0].Value)
+	got := lo.FromPtr(meta.Items[0].Value)
 	// SERVER_BINARY_TAR_URL is left unchanged; the arch-native node pool template carries the correct URL and hash.
 	require.Contains(t, got, "kubernetes-server-linux-arm64.tar.gz")
 	require.Contains(t, got, "cloud.google.com/machine-family=e2")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`swag.String` and `swag.StringValue` are deprecated in `go-openapi/swag`. The same file already used `lo.ToPtr`/`lo.FromPtr` for identical purposes in several places — this unifies the approach and removes the deprecated calls from both the implementation and the test file.

Surfaced by upgrading golangci-lint to v2.12.2 (staticcheck SA1019).

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the deprecated `swag.String`/`swag.StringValue` helpers from `go-openapi/swag` and replaces them with the already-imported `lo.ToPtr`/`lo.FromPtr` equivalents across `utils.go` and `utils_test.go`. Both pairs of functions are semantically identical for string pointers — `ToPtr` allocates a pointer to the given value and `FromPtr` safely dereferences it (returning `""` for a nil pointer), so no behaviour is changed.

- **`pkg/providers/metadata/utils.go`**: 12 call sites updated; `swag` import removed.
- **`pkg/providers/metadata/utils_test.go`**: 5 call sites updated; `swag` import removed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely mechanical substitution of deprecated helpers with functionally identical alternatives, with no logic changes.

Every replaced call is a direct 1-to-1 substitution: swag.String(v) → lo.ToPtr(v) and swag.StringValue(p) → lo.FromPtr(p). Both pairs allocate/dereference a *string identically, so runtime behaviour is unchanged. The swag import is correctly removed from both files. No error handling, control flow, or data transformation was touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/providers/metadata/utils.go | Replaces all uses of deprecated swag.String/swag.StringValue with lo.ToPtr/lo.FromPtr; removes the go-openapi/swag import. Both functions are semantically identical for string pointers. |
| pkg/providers/metadata/utils_test.go | Mirrors the same swag → lo substitution in test helpers and assertions; removes the swag import. No test logic changed. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["compute.Metadata item (Value *string)"] -->|"read"| B["lo.FromPtr(item.Value)"]
    B --> C["string processing\n(parse / regex / replace)"]
    C -->|"write back"| D["lo.ToPtr(result)"]
    D --> A

    style B fill:#d4edda,stroke:#28a745
    style D fill:#d4edda,stroke:#28a745
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: replace deprecated swag.String/Stri..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/4c0d71b0431109fdf6636aa724f99c2c54fedb59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32218813)</sub>

<!-- /greptile_comment -->