### PR TITLE
fix(helm): allow global key in values schema for subchart usage

### DIFF
--- a/charts/karpenter-crd/values.schema.json
+++ b/charts/karpenter-crd/values.schema.json
@@ -3,6 +3,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "global": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Reserved for Helm parent-chart globals; not consumed by this chart."
+    },
     "additionalAnnotations": {
       "type": "object",
       "additionalProperties": { "type": "string" },

--- a/charts/karpenter/values.schema.json
+++ b/charts/karpenter/values.schema.json
@@ -4,6 +4,11 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "global": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Reserved for Helm parent-chart globals; not consumed by this chart."
+    },
     "nameOverride": {
       "type": "string",
       "description": "Override the default chart name."


### PR DESCRIPTION
## Summary

When the `karpenter` or `karpenter-crd` chart is used as a Helm subchart (declared under `dependencies:` in a parent `Chart.yaml`), Helm auto-injects a `global` object into the merged values before schema validation. Since both `values.schema.json` files set `additionalProperties: false` at the root without declaring `global`, validation fails with:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
karpenter-crd:
- at '': additional properties 'global' not allowed
karpenter:
- at '': additional properties 'global' not allowed
```

This makes the charts unusable in wrapper/composition patterns (common with ArgoCD / Flux).

## Change

Declared `global` as an allowed `object` property (with `additionalProperties: true`) in both schemas. The chart itself does not consume `global`, this is purely to satisfy Helm's subchart contract.

I kept the root `additionalProperties: false` so the strict schema still catches typos in `values.yaml` for direct users.

Fix #360

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a schema validation error that prevented these charts from being used as Helm subcharts (e.g., in ArgoCD/Flux compositions), where Helm auto-injects a `global` key into the merged values before validation.

- Adds a `\"global\"` property entry (`type: object`, `additionalProperties: true`) to the root `properties` block in both `charts/karpenter/values.schema.json` and `charts/karpenter-crd/values.schema.json`.
- The root `additionalProperties: false` is preserved in both files, so strict typo-catching for all other keys remains intact; only `global` is newly allowed through.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This is a safe, additive schema change that unblocks subchart usage without weakening existing validation for direct users.

Both files receive a single, well-scoped property addition that follows the standard Helm subchart pattern. The root `additionalProperties: false` constraint is preserved, so all other keys remain strictly validated. The chart itself does not read `global`, so there is no risk of unintended behavior from the looser `additionalProperties: true` inside the `global` object.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| charts/karpenter/values.schema.json | Adds `global` as an explicitly declared, open-ended object property to fix subchart schema validation; all other constraints unchanged. |
| charts/karpenter-crd/values.schema.json | Same one-property addition as the main chart schema; minimal, targeted change with no unintended side effects. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Parent as Parent Chart
    participant Helm as Helm Engine
    participant Schema as values.schema.json
    participant Chart as karpenter / karpenter-crd

    Parent->>Helm: helm install (with dependencies)
    Helm->>Helm: "Merge parent values + auto-inject global{}"
    Helm->>Schema: Validate merged values against schema
    Note over Schema: Before PR: additionalProperties:false<br/>rejects unknown "global" key → ERROR
    Note over Schema: After PR: "global" declared as<br/>object with additionalProperties:true → OK
    Schema-->>Helm: Validation passed
    Helm->>Chart: Render templates with validated values
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(helm): allow global key in values sc..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/879519aa5917d413037fa1ebe503d0069a22c22c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32465189)</sub>

<!-- /greptile_comment -->