### PR TITLE
Revert "chore(dependabot): move controller-runtime to go-dependencies group"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,18 +9,20 @@ updates:
     ignore:
       - dependency-name: "k8s.io/*"
     groups:
-      # karpenter upgrades require interface adoption and e2e validation;
-      # keep isolated so they don't auto-merge with routine dep bumps.
+      # karpenter-core and controller-runtime must be updated together and
+      # require e2e validation + interface adoption before merging.
       karpenter-core:
         applies-to: version-updates
         patterns:
           - "sigs.k8s.io/karpenter"
+          - "sigs.k8s.io/controller-runtime"
       go-dependencies:
         applies-to: version-updates
         patterns:
           - "*"
         exclude-patterns:
           - "sigs.k8s.io/karpenter"
+          - "sigs.k8s.io/controller-runtime"
           - "k8s.io/*"
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Reverts cloudpilot-ai/karpenter-provider-gcp#348 as it broke dependabot again

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reverts #348 by moving `sigs.k8s.io/controller-runtime` back into the `karpenter-core` dependabot group and re-adding it to the `exclude-patterns` of the `go-dependencies` group. The motivation is that PR #348 caused dependabot to break, so the previous working configuration is being restored.

- `controller-runtime` is placed back in the `karpenter-core` group alongside `sigs.k8s.io/karpenter`, ensuring both are bumped together and gated behind e2e validation.
- The comment on the `karpenter-core` group is updated to explicitly mention `controller-runtime` and the reason these two dependencies must be co-upgraded.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this is a targeted config-only revert that restores a previously working dependabot grouping.

The change touches only `.github/dependabot.yml`, adding `controller-runtime` back to the `karpenter-core` group and excluding it from `go-dependencies`. It mirrors a known-good prior state and no logic, tests, or production code are affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Reverts PR #348 — moves `sigs.k8s.io/controller-runtime` back into the `karpenter-core` group and excludes it from `go-dependencies`, with an updated comment explaining the coupling. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;chore(dependabot): move controll..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/def8b44d38e277a2c76a2c36df1caeba1c8ae19e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32240745)</sub>

<!-- /greptile_comment -->