### PR TITLE
Revert "chore(dependabot): move controller-runtime to go-dependencies group (#348)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,18 +9,20 @@ updates:
     ignore:
       - dependency-name: "k8s.io/*"
     groups:
-      # karpenter upgrades require interface adoption and e2e validation;
-      # keep isolated so they don't auto-merge with routine dep bumps.
+      # karpenter-core and controller-runtime must be updated together and
+      # require e2e validation + interface adoption before merging.
       karpenter-core:
         applies-to: version-updates
         patterns:
           - "sigs.k8s.io/karpenter"
+          - "sigs.k8s.io/controller-runtime"
       go-dependencies:
         applies-to: version-updates
         patterns:
           - "*"
         exclude-patterns:
           - "sigs.k8s.io/karpenter"
+          - "sigs.k8s.io/controller-runtime"
           - "k8s.io/*"
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Reverts #348 with a proper `Signed-off-by` trailer to satisfy DCO. The auto-generated revert PR #349 was missing the sign-off.

See #349 for the original revert rationale.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.
- Supersedes #349 (same revert, DCO-compliant commit).