### PR TITLE
Document metadata override behavior

### DIFF
--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -2,9 +2,11 @@
 
 ## Instance metadata
 
-Set GCE instance metadata key-value pairs for advanced configuration:
+Set GCE instance metadata key-value pairs for advanced configuration. Values in `spec.metadata` override matching keys from the base instance template; new keys are added.
 
 See [`examples/nodeclass/gcenodeclass-metadata.yaml`](https://github.com/cloudpilot-ai/karpenter-provider-gcp/blob/main/examples/nodeclass/gcenodeclass-metadata.yaml).
+
+For example, if the base GKE node-pool template sets `serial-port-logging-enable=true`, specifying `serial-port-logging-enable: "false"` in `spec.metadata` results in the provisioned instance having `serial-port-logging-enable=false`.
 
 > **Note:** For GPU driver version control, use `spec.gpuDriverVersion` instead of setting `cloud.google.com/gke-gpu-driver-version` via metadata. See [GPU Nodes](../gpu-nodes.md) for details.
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/a746667e-6862-4bf7-9623-ce3ab688dc00)

Explains that spec.metadata values override matching keys from the base instance template rather than concatenating them. Adds a concrete example showing how serial-port-logging-enable can be overridden.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #394: fix(metadata): override base-template metadata instead of concatenating](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/394)

---

_Tip: Configure how Promptless handles changelogs in [Agent Settings](https://app.gopromptless.ai/configure/settings) 📋_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR is a documentation-only change that clarifies the override semantics of `spec.metadata` relative to the base GKE node-pool instance template, complementing the behavioral fix in PR #394.

- Adds a one-sentence description on line 5 explaining that `spec.metadata` keys override matching base-template keys rather than concatenating with them, and that new keys are appended.
- Adds a concrete prose example on line 9 demonstrating the `serial-port-logging-enable` override pattern to make the behavior immediately tangible for users.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no code modifications; safe to merge.

The change adds two sentences to a markdown file, accurately describing the override behavior introduced by the accompanying code fix in PR #394. The prose is clear, the example is concrete and correct, and no code paths are touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/examples/advanced.md | Documentation update clarifying that spec.metadata values override (not concatenate) matching keys from the base instance template, with a concrete serial-port-logging-enable example added. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Base Instance Template metadata] --> C{Key present in spec.metadata?}
    B[spec.metadata key-value pairs] --> C
    C -->|Yes - override| D[Use spec.metadata value]
    C -->|No - keep| E[Use base template value]
    B --> F{Key absent from base template?}
    F -->|Yes - append| G[Add new key from spec.metadata]
    D --> H[Final Instance Metadata]
    E --> H
    G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: document metadata override behavio..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/b80df6b4b7ee13c643c177a5099a6d876f2b5fb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34771260)</sub>

<!-- /greptile_comment -->