### PR TITLE
Fix incorrect failure threshold references in bootstrap-pool.md

### DIFF
--- a/docs/bootstrap-pool.md
+++ b/docs/bootstrap-pool.md
@@ -9,7 +9,7 @@ On startup and every 12 minutes, Karpenter runs pool discovery:
 1. **Pinned pool** (if `DEFAULT_NODEPOOL_TEMPLATE_NAME` is set): Use that pool exclusively. Return an error if it does not exist or is not RUNNING.
 2. **default-pool**: If the cluster's `default-pool` exists and is RUNNING or RUNNING_WITH_ERROR, use it.
 3. **Alphabetical fallback**: Sort all remaining RUNNING or RUNNING_WITH_ERROR pools by name and use the first one.
-4. **No eligible pool**: If no pool passes the above checks, Karpenter logs a warning and retries with exponential backoff. After 5 consecutive failures (~7.5 minutes), it creates a minimal `karpenter-fallback` pool as a last resort.
+4. **No eligible pool**: If no pool passes the above checks, Karpenter creates a minimal `karpenter-fallback` pool and polls every 15 seconds until it becomes RUNNING.
 
 A pool is eligible when its status is `RUNNING` or `RUNNING_WITH_ERROR`. Pools in `PROVISIONING`, `STOPPING`, `ERROR`, or `RECONCILING` states are skipped.
 
@@ -31,7 +31,7 @@ When set, Karpenter uses only that pool and returns an error if it is not RUNNIN
 
 ## The fallback pool
 
-If no RUNNING pool exists after 5 retries, Karpenter creates a zero-node pool named `karpenter-fallback`. This pool is hardened against common GCP org policy constraints:
+When no RUNNING pool exists, Karpenter creates a zero-node pool named `karpenter-fallback`. This pool is hardened against common GCP org policy constraints:
 
 | Constraint                                             | Fallback pool setting                                    |
 |--------------------------------------------------------|----------------------------------------------------------|


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/9ec1da71-64c9-4812-969b-9efa969517ba)

Removes incorrect documentation stating Karpenter waits for 5 consecutive failures before creating the fallback pool. The code shows the fallback is created immediately when no eligible pool is found. Addresses reviewer feedback from @dm3ch on PR #329.

---

_Tip: Tag @Promptless in GitHub PR comments to guide documentation changes during code review 🐙_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects two inaccurate statements in `docs/bootstrap-pool.md` about when and how the `karpenter-fallback` pool is created. The previous documentation claimed Karpenter waited for 5 consecutive failures (~7.5 minutes) before creating the fallback pool, which did not match the actual controller logic.

- The controller (`pkg/controllers/nodepooltemplate/controller.go`) immediately calls `EnsureFallbackPool` on the first `Sync` failure — no retry counter or exponential backoff precedes it.
- After creation, the controller returns `RequeueAfter: 15 * time.Second` to poll until the pool becomes RUNNING, which the updated doc now correctly describes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change that brings the docs into sync with the existing controller implementation; no runtime behavior is altered.

Both changed sentences were verified against the controller source. The old "5 consecutive failures" text had no basis in the code, and the new wording — immediate fallback creation followed by 15-second polling — matches controller.go exactly. No logic, configuration, or tests are touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/bootstrap-pool.md | Removes two incorrect references to "5 consecutive failures" and replaces them with accurate descriptions that match the controller's immediate-fallback-creation and 15-second polling behavior. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Reconcile triggered]) --> B{DEFAULT_NODEPOOL_TEMPLATE_NAME set?}
    B -- Yes --> C[Validate preferred pool]
    C -- eligible --> D[Use preferred pool]
    C -- not eligible --> E[Return error]
    B -- No --> F{default-pool RUNNING?}
    F -- Yes --> G[Use default-pool]
    F -- No --> H{Other eligible pool?}
    H -- Yes --> I[Use first alphabetically]
    H -- No --> J[EnsureFallbackPool created immediately]
    J --> K[Return RequeueAfter: 15s]
    K --> A
    D --> L[Return RequeueAfter: 12min]
    G --> L
    I --> L
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove incorrect failure threshold ..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/a2bf8f7d6332b5511a02db0690cde3c96f24281a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32781684)</sub>

<!-- /greptile_comment -->