### PR TITLE
chore(dependabot): move controller-runtime to go-dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,20 +9,18 @@ updates:
     ignore:
       - dependency-name: "k8s.io/*"
     groups:
-      # karpenter-core and controller-runtime must be updated together and
-      # require e2e validation + interface adoption before merging.
+      # karpenter upgrades require interface adoption and e2e validation;
+      # keep isolated so they don't auto-merge with routine dep bumps.
       karpenter-core:
         applies-to: version-updates
         patterns:
           - "sigs.k8s.io/karpenter"
-          - "sigs.k8s.io/controller-runtime"
       go-dependencies:
         applies-to: version-updates
         patterns:
           - "*"
         exclude-patterns:
           - "sigs.k8s.io/karpenter"
-          - "sigs.k8s.io/controller-runtime"
           - "k8s.io/*"
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Follow-up to #343. `sigs.k8s.io/controller-runtime` was grouped with `karpenter-core` in that PR, but this is overly conservative. karpenter-core gets its own group because upgrades require interface adoption and e2e validation. controller-runtime doesn't have that property — its upgrades are backward compatible within the major version and don't require any adoption work on our side. Keeping it in `karpenter-core` would block routine patch bumps behind an unnecessary manual gate.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR moves `sigs.k8s.io/controller-runtime` out of the manually-gated `karpenter-core` dependabot group and into the routine `go-dependencies` wildcard group, following up on #343.

- `controller-runtime` is removed from the `karpenter-core` group patterns and from the `go-dependencies` exclude-patterns, so it now receives automated patch/minor bumps alongside other ordinary Go dependencies.
- The comment above the `karpenter-core` group is updated to clarify that isolation is only needed for karpenter itself (interface adoption + e2e validation), not for `controller-runtime`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to a single dependabot config file and has no runtime impact.

The only modified file is `.github/dependabot.yml`. Removing `controller-runtime` from the `karpenter-core` group and its exclude-list is correct: the wildcard `go-dependencies` group will now catch it, and `k8s.io/*` transitive changes brought in by a controller-runtime bump will still be included in the same dependabot PR via `go mod tidy`.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Removes `sigs.k8s.io/controller-runtime` from the `karpenter-core` group and its exclude-patterns, allowing it to be managed by the wildcard `go-dependencies` group instead. Comment is updated accordingly. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot detects Go dep update] --> B{Which dependency?}
    B -->|sigs.k8s.io/karpenter| C[karpenter-core group\nManual gate — e2e required]
    B -->|k8s.io/*| D[Ignored entirely\nTransitive only]
    B -->|sigs.k8s.io/controller-runtime\nAND all other deps| E[go-dependencies group\nRoutine auto-bump]
    C --> F[PR blocked until\ninterface adoption done]
    E --> G[PR created and\ncan auto-merge]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(dependabot): move controller-runti..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/ad9dbbf01f01dcb830460b2322a4f5165a2754ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32220878)</sub>

<!-- /greptile_comment -->