### PR TITLE
fix(dependabot): allow indirect deps for hack/tools group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,10 @@ updates:
     directory: "/hack/tools"
     schedule:
       interval: "weekly"
+    # Go 1.24 tool directives cause all entries (including tool binaries) to
+    # appear as //indirect in go.mod; allow indirect so the group can match them.
+    allow:
+      - dependency-type: "all"
     groups:
       dev-tools:
         patterns:


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

Go 1.24's `tool` directive marks all entries in `hack/tools/go.mod` — including the tool binaries themselves — as `// indirect` in the `require` block. Dependabot's default `allowed-updates` is `dependency-type: direct`, so the `dev-tools` group matched nothing and fell back to opening one PR per package.

Adding `allow: [{dependency-type: all}]` to the `/hack/tools` entry lets dependabot include those indirect entries and bundle them into a single grouped PR.

## Which issue(s) this PR fixes

N/A

## Special notes for your reviewer

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.
- After merge, the 7 open individual dependabot PRs (#366–#372) for `/hack/tools` can be closed; dependabot will re-open them as one grouped PR on the next run.

## Does this PR introduce a user-facing change?

No

## Additional documentation e.g., usage docs, etc.

N/A

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Dependabot grouping regression caused by Go 1.24's `tool` directive, which marks all entries in `hack/tools/go.mod` — including the tool binaries themselves — as `// indirect`. Because Dependabot's default `allowed-updates` only covers direct dependencies, the `dev-tools` group matched nothing and fell back to one PR per package.

- Adds `allow: [{dependency-type: \"all\"}]` to the `/hack/tools` gomod block so Dependabot includes indirect entries and can bundle them into the single `dev-tools` grouped PR.
- The root `/` gomod entry is intentionally left without this override, preserving its existing `ignore` behaviour for `k8s.io/*` transitive dependencies.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is confined to a single Dependabot config block and has no runtime impact on the codebase.

The addition is a two-line Dependabot YAML tweak with a clear, well-commented rationale matching the documented Go 1.24 tool directive behaviour. The root / gomod block is unaffected, and the ignore rules for k8s.io/* remain intact. No application code, tests, or CI workflows are touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds `allow: [{dependency-type: "all"}]` to the `/hack/tools` gomod entry so Dependabot includes indirect deps (Go 1.24 tool-directive behavior) in the `dev-tools` group PR. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dependabot): allow indirect deps for..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/f81f6fdca6e11db3d78ce2f724547689798293a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32785940)</sub>

<!-- /greptile_comment -->