### PR TITLE
fix(kubeletConfiguration): honour systemReserved, kubeReserved, eviction* and other fields

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,6 +5,20 @@
 
 ## Unreleased
 
+### `kubeletConfiguration` fields now take effect
+
+`spec.kubeletConfiguration` fields on `GCENodeClass` that were previously accepted by the CRD but silently dropped at provisioning time are now applied to the kubelet on every Karpenter-provisioned node and to Karpenter's scheduler bin-packing. The previously honoured fields (`maxPods`) are unchanged.
+
+Newly honoured fields:
+
+- `systemReserved`, `kubeReserved` — reservations passed to the kubelet via `--config` and used by the scheduler to compute allocatable.
+- `evictionHard`, `evictionSoft`, `evictionSoftGracePeriod`, `evictionMaxPodGracePeriod` — passed to the kubelet. For the scheduler's overhead, only `evictionHard.memory.available` and `evictionHard.nodefs.available` are modelled (matches `aws/karpenter-provider-aws` and the [Kubernetes node-pressure-eviction docs](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#eviction-thresholds)). `evictionSoft` is a warning threshold and is enforced by the kubelet at runtime but does not reduce scheduler allocatable.
+- `imageGCHighThresholdPercent`, `imageGCLowThresholdPercent`, `cpuCFSQuota`, `clusterDNS`, `podsPerCore` — passed to the kubelet. `podsPerCore` additionally caps `node.status.capacity.pods` at `podsPerCore × cpus`.
+
+**Action required:** audit existing `GCENodeClass` objects that set any of these fields. The values will now take effect on the next node provision, and a change to any field triggers Karpenter's standard drift-driven node rotation.
+
+The CRD value schema for `systemReserved`, `kubeReserved`, `evictionHard`, and `evictionSoft` is now validated against the `resource.Quantity` regex (and percentage syntax for the eviction fields). Existing values that already parsed as `resource.Quantity` are unaffected.
+
 ### GPU node provisioning (`gpuDriverVersion`)
 
 Karpenter now automatically sets the two node labels required by the GKE GPU software stack

--- a/charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -300,6 +300,8 @@ spec:
                     x-kubernetes-validations:
                     - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
                       rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    - message: evictionHard values must be a percentage or a resource.Quantity
+                      rule: self.all(x, self[x].matches('^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$'))
                   evictionMaxPodGracePeriod:
                     description: |-
                       EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
@@ -316,6 +318,8 @@ spec:
                     x-kubernetes-validations:
                     - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
                       rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    - message: evictionSoft values must be a percentage or a resource.Quantity
+                      rule: self.all(x, self[x].matches('^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$'))
                   evictionSoftGracePeriod:
                     additionalProperties:
                       type: string
@@ -360,6 +364,8 @@ spec:
                         || x=='pid')
                     - message: kubeReserved value cannot be a negative resource quantity
                       rule: self.all(x, !self[x].startsWith('-'))
+                    - message: kubeReserved values must be a resource.Quantity
+                      rule: self.all(x, self[x].matches('^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$'))
                   maxPods:
                     description: |-
                       MaxPods is an override for the maximum number of pods that can run on
@@ -389,6 +395,8 @@ spec:
                     - message: systemReserved value cannot be a negative resource
                         quantity
                       rule: self.all(x, !self[x].startsWith('-'))
+                    - message: systemReserved values must be a resource.Quantity
+                      rule: self.all(x, self[x].matches('^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$'))
                 type: object
                 x-kubernetes-validations:
                 - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent

--- a/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -297,6 +297,8 @@ spec:
                     x-kubernetes-validations:
                     - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
                       rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    - message: evictionHard values must be a percentage or a resource.Quantity
+                      rule: self.all(x, self[x].matches('^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$'))
                   evictionMaxPodGracePeriod:
                     description: |-
                       EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
@@ -313,6 +315,8 @@ spec:
                     x-kubernetes-validations:
                     - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
                       rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
+                    - message: evictionSoft values must be a percentage or a resource.Quantity
+                      rule: self.all(x, self[x].matches('^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$'))
                   evictionSoftGracePeriod:
                     additionalProperties:
                       type: string
@@ -357,6 +361,8 @@ spec:
                         || x=='pid')
                     - message: kubeReserved value cannot be a negative resource quantity
                       rule: self.all(x, !self[x].startsWith('-'))
+                    - message: kubeReserved values must be a resource.Quantity
+                      rule: self.all(x, self[x].matches('^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$'))
                   maxPods:
                     description: |-
                       MaxPods is an override for the maximum number of pods that can run on
@@ -386,6 +392,8 @@ spec:
                     - message: systemReserved value cannot be a negative resource
                         quantity
                       rule: self.all(x, !self[x].startsWith('-'))
+                    - message: systemReserved values must be a resource.Quantity
+                      rule: self.all(x, self[x].matches('^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$'))
                 type: object
                 x-kubernetes-validations:
                 - message: imageGCHighThresholdPercent must be greater than imageGCLowThresholdPercent

--- a/pkg/apis/v1alpha1/gcenodeclass.go
+++ b/pkg/apis/v1alpha1/gcenodeclass.go
@@ -186,6 +186,19 @@ type ImageSelectorTerm struct {
 	Version string `json:"version,omitempty"`
 }
 
+/*
+Maintainers: JSON tags on every field below MUST match the upstream kubelet
+`kubelet/config/v1beta1.KubeletConfiguration` schema. The entire struct is
+JSON-marshaled and merged into the kubelet-config bootstrap metadata YAML
+at provisioning time (see pkg/providers/metadata/utils.go), so any field
+added here with a matching upstream JSON tag automatically takes effect at
+kubelet runtime without further plumbing. A consequence is that adding a new
+field also requires deciding whether scheduler bin-packing must agree with
+the field's runtime effect — only resource-reservation-like fields
+(systemReserved, kubeReserved, eviction*, podsPerCore) need additional
+scheduler overhead/capacity plumbing in pkg/providers/instancetype.
+*/
+
 // KubeletConfiguration defines args to be used when configuring kubelet on provisioned nodes.
 // They are a vswitch of the upstream types, recognizing not all options may be supported.
 // Wherever possible, the types and names should reflect the upstream kubelet types.
@@ -210,22 +223,26 @@ type KubeletConfiguration struct {
 	// SystemReserved contains resources reserved for OS system daemons and kernel memory.
 	// +kubebuilder:validation:XValidation:message="valid keys for systemReserved are ['cpu','memory','ephemeral-storage','pid']",rule="self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')"
 	// +kubebuilder:validation:XValidation:message="systemReserved value cannot be a negative resource quantity",rule="self.all(x, !self[x].startsWith('-'))"
+	// +kubebuilder:validation:XValidation:message="systemReserved values must be a resource.Quantity",rule="self.all(x, self[x].matches('^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$'))"
 	// +kubebuilder:validation:MaxProperties=10
 	// +optional
 	SystemReserved map[string]string `json:"systemReserved,omitempty"`
 	// KubeReserved contains resources reserved for Kubernetes system components.
 	// +kubebuilder:validation:XValidation:message="valid keys for kubeReserved are ['cpu','memory','ephemeral-storage','pid']",rule="self.all(x, x=='cpu' || x=='memory' || x=='ephemeral-storage' || x=='pid')"
 	// +kubebuilder:validation:XValidation:message="kubeReserved value cannot be a negative resource quantity",rule="self.all(x, !self[x].startsWith('-'))"
+	// +kubebuilder:validation:XValidation:message="kubeReserved values must be a resource.Quantity",rule="self.all(x, self[x].matches('^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$'))"
 	// +kubebuilder:validation:MaxProperties=10
 	// +optional
 	KubeReserved map[string]string `json:"kubeReserved,omitempty"`
 	// EvictionHard is the map of signal names to quantities that define hard eviction thresholds
 	// +kubebuilder:validation:XValidation:message="valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']",rule="self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])"
+	// +kubebuilder:validation:XValidation:message="evictionHard values must be a percentage or a resource.Quantity",rule="self.all(x, self[x].matches('^((\\d{1,2}(\\.\\d{1,2})?|100(\\.0{1,2})?)%||(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?)$'))"
 	// +kubebuilder:validation:MaxProperties=10
 	// +optional
 	EvictionHard map[string]string `json:"evictionHard,omitempty"`
 	// EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
 	// +kubebuilder:validation:XValidation:message="valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']",rule="self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])"
+	// +kubebuilder:validation:XValidation:message="evictionSoft values must be a percentage or a resource.Quantity",rule="self.all(x, self[x].matches('^((\\d{1,2}(\\.\\d{1,2})?|100(\\.0{1,2})?)%||(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?)$'))"
 	// +kubebuilder:validation:MaxProperties=10
 	// +optional
 	EvictionSoft map[string]string `json:"evictionSoft,omitempty"`

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -836,7 +836,7 @@ func (p *DefaultProvider) setupInstanceMetadata(ctx context.Context, instanceMet
 		return fmt.Errorf("failed to set max pods per node in metadata: %w", err)
 	}
 
-	if err := metadata.RenderKubeletConfigMetadata(instanceMetadata, instanceType, capacityType); err != nil {
+	if err := metadata.RenderKubeletConfigMetadata(instanceMetadata, nodeClass, instanceType, capacityType); err != nil {
 		return fmt.Errorf("failed to render kubelet config metadata: %w", err)
 	}
 

--- a/pkg/providers/instancetype/overhead.go
+++ b/pkg/providers/instancetype/overhead.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancetype
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
+)
+
+// Eviction signal keys recognized for overhead modeling. imagefs.available
+// and pid.available are accepted by the CRD but not factored into the
+// scheduler's view of allocatable — matches aws/karpenter-provider-aws.
+const (
+	signalMemoryAvailable = "memory.available"
+	signalNodeFSAvailable = "nodefs.available"
+)
+
+// kcSystemReserved returns Overhead.SystemReserved derived from the user's
+// systemReserved map. CRD pattern validation guarantees every value is a
+// parseable resource.Quantity, so MustParse is safe here.
+func kcSystemReserved(kc *v1alpha1.KubeletConfiguration) corev1.ResourceList {
+	out := corev1.ResourceList{}
+	if kc == nil {
+		return out
+	}
+	for k, v := range kc.SystemReserved {
+		out[corev1.ResourceName(k)] = resource.MustParse(v)
+	}
+	return out
+}
+
+// mergeKubeReserved returns computed with user keys overlaid. Mirrors AWS's
+// lo.Assign(computed, user) semantics: user keys win per-key, computed
+// sub-keys for sub-keys the user did not set survive.
+func mergeKubeReserved(computed corev1.ResourceList, kc *v1alpha1.KubeletConfiguration) corev1.ResourceList {
+	out := computed.DeepCopy()
+	if kc == nil {
+		return out
+	}
+	for k, v := range kc.KubeReserved {
+		out[corev1.ResourceName(k)] = resource.MustParse(v)
+	}
+	return out
+}
+
+// evictionThreshold returns the eviction overhead used by the scheduler.
+// Only evictionHard is factored into overhead; evictionSoft is a warning
+// threshold with a grace period and is not modeled here, matching
+// aws/karpenter-provider-aws and the Kubernetes node-pressure-eviction docs:
+// https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#eviction-thresholds
+// https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/#eviction-signals
+//
+// Only memory.available and nodefs.available are modeled; imagefs.available
+// and pid.available are out of scope for scheduler bin-packing.
+func evictionThreshold(memory, storage *resource.Quantity, computed corev1.ResourceList, kc *v1alpha1.KubeletConfiguration) corev1.ResourceList {
+	out := computed.DeepCopy()
+	if kc == nil || len(kc.EvictionHard) == 0 {
+		return out
+	}
+	if v, ok := kc.EvictionHard[signalMemoryAvailable]; ok {
+		out[corev1.ResourceMemory] = computeEvictionSignal(*memory, v)
+	}
+	if v, ok := kc.EvictionHard[signalNodeFSAvailable]; ok {
+		out[corev1.ResourceEphemeralStorage] = computeEvictionSignal(*storage, v)
+	}
+	return out
+}
+
+// computeEvictionSignal resolves an eviction signal value against a capacity.
+// CRD pattern restricts inputs to either a percentage like "5%" or a
+// resource.Quantity. MustParse is safe on the non-percentage branch.
+func computeEvictionSignal(capacity resource.Quantity, signal string) resource.Quantity {
+	if strings.HasSuffix(signal, "%") {
+		pct, err := strconv.ParseFloat(strings.TrimSuffix(signal, "%"), 64)
+		if err != nil {
+			// CRD pattern validates this; defensive fallback to zero.
+			return resource.Quantity{}
+		}
+		return *resource.NewQuantity(int64(math.Ceil(float64(capacity.Value())*pct/100.0)), capacity.Format)
+	}
+	return resource.MustParse(signal)
+}
+
+// kcMaxPods returns the effective max pods for an instance type, honoring
+// nodeClass.GetMaxPods() and PodsPerCore (cap pods at podsPerCore × cpus).
+// Mirrors AWS's pods() helper.
+func kcMaxPods(nodeClassMaxPods int32, kc *v1alpha1.KubeletConfiguration, cpus int64) int64 {
+	maxPods := int64(nodeClassMaxPods)
+	if kc != nil && kc.PodsPerCore != nil && *kc.PodsPerCore > 0 {
+		byCores := int64(*kc.PodsPerCore) * cpus
+		if byCores < maxPods {
+			return byCores
+		}
+	}
+	return maxPods
+}

--- a/pkg/providers/instancetype/overhead_test.go
+++ b/pkg/providers/instancetype/overhead_test.go
@@ -1,0 +1,299 @@
+/*
+Copyright 2025 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instancetype
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
+
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/operator/options"
+)
+
+func TestKCSystemReserved(t *testing.T) {
+	tests := []struct {
+		name string
+		kc   *v1alpha1.KubeletConfiguration
+		want corev1.ResourceList
+	}{
+		{name: "nil → empty", kc: nil, want: corev1.ResourceList{}},
+		{
+			name: "cpu and memory parsed",
+			kc: &v1alpha1.KubeletConfiguration{
+				SystemReserved: map[string]string{"cpu": "1", "memory": "1Gi"},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := kcSystemReserved(tt.kc)
+			assert.True(t, quantityListsEqual(tt.want, got), "want %v, got %v", tt.want, got)
+		})
+	}
+}
+
+func TestMergeKubeReserved(t *testing.T) {
+	computed := corev1.ResourceList{
+		corev1.ResourceCPU:              resource.MustParse("100m"),
+		corev1.ResourceMemory:           resource.MustParse("200Mi"),
+		corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
+	}
+	tests := []struct {
+		name string
+		kc   *v1alpha1.KubeletConfiguration
+		want corev1.ResourceList
+	}{
+		{name: "nil → computed survives", kc: nil, want: computed},
+		{
+			// Issue #220 guard: partial user override must preserve
+			// provider-computed sub-keys (ephemeral-storage, memory) so a
+			// user setting kubeReserved.cpu does not crash the kubelet.
+			name: "partial user override preserves computed sub-keys (#220)",
+			kc: &v1alpha1.KubeletConfiguration{
+				KubeReserved: map[string]string{"cpu": "500m"},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:              resource.MustParse("500m"),
+				corev1.ResourceMemory:           resource.MustParse("200Mi"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("15Gi"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeKubeReserved(computed, tt.kc)
+			assert.True(t, quantityListsEqual(tt.want, got), "want %v, got %v", tt.want, got)
+			// Defensive: must not mutate input.
+			assert.Equal(t, "100m", computed.Cpu().String())
+			assert.Equal(t, "15Gi", computed.StorageEphemeral().String())
+		})
+	}
+}
+
+func TestEvictionThreshold(t *testing.T) {
+	mem10Gi := resource.MustParse("10Gi")
+	storage100Gi := resource.MustParse("100Gi")
+	computed := corev1.ResourceList{
+		corev1.ResourceMemory:           resource.MustParse("100Mi"),
+		corev1.ResourceEphemeralStorage: resource.MustParse("10Gi"),
+	}
+	tests := []struct {
+		name        string
+		kc          *v1alpha1.KubeletConfiguration
+		wantMemory  resource.Quantity
+		wantStorage resource.Quantity
+	}{
+		{
+			// evictionSoft is intentionally not modeled in overhead — only
+			// evictionHard is, matching AWS and the Kubernetes
+			// node-pressure-eviction docs. Also covers nil-kc and unmodelled
+			// signals (imagefs.available, pid.available) — all paths that
+			// must leave computed untouched.
+			name:        "evictionSoft and unmodelled signals → computed survives",
+			kc:          &v1alpha1.KubeletConfiguration{EvictionSoft: map[string]string{"memory.available": "1Gi"}},
+			wantMemory:  resource.MustParse("100Mi"),
+			wantStorage: resource.MustParse("10Gi"),
+		},
+		{
+			// 5% of 10 GiB. math.Ceil mirrors production rounding so the
+			// expectation tracks the implementation for any percentage.
+			name:        "evictionHard memory.available % → overhead reflects %",
+			kc:          &v1alpha1.KubeletConfiguration{EvictionHard: map[string]string{"memory.available": "5%"}},
+			wantMemory:  *resource.NewQuantity(int64(math.Ceil(0.05*float64(mem10Gi.Value()))), resource.BinarySI),
+			wantStorage: resource.MustParse("10Gi"),
+		},
+		{
+			name:        "evictionHard nodefs.available % → overhead reflects %",
+			kc:          &v1alpha1.KubeletConfiguration{EvictionHard: map[string]string{"nodefs.available": "10%"}},
+			wantMemory:  resource.MustParse("100Mi"),
+			wantStorage: *resource.NewQuantity(int64(math.Ceil(0.10*float64(storage100Gi.Value()))), resource.BinarySI),
+		},
+		{
+			// Both set → evictionHard wins; evictionSoft remains ignored.
+			name: "evictionHard and evictionSoft both set → evictionHard wins",
+			kc: &v1alpha1.KubeletConfiguration{
+				EvictionHard: map[string]string{"memory.available": "500Mi"},
+				EvictionSoft: map[string]string{"memory.available": "1Gi"},
+			},
+			wantMemory:  resource.MustParse("500Mi"),
+			wantStorage: resource.MustParse("10Gi"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evictionThreshold(&mem10Gi, &storage100Gi, computed, tt.kc)
+			gotMem := got[corev1.ResourceMemory]
+			gotStor := got[corev1.ResourceEphemeralStorage]
+			assert.True(t, tt.wantMemory.Cmp(gotMem) == 0, "memory: want %s, got %s", tt.wantMemory.String(), gotMem.String())
+			assert.True(t, tt.wantStorage.Cmp(gotStor) == 0, "storage: want %s, got %s", tt.wantStorage.String(), gotStor.String())
+			// Defensive: must not mutate input.
+			computedMem := computed[corev1.ResourceMemory]
+			assert.Equal(t, "100Mi", computedMem.String())
+		})
+	}
+}
+
+func TestComputeEvictionSignal(t *testing.T) {
+	capacity1000 := *resource.NewQuantity(1000, resource.DecimalSI)
+	capacity10Gi := resource.MustParse("10Gi")
+	tests := []struct {
+		name     string
+		capacity resource.Quantity
+		signal   string
+		want     resource.Quantity
+	}{
+		{name: "percentage", capacity: capacity1000, signal: "10%", want: *resource.NewQuantity(100, resource.DecimalSI)},
+		{name: "absolute quantity", capacity: capacity10Gi, signal: "500Mi", want: resource.MustParse("500Mi")},
+		{name: "malformed percentage → defensive zero", capacity: capacity1000, signal: "%", want: resource.Quantity{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeEvictionSignal(tt.capacity, tt.signal)
+			assert.True(t, tt.want.Cmp(got) == 0, "want %s, got %s", tt.want.String(), got.String())
+		})
+	}
+}
+
+func TestKCMaxPods(t *testing.T) {
+	tests := []struct {
+		name             string
+		nodeClassMaxPods int32
+		podsPerCore      *int32
+		cpus             int64
+		want             int64
+	}{
+		{name: "podsPerCore unset → nodeClassMaxPods unchanged", nodeClassMaxPods: 110, podsPerCore: nil, cpus: 4, want: 110},
+		{name: "podsPerCore=0 → nodeClassMaxPods unchanged", nodeClassMaxPods: 110, podsPerCore: lo.ToPtr[int32](0), cpus: 4, want: 110},
+		{name: "podsPerCore × cpus < max → podsPerCore wins", nodeClassMaxPods: 110, podsPerCore: lo.ToPtr[int32](8), cpus: 2, want: 16},
+		{name: "podsPerCore × cpus ≥ max → max wins", nodeClassMaxPods: 64, podsPerCore: lo.ToPtr[int32](8), cpus: 16, want: 64},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var kc *v1alpha1.KubeletConfiguration
+			if tt.podsPerCore != nil {
+				kc = &v1alpha1.KubeletConfiguration{PodsPerCore: tt.podsPerCore}
+			}
+			got := kcMaxPods(tt.nodeClassMaxPods, kc, tt.cpus)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestNewInstanceType_RespectsKubeletConfiguration is the integration-level
+// guard that the per-field helpers are wired correctly into NewInstanceType.
+// It covers the #398 fix (SystemReserved verbatim, KubeReserved merged with
+// the #220 ephemeral-storage survival, PodsPerCore caps Capacity[pods]) and
+// the nil-kc baseline in a single table.
+func TestNewInstanceType_RespectsKubeletConfiguration(t *testing.T) {
+	ctx := options.ToContext(context.Background(), &options.Options{VMMemoryOverheadPercent: 0.07})
+	mt := &computepb.MachineType{
+		Name:      lo.ToPtr("n2-standard-4"),
+		GuestCpus: lo.ToPtr[int32](4),
+		MemoryMb:  lo.ToPtr[int32](16384),
+	}
+	tests := []struct {
+		name   string
+		kc     *v1alpha1.KubeletConfiguration
+		assert func(t *testing.T, it *cloudprovider.InstanceType)
+	}{
+		{
+			name: "nil kc → SystemReserved empty, KubeReserved computed, default max pods",
+			kc:   nil,
+			assert: func(t *testing.T, it *cloudprovider.InstanceType) {
+				assert.Empty(t, it.Overhead.SystemReserved)
+				assert.Greater(t, it.Overhead.KubeReserved.Cpu().MilliValue(), int64(0))
+				assert.Greater(t, it.Overhead.KubeReserved.Memory().Value(), int64(0))
+				pods := it.Capacity[corev1.ResourcePods]
+				assert.Equal(t, int64(v1alpha1.KubeletMaxPods), pods.Value())
+			},
+		},
+		{
+			// #398 + #220 integration guard: SystemReserved verbatim;
+			// KubeReserved.cpu user-overridden; KubeReserved.memory and
+			// .ephemeral-storage survive from provider-computed defaults.
+			name: "user reservations honored with computed sub-keys surviving (#398, #220)",
+			kc: &v1alpha1.KubeletConfiguration{
+				SystemReserved: map[string]string{"cpu": "1", "memory": "1Gi"},
+				KubeReserved:   map[string]string{"cpu": "500m"},
+			},
+			assert: func(t *testing.T, it *cloudprovider.InstanceType) {
+				assert.Equal(t, "1", it.Overhead.SystemReserved.Cpu().String())
+				assert.Equal(t, "1Gi", it.Overhead.SystemReserved.Memory().String())
+				assert.Equal(t, "500m", it.Overhead.KubeReserved.Cpu().String())
+				assert.Greater(t, it.Overhead.KubeReserved.Memory().Value(), int64(0))
+				assert.Greater(t, it.Overhead.KubeReserved.StorageEphemeral().Value(), int64(0))
+			},
+		},
+		{
+			name: "PodsPerCore caps Capacity[pods]",
+			kc:   &v1alpha1.KubeletConfiguration{PodsPerCore: lo.ToPtr[int32](8)},
+			assert: func(t *testing.T, it *cloudprovider.InstanceType) {
+				pods := it.Capacity[corev1.ResourcePods]
+				assert.Equal(t, int64(32), pods.Value(), "8 podsPerCore × 4 cpus")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeClass := &v1alpha1.GCENodeClass{Spec: v1alpha1.GCENodeClassSpec{KubeletConfiguration: tt.kc}}
+			it := NewInstanceType(ctx, mt, nodeClass, "us-central1", testOfferings())
+			assert.NotNil(t, it)
+			tt.assert(t, it)
+		})
+	}
+}
+
+// quantityListsEqual compares two ResourceLists by Quantity.Cmp so 1Gi vs
+// 1024Mi compare equal regardless of Format.
+func quantityListsEqual(a, b corev1.ResourceList) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok || av.Cmp(bv) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func testOfferings() cloudprovider.Offerings {
+	return cloudprovider.Offerings{
+		{
+			Available: true,
+			Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-central1-a"),
+				scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, karpv1.CapacityTypeOnDemand),
+			),
+		},
+	}
+}

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -67,17 +67,24 @@ func NewInstanceType(ctx context.Context, mt *computepb.MachineType, nodeClass *
 		"ephemeralEviction", ephemeralEviction,
 		"ephemeralSystem", ephemeralSystem)
 
+	kc := nodeClass.Spec.KubeletConfiguration
+
+	computedKubeReserved := corev1.ResourceList{
+		corev1.ResourceCPU:              *resource.NewMilliQuantity(reservedCPU, resource.DecimalSI),
+		corev1.ResourceMemory:           *resource.NewQuantity(reservedMemory*1024*1024, resource.BinarySI),
+		corev1.ResourceEphemeralStorage: *resource.NewQuantity(ephemeralSystem*1024*1024*1024, resource.BinarySI),
+	}
+	computedEviction := corev1.ResourceList{
+		corev1.ResourceMemory:           *resource.NewQuantity(evictionMemory*1024*1024, resource.BinarySI),
+		corev1.ResourceEphemeralStorage: *resource.NewQuantity(ephemeralEviction*1024*1024*1024, resource.BinarySI),
+	}
+	memoryQuantity := memory(ctx, mt)
+	storageQuantity := resource.NewQuantity(totalStorageBytes, resource.BinarySI)
+
 	overhead := cloudprovider.InstanceTypeOverhead{
-		KubeReserved: corev1.ResourceList{
-			corev1.ResourceCPU:              *resource.NewMilliQuantity(reservedCPU, resource.DecimalSI),
-			corev1.ResourceMemory:           *resource.NewQuantity(reservedMemory*1024*1024, resource.BinarySI),
-			corev1.ResourceEphemeralStorage: *resource.NewQuantity(ephemeralSystem*1024*1024*1024, resource.BinarySI),
-		},
-		EvictionThreshold: corev1.ResourceList{
-			corev1.ResourceMemory:           *resource.NewQuantity(evictionMemory*1024*1024, resource.BinarySI),
-			corev1.ResourceEphemeralStorage: *resource.NewQuantity(ephemeralEviction*1024*1024*1024, resource.BinarySI),
-		},
-		SystemReserved: corev1.ResourceList{},
+		KubeReserved:      mergeKubeReserved(computedKubeReserved, kc),
+		SystemReserved:    kcSystemReserved(kc),
+		EvictionThreshold: evictionThreshold(memoryQuantity, storageQuantity, computedEviction, kc),
 	}
 
 	it := &cloudprovider.InstanceType{
@@ -201,10 +208,11 @@ func machineTypeArch(mt *computepb.MachineType) string {
 }
 
 func computeCapacity(ctx context.Context, mt *computepb.MachineType, nodeClass *v1alpha1.GCENodeClass, totalStorageBytes int64) corev1.ResourceList {
+	maxPods := kcMaxPods(nodeClass.GetMaxPods(), nodeClass.Spec.KubeletConfiguration, int64(mt.GetGuestCpus()))
 	resourceList := corev1.ResourceList{
 		corev1.ResourceCPU:              *cpu(mt),
 		corev1.ResourceMemory:           *memory(ctx, mt),
-		corev1.ResourcePods:             *resource.NewQuantity(int64(nodeClass.GetMaxPods()), resource.DecimalSI),
+		corev1.ResourcePods:             *resource.NewQuantity(maxPods, resource.DecimalSI),
 		corev1.ResourceEphemeralStorage: *resource.NewQuantity(totalStorageBytes, resource.BinarySI),
 		v1alpha1.ResourceNVIDIAGPU:      *resource.NewQuantity(int64(len(mt.GetAccelerators())), resource.DecimalSI),
 	}

--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metadata
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -61,7 +62,7 @@ func GetClusterName(metadata *compute.Metadata) (string, error) {
 	return clusterName, nil
 }
 
-func RenderKubeletConfigMetadata(metaData *compute.Metadata, instanceType *cloudprovider.InstanceType, capacityType string) error {
+func RenderKubeletConfigMetadata(metaData *compute.Metadata, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, capacityType string) error {
 	targetEntry, index, ok := lo.FindIndexOf(metaData.Items, func(item *compute.MetadataItems) bool {
 		return item.Key == KubeletConfigLabel
 	})
@@ -83,7 +84,9 @@ func RenderKubeletConfigMetadata(metaData *compute.Metadata, instanceType *cloud
 		return fmt.Errorf("failed to parse kubelet-config YAML: %w", err)
 	}
 
-	// Update kubeReserved
+	// Update kubeReserved with provider-computed defaults first; user values
+	// in spec.kubeletConfiguration.kubeReserved overlay these per-sub-key
+	// below via mergeUserKubeletConfig.
 	kubeReserved, ok := config["kubeReserved"].(map[string]interface{})
 	if !ok {
 		kubeReserved = make(map[string]interface{})
@@ -93,6 +96,17 @@ func RenderKubeletConfigMetadata(metaData *compute.Metadata, instanceType *cloud
 	kubeReserved["ephemeral-storage"] = ephemeralStorage
 	config["kubeReserved"] = kubeReserved
 
+	// Merge user-supplied KubeletConfiguration on top of the provider defaults.
+	// Map fields (kubeReserved, systemReserved, eviction*) merge one level
+	// deep so user sub-keys win but computed sub-keys for unset keys survive
+	// (e.g. computed kubeReserved.ephemeral-storage from boot disk size).
+	if err := mergeUserKubeletConfig(config, nodeClass.Spec.KubeletConfiguration); err != nil {
+		return fmt.Errorf("failed to merge user KubeletConfiguration: %w", err)
+	}
+
+	// Spot-specific overrides are applied AFTER the user merge: graceful
+	// node shutdown is required for Spot preemption handling and must not
+	// be overridable from the nodeclass.
 	if capacityType == karpv1.CapacityTypeSpot {
 		featureGates, ok := config["featureGates"].(map[string]interface{})
 		if !ok {
@@ -113,6 +127,36 @@ func RenderKubeletConfigMetadata(metaData *compute.Metadata, instanceType *cloud
 	targetEntry.Value = lo.ToPtr(string(updatedYAML))
 	metaData.Items[index] = targetEntry
 
+	return nil
+}
+
+// mergeUserKubeletConfig overlays user KubeletConfiguration onto config.
+// Scalar/slice keys replace verbatim; map keys merge one level deep so
+// provider-computed sub-keys (e.g. kubeReserved.ephemeral-storage from #220)
+// survive a partial user override.
+func mergeUserKubeletConfig(config map[string]interface{}, kc *v1alpha1.KubeletConfiguration) error {
+	if kc == nil {
+		return nil
+	}
+	raw, err := json.Marshal(kc)
+	if err != nil {
+		return fmt.Errorf("marshal KubeletConfiguration: %w", err)
+	}
+	userMap := map[string]interface{}{}
+	if err := json.Unmarshal(raw, &userMap); err != nil {
+		return fmt.Errorf("unmarshal KubeletConfiguration: %w", err)
+	}
+	for k, v := range userMap {
+		if userSub, ok := v.(map[string]interface{}); ok {
+			if existingSub, ok := config[k].(map[string]interface{}); ok {
+				for sk, sv := range userSub {
+					existingSub[sk] = sv
+				}
+				continue
+			}
+		}
+		config[k] = v
+	}
 	return nil
 }
 

--- a/pkg/providers/metadata/utils_kubelet_config_test.go
+++ b/pkg/providers/metadata/utils_kubelet_config_test.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2025 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metadata
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/compute/v1"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
+)
+
+// kubeletConfigMeta returns a *compute.Metadata whose only entry is a
+// kubelet-config item with the given YAML body. Mirrors a real GKE bootstrap
+// template's kubelet-config metadata key.
+func kubeletConfigMeta(initial string) *compute.Metadata {
+	return &compute.Metadata{
+		Items: []*compute.MetadataItems{
+			{Key: KubeletConfigLabel, Value: lo.ToPtr(initial)},
+		},
+	}
+}
+
+// instanceTypeWithKubeReserved returns a minimal *cloudprovider.InstanceType
+// whose Overhead.KubeReserved holds the given cpu (milli), memory (Mi),
+// and ephemeral-storage values. RenderKubeletConfigMetadata reads only these
+// fields off the instance type.
+func instanceTypeWithKubeReserved(cpuMilli, memMiB int64, ephemeralStorage string) *cloudprovider.InstanceType {
+	return &cloudprovider.InstanceType{
+		Name: "test",
+		Overhead: &cloudprovider.InstanceTypeOverhead{
+			KubeReserved: corev1.ResourceList{
+				corev1.ResourceCPU:              *resource.NewMilliQuantity(cpuMilli, resource.DecimalSI),
+				corev1.ResourceMemory:           *resource.NewQuantity(memMiB*1024*1024, resource.BinarySI),
+				corev1.ResourceEphemeralStorage: resource.MustParse(ephemeralStorage),
+			},
+		},
+	}
+}
+
+// renderedKubeletConfig invokes RenderKubeletConfigMetadata on a fresh
+// baseKubeletConfigYAML and parses the resulting kubelet-config YAML back
+// into a map so tests can assert on specific keys.
+func renderedKubeletConfig(t *testing.T, nodeClass *v1alpha1.GCENodeClass, it *cloudprovider.InstanceType, capacityType string) map[string]interface{} {
+	t.Helper()
+	meta := kubeletConfigMeta(baseKubeletConfigYAML)
+	require.NoError(t, RenderKubeletConfigMetadata(meta, nodeClass, it, capacityType))
+	var got map[string]interface{}
+	require.NoError(t, yaml.Unmarshal([]byte(lo.FromPtr(meta.Items[0].Value)), &got))
+	return got
+}
+
+func nodeClassWith(kc *v1alpha1.KubeletConfiguration) *v1alpha1.GCENodeClass {
+	return &v1alpha1.GCENodeClass{
+		Spec: v1alpha1.GCENodeClassSpec{KubeletConfiguration: kc},
+	}
+}
+
+const baseKubeletConfigYAML = "apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\n"
+
+func TestMergeUserKubeletConfig_NilLeavesConfigUntouched(t *testing.T) {
+	config := map[string]interface{}{
+		"kubeReserved": map[string]interface{}{
+			"cpu":               "80m",
+			"memory":            "100Mi",
+			"ephemeral-storage": "15Gi",
+		},
+	}
+	require.NoError(t, mergeUserKubeletConfig(config, nil))
+	require.Equal(t, map[string]interface{}{
+		"cpu":               "80m",
+		"memory":            "100Mi",
+		"ephemeral-storage": "15Gi",
+	}, config["kubeReserved"])
+}
+
+func TestMergeUserKubeletConfig_EmptyStructLeavesConfigUntouched(t *testing.T) {
+	config := map[string]interface{}{"kubeReserved": map[string]interface{}{"cpu": "80m"}}
+	require.NoError(t, mergeUserKubeletConfig(config, &v1alpha1.KubeletConfiguration{}))
+	require.Equal(t, map[string]interface{}{"cpu": "80m"}, config["kubeReserved"])
+}
+
+func TestMergeUserKubeletConfig_DeepMergesKubeReserved(t *testing.T) {
+	// Provider-computed defaults already in config.
+	config := map[string]interface{}{
+		"kubeReserved": map[string]interface{}{
+			"cpu":               "80m",
+			"memory":            "100Mi",
+			"ephemeral-storage": "15Gi",
+		},
+	}
+	// User only sets cpu — memory and ephemeral-storage must survive.
+	kc := &v1alpha1.KubeletConfiguration{
+		KubeReserved: map[string]string{"cpu": "500m"},
+	}
+	require.NoError(t, mergeUserKubeletConfig(config, kc))
+	got, ok := config["kubeReserved"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "500m", got["cpu"], "user cpu wins")
+	require.Equal(t, "100Mi", got["memory"], "computed memory survives")
+	require.Equal(t, "15Gi", got["ephemeral-storage"], "computed ephemeral-storage survives (issue #220 regression guard)")
+}
+
+func TestRenderKubeletConfigMetadata_NilKubeletConfiguration(t *testing.T) {
+	got := renderedKubeletConfig(
+		t,
+		nodeClassWith(nil),
+		instanceTypeWithKubeReserved(80, 100, "15Gi"),
+		karpv1.CapacityTypeOnDemand,
+	)
+	// Only the provider-computed kubeReserved should appear; nothing else from a user struct.
+	require.Equal(t, map[string]interface{}{
+		"cpu":               "80m",
+		"memory":            "100Mi",
+		"ephemeral-storage": "15Gi",
+	}, got["kubeReserved"])
+	require.NotContains(t, got, "systemReserved")
+	require.NotContains(t, got, "evictionHard")
+}
+
+func TestRenderKubeletConfigMetadata_EmptyKubeletConfiguration(t *testing.T) {
+	got := renderedKubeletConfig(
+		t,
+		nodeClassWith(&v1alpha1.KubeletConfiguration{}),
+		instanceTypeWithKubeReserved(80, 100, "15Gi"),
+		karpv1.CapacityTypeOnDemand,
+	)
+	require.Equal(t, map[string]interface{}{
+		"cpu":               "80m",
+		"memory":            "100Mi",
+		"ephemeral-storage": "15Gi",
+	}, got["kubeReserved"])
+}
+
+func TestRenderKubeletConfigMetadata_SystemReserved(t *testing.T) {
+	got := renderedKubeletConfig(
+		t,
+		nodeClassWith(&v1alpha1.KubeletConfiguration{
+			SystemReserved: map[string]string{"cpu": "1", "memory": "1Gi"},
+		}),
+		instanceTypeWithKubeReserved(80, 100, "15Gi"),
+		karpv1.CapacityTypeOnDemand,
+	)
+	require.Equal(t, map[string]interface{}{"cpu": "1", "memory": "1Gi"}, got["systemReserved"])
+}
+
+func TestRenderKubeletConfigMetadata_KubeReservedUserWinsAndComputedSurvives(t *testing.T) {
+	got := renderedKubeletConfig(
+		t,
+		nodeClassWith(&v1alpha1.KubeletConfiguration{
+			KubeReserved: map[string]string{"cpu": "500m"},
+		}),
+		instanceTypeWithKubeReserved(80, 100, "15Gi"),
+		karpv1.CapacityTypeOnDemand,
+	)
+	kr, ok := got["kubeReserved"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, "500m", kr["cpu"], "user cpu must win")
+	require.Equal(t, "100Mi", kr["memory"], "computed memory must survive")
+	require.Equal(t, "15Gi", kr["ephemeral-storage"], "computed ephemeral-storage must survive (issue #220 regression)")
+}
+
+func TestRenderKubeletConfigMetadata_KubeReservedSmallBootDiskIssue220Regression(t *testing.T) {
+	// Simulate the issue #220 scenario: a small boot disk yields a small
+	// computed ephemeral-storage reservation (e.g. 7Gi for a 30 GiB disk).
+	// User sets cpu only. The small computed ephemeral-storage value must
+	// survive — not be replaced by a larger default — otherwise
+	// reservation > capacity and kubelet refuses to start.
+	got := renderedKubeletConfig(
+		t,
+		nodeClassWith(&v1alpha1.KubeletConfiguration{
+			KubeReserved: map[string]string{"cpu": "200m"},
+		}),
+		instanceTypeWithKubeReserved(60, 80, "7Gi"), // small disk → 7Gi computed reservation
+		karpv1.CapacityTypeOnDemand,
+	)
+	kr := got["kubeReserved"].(map[string]interface{})
+	require.Equal(t, "7Gi", kr["ephemeral-storage"], "computed small ephemeral-storage must survive user merge")
+	require.Equal(t, "200m", kr["cpu"])
+}
+
+func TestRenderKubeletConfigMetadata_EvictionHard(t *testing.T) {
+	got := renderedKubeletConfig(
+		t,
+		nodeClassWith(&v1alpha1.KubeletConfiguration{
+			EvictionHard: map[string]string{"memory.available": "5%"},
+		}),
+		instanceTypeWithKubeReserved(80, 100, "15Gi"),
+		karpv1.CapacityTypeOnDemand,
+	)
+	require.Equal(t, map[string]interface{}{"memory.available": "5%"}, got["evictionHard"])
+}
+
+func TestRenderKubeletConfigMetadata_EvictionSoftGracePeriodDuration(t *testing.T) {
+	// metav1.Duration.MarshalJSON renders as "30s" — verifies the
+	// JSON-marshal round-trip handles Duration cleanly.
+	got := renderedKubeletConfig(
+		t,
+		nodeClassWith(&v1alpha1.KubeletConfiguration{
+			EvictionSoftGracePeriod: map[string]metav1.Duration{
+				"memory.available": {Duration: 30 * time.Second},
+			},
+		}),
+		instanceTypeWithKubeReserved(80, 100, "15Gi"),
+		karpv1.CapacityTypeOnDemand,
+	)
+	require.Equal(t, map[string]interface{}{"memory.available": "30s"}, got["evictionSoftGracePeriod"])
+}
+
+func TestRenderKubeletConfigMetadata_CPUCFSQuotaFalse(t *testing.T) {
+	got := renderedKubeletConfig(
+		t,
+		nodeClassWith(&v1alpha1.KubeletConfiguration{
+			CPUCFSQuota: lo.ToPtr(false),
+		}),
+		instanceTypeWithKubeReserved(80, 100, "15Gi"),
+		karpv1.CapacityTypeOnDemand,
+	)
+	v, ok := got["cpuCFSQuota"]
+	require.True(t, ok, "cpuCFSQuota=false must appear in rendered YAML")
+	require.Equal(t, false, v)
+}
+
+func TestRenderKubeletConfigMetadata_ClusterDNS(t *testing.T) {
+	got := renderedKubeletConfig(
+		t,
+		nodeClassWith(&v1alpha1.KubeletConfiguration{
+			ClusterDNS: []string{"10.0.1.100"},
+		}),
+		instanceTypeWithKubeReserved(80, 100, "15Gi"),
+		karpv1.CapacityTypeOnDemand,
+	)
+	v, ok := got["clusterDNS"].([]interface{})
+	require.True(t, ok)
+	require.Equal(t, []interface{}{"10.0.1.100"}, v)
+}
+
+func TestRenderKubeletConfigMetadata_ImageGCThresholds(t *testing.T) {
+	got := renderedKubeletConfig(
+		t,
+		nodeClassWith(&v1alpha1.KubeletConfiguration{
+			ImageGCHighThresholdPercent: lo.ToPtr(int32(85)),
+			ImageGCLowThresholdPercent:  lo.ToPtr(int32(80)),
+		}),
+		instanceTypeWithKubeReserved(80, 100, "15Gi"),
+		karpv1.CapacityTypeOnDemand,
+	)
+	// yaml.v3 unmarshals untyped numbers as int.
+	require.EqualValues(t, 85, got["imageGCHighThresholdPercent"])
+	require.EqualValues(t, 80, got["imageGCLowThresholdPercent"])
+}
+
+func TestRenderKubeletConfigMetadata_SpotAppliesAfterUserMerge(t *testing.T) {
+	// Spot-specific kubelet keys (GracefulNodeShutdown feature gate and
+	// the two shutdown grace periods) are applied AFTER the user merge,
+	// so Spot preemption handling remains correct even when the user has
+	// supplied an unrelated KubeletConfiguration. Forward-compatibility
+	// guard: if any of those keys are ever added to v1alpha1.KubeletConfiguration,
+	// the provider override still wins.
+	got := renderedKubeletConfig(
+		t,
+		nodeClassWith(&v1alpha1.KubeletConfiguration{
+			SystemReserved: map[string]string{"cpu": "1"},
+		}),
+		instanceTypeWithKubeReserved(80, 100, "15Gi"),
+		karpv1.CapacityTypeSpot,
+	)
+	require.Equal(t, "30s", got["shutdownGracePeriod"])
+	require.Equal(t, "15s", got["shutdownGracePeriodCriticalPods"])
+	fg, ok := got["featureGates"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, true, fg["GracefulNodeShutdown"])
+	// And the user value still landed (merge happened before Spot override).
+	require.Equal(t, map[string]interface{}{"cpu": "1"}, got["systemReserved"])
+}

--- a/test/pkg/environment/helpers.go
+++ b/test/pkg/environment/helpers.go
@@ -121,6 +121,42 @@ func (e *Environment) CreateNodeClass(ctx context.Context, name, imageFamily str
 	e.trackNodeClass(name)
 }
 
+// CreateNodeClassWithKubeletConfig creates a GCENodeClass identical to
+// CreateNodeClass but with the given spec.kubeletConfiguration attached.
+// kubeletConfig is a map[string]any whose keys must match the JSON field
+// names on v1alpha1.KubeletConfiguration (systemReserved, kubeReserved,
+// evictionHard, podsPerCore, etc.). Used by e2e tests verifying issue
+// #398 (kubelet honors user reservations).
+func (e *Environment) CreateNodeClassWithKubeletConfig(
+	ctx context.Context,
+	name, imageFamily string,
+	kubeletConfig map[string]any,
+) {
+	diskGiB := int64(DefaultE2EDiskGiB)
+	if imageFamily == gcpv1alpha1.ImageFamilyUbuntu {
+		diskGiB = 50
+	}
+	deleteIfExists(ctx, e.DynamicClient, gceNodeClassGVR, name)
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "karpenter.k8s.gcp/v1alpha1",
+		"kind":       "GCENodeClass",
+		"metadata":   map[string]any{"name": name},
+		"spec": map[string]any{
+			"imageSelectorTerms": []any{
+				map[string]any{"alias": imageFamily + "@latest"},
+			},
+			"disks": []any{
+				map[string]any{"category": "pd-balanced", "sizeGiB": diskGiB, "boot": true},
+			},
+			"subnetRangeName":      e.PodsRangeName,
+			"kubeletConfiguration": kubeletConfig,
+		},
+	}}
+	_, err := e.DynamicClient.Resource(gceNodeClassGVR).Create(ctx, obj, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "creating GCENodeClass %s", name)
+	e.trackNodeClass(name)
+}
+
 // CreateNodeClassWithFamilyChannel creates a GCENodeClass using the new
 // family+channel image selector (e.g. family=ContainerOptimizedOS, channel=stable).
 func (e *Environment) CreateNodeClassWithFamilyChannel(ctx context.Context, name, family, channel string) {
@@ -433,6 +469,30 @@ func (e *Environment) CreateDeployment(ctx context.Context, name, appLabel, node
 
 	_, err := e.KubeClient.AppsV1().Deployments(TestNamespace).Create(ctx, dep, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "creating Deployment %s", name)
+}
+
+// WaitForRunningPodsOnNode polls until at least `n` pods with the given app
+// label are Running and Ready on the given node. Fails the test if
+// ProvisioningTimeout is exceeded. Used to verify the node can actually
+// schedule the configured number of pods (issue #120 guard: maxPods must
+// not exceed the node's pod-CIDR-derived IP capacity).
+func (e *Environment) WaitForRunningPodsOnNode(ctx context.Context, appLabel, nodeName string, n int) {
+	Eventually(func(g Gomega) {
+		pods, err := e.KubeClient.CoreV1().Pods(TestNamespace).List(ctx,
+			metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", appLabel)})
+		g.Expect(err).NotTo(HaveOccurred())
+		running := 0
+		for i := range pods.Items {
+			if pods.Items[i].Spec.NodeName == nodeName && isRunningAndReady(&pods.Items[i]) {
+				running++
+			}
+		}
+		if running < n {
+			e.logWaitStatus(ctx, appLabel, pods.Items)
+		}
+		g.Expect(running).To(BeNumerically(">=", n),
+			"only %d/%d pods with label app=%s are Running on node %s", running, n, appLabel, nodeName)
+	}).WithTimeout(ProvisioningTimeout).WithPolling(DefaultPollInterval).Should(Succeed())
 }
 
 // WaitForRunningPod polls until a pod with the given app label is Running and

--- a/test/suites/kubelet_config/kubelet_config_test.go
+++ b/test/suites/kubelet_config/kubelet_config_test.go
@@ -1,0 +1,281 @@
+/*
+Copyright 2026 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet_config_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	gcpv1alpha1 "github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/test/pkg/environment"
+)
+
+// kubeletConfigCase describes one e2e scenario: provision a node with
+// kubeletConfig attached to the GCENodeClass, then assert against the
+// resulting node's status. Mirrors environment.TestCase fields for the
+// provisioning side; assertions live in assert. postProvision (optional)
+// runs after the first pod is Running and before assert — used by the
+// maxPods density case to scale the deployment up.
+type kubeletConfigCase struct {
+	tc            environment.TestCase
+	kubeletConfig map[string]any
+	postProvision func(ctx context.Context, deploymentName, nodeName string)
+	assert        func(node *corev1.Node)
+}
+
+var _ = DescribeTable("kubeletConfiguration honored on provisioned nodes (#398)",
+	func(ctx SpecContext, c kubeletConfigCase) {
+		runKubeletConfigTest(ctx, c)
+	},
+
+	// systemReserved reduces allocatable: the literal assertion from
+	// issue #398. n2-standard-4 has 4 vCPU / 16 GiB. With systemReserved
+	// cpu=1 / memory=1Gi, the kubelet must report allocatable < capacity
+	// by at least those amounts.
+	Entry("COS: systemReserved reduces allocatable", kubeletConfigCase{
+		tc: environment.TestCase{
+			CapacityType:  karpv1.CapacityTypeOnDemand,
+			Arch:          karpv1.ArchitectureAmd64,
+			Families:      []string{"n2"},
+			InstanceTypes: []string{"n2-standard-4"},
+			ImageFamily:   gcpv1alpha1.ImageFamilyContainerOptimizedOS,
+		},
+		kubeletConfig: map[string]any{
+			"systemReserved": map[string]any{
+				"cpu":    "1",
+				"memory": "1Gi",
+			},
+		},
+		assert: assertSystemReservedReducesAllocatable,
+	}, SpecTimeout(15*time.Minute)),
+
+	Entry("Ubuntu: systemReserved reduces allocatable", kubeletConfigCase{
+		tc: environment.TestCase{
+			CapacityType:  karpv1.CapacityTypeOnDemand,
+			Arch:          karpv1.ArchitectureAmd64,
+			Families:      []string{"n2"},
+			InstanceTypes: []string{"n2-standard-4"},
+			ImageFamily:   gcpv1alpha1.ImageFamilyUbuntu,
+		},
+		kubeletConfig: map[string]any{
+			"systemReserved": map[string]any{
+				"cpu":    "1",
+				"memory": "1Gi",
+			},
+		},
+		assert: assertSystemReservedReducesAllocatable,
+	}, SpecTimeout(15*time.Minute)),
+
+	// Partial kubeReserved override: issue #220 regression guard at the
+	// integration level. The user sets only cpu; the kubelet must still
+	// receive memory and ephemeral-storage from provider-computed
+	// defaults so the node comes up Ready.
+	Entry("COS: partial kubeReserved override keeps node Ready (#220)", kubeletConfigCase{
+		tc: environment.TestCase{
+			CapacityType:  karpv1.CapacityTypeOnDemand,
+			Arch:          karpv1.ArchitectureAmd64,
+			Families:      []string{"n2"},
+			InstanceTypes: []string{"n2-standard-4"},
+			ImageFamily:   gcpv1alpha1.ImageFamilyContainerOptimizedOS,
+		},
+		kubeletConfig: map[string]any{
+			"kubeReserved": map[string]any{
+				"cpu": "500m",
+			},
+		},
+		assert: assertKubeReservedCPUOverride,
+	}, SpecTimeout(15*time.Minute)),
+
+	// podsPerCore caps capacity[pods]. n2-standard-4 = 4 vCPU; with
+	// podsPerCore=8 expect exactly 32.
+	Entry("COS: podsPerCore caps capacity[pods]", kubeletConfigCase{
+		tc: environment.TestCase{
+			CapacityType:  karpv1.CapacityTypeOnDemand,
+			Arch:          karpv1.ArchitectureAmd64,
+			Families:      []string{"n2"},
+			InstanceTypes: []string{"n2-standard-4"},
+			ImageFamily:   gcpv1alpha1.ImageFamilyContainerOptimizedOS,
+		},
+		kubeletConfig: map[string]any{
+			"podsPerCore": int64(8),
+		},
+		assert: assertPodsPerCoreCapsCapacity(32),
+	}, SpecTimeout(15*time.Minute)),
+
+	// maxPods is reflected in capacity (scheduler / kubelet agreement,
+	// issue #133) AND the node can actually run that many pods without IP
+	// exhaustion (issue #120 — pod-CIDR must be sized to maxPods).
+	// maxPods=50 is comfortably above the GKE default of 110 / 32 on
+	// small node pools? Actually GKE default is 110; we pick 50 to make
+	// the density check fit on a single n2-standard-4 (4 vCPU) while
+	// still being a value clearly distinct from any default. The density
+	// check scales the deployment to 40 pods, leaving slack for system
+	// pods.
+	Entry("COS: maxPods reflected in capacity and IPs sized accordingly (#133, #120)", kubeletConfigCase{
+		tc: environment.TestCase{
+			CapacityType:  karpv1.CapacityTypeOnDemand,
+			Arch:          karpv1.ArchitectureAmd64,
+			Families:      []string{"n2"},
+			InstanceTypes: []string{"n2-standard-4"},
+			ImageFamily:   gcpv1alpha1.ImageFamilyContainerOptimizedOS,
+		},
+		kubeletConfig: map[string]any{
+			"maxPods": int64(50),
+		},
+		postProvision: func(ctx context.Context, deploymentName, nodeName string) {
+			env.ScaleDeployment(ctx, deploymentName, 40)
+			env.WaitForRunningPodsOnNode(ctx, deploymentName, nodeName, 40)
+		},
+		assert: assertMaxPodsCapacity(50),
+	}, SpecTimeout(20*time.Minute)),
+)
+
+// runKubeletConfigTest provisions a node with the given kubeletConfig and
+// invokes c.assert against the resulting Node. Mirrors
+// provisioning_test.runProvisioningTest but uses
+// CreateNodeClassWithKubeletConfig.
+func runKubeletConfigTest(ctx context.Context, c kubeletConfigCase) {
+	prefix := environment.TestPrefix(c.tc.Arch, c.tc.CapacityType, osSlug(c.tc.ImageFamily), "kubeletconfig")
+	suffix := environment.UniqueSuffix()
+	name := prefix + "-" + suffix
+
+	GinkgoWriter.Printf("[setup] arch=%s capacityType=%s os=%s nodePool=%s kubeletConfig=%v\n",
+		c.tc.Arch, c.tc.CapacityType, c.tc.ImageFamily, name, c.kubeletConfig)
+
+	initialNodes := env.AllNodeNames(ctx)
+
+	var provisionedNodeName string
+	DeferCleanup(func(ctx context.Context) {
+		env.DeleteDeployment(ctx, name)
+		env.DeleteNodePool(ctx, name)
+		env.DeleteNodeClass(ctx, name)
+		if provisionedNodeName != "" {
+			Expect(env.WaitForNodeRemoval(ctx, provisionedNodeName)).To(Succeed())
+		}
+	})
+
+	imageFamily := c.tc.ImageFamily
+	if imageFamily == "" {
+		imageFamily = gcpv1alpha1.ImageFamilyContainerOptimizedOS
+	}
+	env.CreateNodeClassWithKubeletConfig(ctx, name, imageFamily, c.kubeletConfig)
+	env.WaitForNodeClassReady(ctx, name)
+	env.CreateNodePool(ctx, name, name, c.tc)
+	env.WaitForNodePoolReady(ctx, name)
+	env.CreateDeployment(ctx, name, name, name, c.tc.Arch)
+
+	env.WaitForNodeClaimLaunched(ctx, name)
+	pod := env.WaitForRunningPod(ctx, name)
+	Expect(pod.Spec.NodeName).NotTo(BeEmpty())
+
+	node, err := env.KubeClient.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	provisionedNodeName = node.Name
+
+	_, existedBefore := initialNodes[node.Name]
+	Expect(existedBefore).To(BeFalse(), "expected a newly provisioned node, got a pre-existing one")
+	Expect(environment.IsNodeReady(node)).To(BeTrue(), "node %s is not Ready", node.Name)
+	Expect(c.tc.InstanceTypes).To(ContainElement(node.Labels[corev1.LabelInstanceTypeStable]))
+
+	if c.postProvision != nil {
+		c.postProvision(ctx, name, node.Name)
+		// Re-fetch the node so assertions see post-scale status (e.g.
+		// capacity pinned by the kubelet's startup config is stable, but
+		// any allocatable changes show up after pods land).
+		node, err = env.KubeClient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	c.assert(node)
+}
+
+// assertSystemReservedReducesAllocatable verifies that the user-configured
+// systemReserved (cpu=1, memory=1Gi) is reflected in node.status.allocatable.
+// Memory is asserted leniently: allocatable.memory < capacity.memory - 1Gi,
+// because eviction and provider-computed kubeReserved also reduce
+// allocatable. CPU is asserted strictly: allocatable.cpu ≤ capacity.cpu - 1.
+func assertSystemReservedReducesAllocatable(node *corev1.Node) {
+	capCPU := node.Status.Capacity[corev1.ResourceCPU]
+	allocCPU := node.Status.Allocatable[corev1.ResourceCPU]
+	oneCPU := resource.MustParse("1")
+	// expected upper bound on allocatable: capacity - 1 CPU
+	capMinusOne := capCPU.DeepCopy()
+	capMinusOne.Sub(oneCPU)
+	Expect(allocCPU.Cmp(capMinusOne) <= 0).To(BeTrue(),
+		"allocatable cpu %s must be <= capacity %s - 1 CPU (= %s) when systemReserved.cpu=1",
+		allocCPU.String(), capCPU.String(), capMinusOne.String())
+
+	capMem := node.Status.Capacity[corev1.ResourceMemory]
+	allocMem := node.Status.Allocatable[corev1.ResourceMemory]
+	oneGi := resource.MustParse("1Gi")
+	capMinusOneGi := capMem.DeepCopy()
+	capMinusOneGi.Sub(oneGi)
+	Expect(allocMem.Cmp(capMinusOneGi) < 0).To(BeTrue(),
+		"allocatable memory %s must be strictly less than capacity %s - 1Gi (= %s) when systemReserved.memory=1Gi",
+		allocMem.String(), capMem.String(), capMinusOneGi.String())
+}
+
+// assertKubeReservedCPUOverride verifies that a partial kubeReserved (only
+// cpu=500m set by the user) keeps the node healthy and reduces allocatable
+// cpu by at least 500m. The "node is Ready" check inside runKubeletConfigTest
+// is the #220 integration regression guard — proves the kubelet did not
+// receive a partial kubeReserved that crashed startup.
+func assertKubeReservedCPUOverride(node *corev1.Node) {
+	capCPU := node.Status.Capacity[corev1.ResourceCPU]
+	allocCPU := node.Status.Allocatable[corev1.ResourceCPU]
+	halfCPU := resource.MustParse("500m")
+	capMinusHalf := capCPU.DeepCopy()
+	capMinusHalf.Sub(halfCPU)
+	Expect(allocCPU.Cmp(capMinusHalf) <= 0).To(BeTrue(),
+		"allocatable cpu %s must be <= capacity %s - 500m (= %s) when kubeReserved.cpu=500m",
+		allocCPU.String(), capCPU.String(), capMinusHalf.String())
+}
+
+// assertPodsPerCoreCapsCapacity returns an assertion that
+// node.status.capacity[pods] equals the given count.
+func assertPodsPerCoreCapsCapacity(want int64) func(*corev1.Node) {
+	return func(node *corev1.Node) {
+		pods := node.Status.Capacity[corev1.ResourcePods]
+		Expect(pods.Value()).To(Equal(want),
+			"capacity.pods %s must equal podsPerCore × cpus", pods.String())
+	}
+}
+
+// assertMaxPodsCapacity returns an assertion that node.status.capacity[pods]
+// equals the user-configured maxPods. Pinning the value is the #133 regression
+// guard against kubelet / scheduler disagreement.
+func assertMaxPodsCapacity(want int64) func(*corev1.Node) {
+	return func(node *corev1.Node) {
+		pods := node.Status.Capacity[corev1.ResourcePods]
+		Expect(pods.Value()).To(Equal(want),
+			"capacity.pods %s must equal kubeletConfiguration.maxPods", pods.String())
+	}
+}
+
+func osSlug(imageFamily string) string {
+	if imageFamily == gcpv1alpha1.ImageFamilyUbuntu {
+		return "ubuntu"
+	}
+	return "cos"
+}

--- a/test/suites/kubelet_config/suite_test.go
+++ b/test/suites/kubelet_config/suite_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet_config_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/test/pkg/environment"
+)
+
+var env *environment.Environment
+
+func TestKubeletConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	BeforeSuite(func() {
+		env = environment.NewEnvironment()
+	})
+	AfterSuite(func() {
+		if env != nil {
+			env.Cleanup()
+		}
+	})
+	RunSpecs(t, "KubeletConfiguration Suite")
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`GCENodeClass.spec.kubeletConfiguration` fields other than `maxPods` were accepted by the CRD but silently dropped at provisioning time. This PR makes them take effect on both the kubelet and Karpenter's scheduler bin-packing.

Newly honoured: `systemReserved`, `kubeReserved`, `evictionHard`, `evictionSoft`, `evictionSoftGracePeriod`, `evictionMaxPodGracePeriod`, `imageGCHighThresholdPercent`, `imageGCLowThresholdPercent`, `cpuCFSQuota`, `clusterDNS`, `podsPerCore`.

Approach mirrors `aws/karpenter-provider-aws`: marshal the whole `KubeletConfiguration` into the kubelet-config bootstrap YAML; plumb `systemReserved`, `kubeReserved`, and `evictionHard` into `InstanceTypeOverhead`. `evictionSoft` is intentionally not modelled in overhead, matching AWS and the [Kubernetes node-pressure-eviction docs](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#eviction-thresholds).

Also tightens CRD validation: `systemReserved` / `kubeReserved` values must match the `resource.Quantity` regex, `evictionHard` / `evictionSoft` values must match percentage-or-quantity. Mirrors AWS's regex.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

Fixes #398

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

`docs/reference/gcenodeclass.md` is regenerated. Narrative docs unchanged.

#### Special notes for your reviewer:

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.
- The `KubeletConfiguration` struct is JSON-marshalled wholesale into the kubelet-config bootstrap YAML. JSON tag names must match upstream `kubelet/config/v1beta1.KubeletConfiguration`; this invariant is documented on the struct.
- E2E suite added under `test/suites/kubelet_config/` covering the reporter's literal assertions (allocatable reflects `systemReserved` / `kubeReserved`) on both COS and Ubuntu, plus `podsPerCore` capping `capacity.pods`, a `#220` regression guard (partial `kubeReserved` override keeps the node `Ready`), and a `maxPods` case asserting `capacity.pods` matches and 40 replicas actually schedule on the node (guards `#133` kubelet/scheduler agreement and `#120` pod-CIDR sizing). Compiles cleanly; needs a manual run against a live GKE cluster (via the `karpenter-gcp-e2e` skill) before merge.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR activates previously silently-dropped `GCENodeClass.spec.kubeletConfiguration` fields (`systemReserved`, `kubeReserved`, `evictionHard/Soft`, `imageGCHighThresholdPercent`, `imageGCLowThresholdPercent`, `cpuCFSQuota`, `clusterDNS`, `podsPerCore`) by JSON-marshalling the struct into the kubelet-config bootstrap YAML and plumbing reservation/eviction fields into the scheduler's `InstanceTypeOverhead`. The approach mirrors `aws/karpenter-provider-aws`.

- **Overhead plumbing** (`overhead.go`, `types.go`): new helpers `kcSystemReserved`, `mergeKubeReserved`, `evictionThreshold`, and `kcMaxPods` wire user config into `cloudprovider.InstanceTypeOverhead` and `Capacity[pods]`, with `DeepCopy` throughout to avoid mutation bugs.
- **Kubelet YAML merge** (`metadata/utils.go`): `mergeUserKubeletConfig` does a one-level-deep map merge so provider-computed sub-keys (e.g. `kubeReserved.ephemeral-storage` derived from boot-disk size, issue #220) survive a partial user override.
- **CRD tightening** (`gcenodeclass.go`, both CRD YAMLs): adds `resource.Quantity` and percentage regex validators for `systemReserved`, `kubeReserved`, `evictionHard`, and `evictionSoft` — but the eviction regexes contain a `%||` typo that admits empty strings and causes a downstream `resource.MustParse("")` panic.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the `%||` → `%|` typo in the eviction CEL regex across the Go source and both CRD YAML files.

The core logic — overhead helpers, kubelet YAML merge, and PodsPerCore capping — is correct, well-tested, and closely mirrors the AWS provider. The only concrete defect is the duplicate pipe character (`||`) in the `evictionHard` and `evictionSoft` CEL validation rules in `gcenodeclass.go` and both generated CRD YAMLs: it creates an empty-string alternative, so `evictionHard: {"memory.available": ""}` passes admission and then causes a `resource.MustParse("")` panic during provisioning. One-character fix (`%||` → `%|`) in three files unblocks the merge.

`pkg/apis/v1alpha1/gcenodeclass.go` and both CRD YAML files (`charts/karpenter-crd/…` and `charts/karpenter/crds/…`) — each contains the `%||` regex bug in the `evictionHard` and `evictionSoft` validation rules.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pkg/apis/v1alpha1/gcenodeclass.go | Adds kubebuilder validation markers for systemReserved/kubeReserved (correct) and evictionHard/evictionSoft (broken: `%||` creates an empty-string alternative that admits "" and triggers a downstream panic). |
| charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml | Generated CRD template carries the same `%||` regex bug in both evictionHard and evictionSoft validation rules. |
| charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml | Second CRD location carries the same `%||` regex bug — both need the single-`|` fix. |
| pkg/providers/instancetype/overhead.go | New file implementing kcSystemReserved, mergeKubeReserved, evictionThreshold, computeEvictionSignal, and kcMaxPods helpers; logic is correct and well-guarded assuming the upstream CRD validation is fixed. |
| pkg/providers/instancetype/types.go | Wires the new overhead helpers into NewInstanceType and computeCapacity; the per-field delegation is clean and the PodsPerCore capping logic is correct. |
| pkg/providers/metadata/utils.go | Adds mergeUserKubeletConfig with correct 1-level-deep map merge and updates RenderKubeletConfigMetadata signature; Spot-specific overrides correctly applied after user merge. |
| pkg/providers/instancetype/overhead_test.go | Comprehensive unit tests for all overhead helpers including nil-kc baselines, partial overrides, percentage eviction math, and an integration-level NewInstanceType guard. |
| pkg/providers/metadata/utils_kubelet_config_test.go | Thorough unit tests for mergeUserKubeletConfig and RenderKubeletConfigMetadata covering nil config, empty struct, deep-merge semantics, Spot override ordering, and Duration marshaling. |
| pkg/providers/instance/instance.go | Passes nodeClass through to RenderKubeletConfigMetadata; minimal, correct change. |
| test/suites/kubelet_config/kubelet_config_test.go | New e2e suite covering systemReserved, partial kubeReserved (#220 regression), podsPerCore, and maxPods density scenarios on both COS and Ubuntu. |
| test/pkg/environment/helpers.go | Adds CreateNodeClassWithKubeletConfig and WaitForRunningPodsOnNode e2e helpers; straightforward additions. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GCENodeClass\nspec.kubeletConfiguration] --> B{NewInstanceType}
    B --> C[kcSystemReserved\n→ Overhead.SystemReserved]
    B --> D[mergeKubeReserved\ncomputed + user\n→ Overhead.KubeReserved]
    B --> E[evictionThreshold\nevictionHard memory/nodefs\n→ Overhead.EvictionThreshold]
    B --> F[kcMaxPods\npodsPerCore × cpus\n→ Capacity pods]

    A --> G{RenderKubeletConfigMetadata}
    G --> H[Set provider kubeReserved\ncpu / memory / ephemeral-storage]
    H --> I[mergeUserKubeletConfig\n1-level-deep map merge]
    I --> J{Spot?}
    J -- yes --> K[Apply featureGates\nshutdownGracePeriod\noverrides]
    J -- no --> L[Marshal to YAML\n→ instance metadata]
    K --> L

    subgraph CRD Admission
        M[evictionHard / evictionSoft values] -->|CEL regex| N{valid?}
        N -- bug: empty str passes --> O[MustParse panics]
        N -- fixed: single pipe --> P[admitted safely]
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pkg/apis/v1alpha1/gcenodeclass.go`, line 147 ([link](https://github.com/cloudpilot-ai/karpenter-provider-gcp/blob/7450254f1d4409bc7d3e22e24646d6a283c0f503/pkg/apis/v1alpha1/gcenodeclass.go#L147)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Empty string passes eviction value validation, triggering a panic**

   The CEL regex for `evictionHard` (and `evictionSoft` below) contains `||` — two consecutive pipe characters — between the percentage alternative and the quantity alternative. In RE2 (which CEL uses), `A||B` is three alternatives: A, the empty string, and B. Because `^` and `$` anchor the match, `^(A||B)$` also matches `""`. A user who sets `evictionHard: {"memory.available": ""}` passes admission, but `computeEvictionSignal` then calls `resource.MustParse("")`, which panics. The comment in that function explicitly says "CRD pattern restricts inputs … MustParse is safe", so the code relies entirely on this validation being correct.

   Change `||` to `|` in both `evictionHard` and `evictionSoft` validation rules here and in the corresponding CRD YAML files (`charts/karpenter-crd/…` and `charts/karpenter/crds/…`).

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fapis%2Fv1alpha1%2Fgcenodeclass.go%0ALine%3A%20147%0A%0AComment%3A%0A**Empty%20string%20passes%20eviction%20value%20validation%2C%20triggering%20a%20panic**%0A%0AThe%20CEL%20regex%20for%20%60evictionHard%60%20%28and%20%60evictionSoft%60%20below%29%20contains%20%60%7C%7C%60%20%E2%80%94%20two%20consecutive%20pipe%20characters%20%E2%80%94%20between%20the%20percentage%20alternative%20and%20the%20quantity%20alternative.%20In%20RE2%20%28which%20CEL%20uses%29%2C%20%60A%7C%7CB%60%20is%20three%20alternatives%3A%20A%2C%20the%20empty%20string%2C%20and%20B.%20Because%20%60%5E%60%20and%20%60%24%60%20anchor%20the%20match%2C%20%60%5E%28A%7C%7CB%29%24%60%20also%20matches%20%60%22%22%60.%20A%20user%20who%20sets%20%60evictionHard%3A%20%7B%22memory.available%22%3A%20%22%22%7D%60%20passes%20admission%2C%20but%20%60computeEvictionSignal%60%20then%20calls%20%60resource.MustParse%28%22%22%29%60%2C%20which%20panics.%20The%20comment%20in%20that%20function%20explicitly%20says%20%22CRD%20pattern%20restricts%20inputs%20%E2%80%A6%20MustParse%20is%20safe%22%2C%20so%20the%20code%20relies%20entirely%20on%20this%20validation%20being%20correct.%0A%0AChange%20%60%7C%7C%60%20to%20%60%7C%60%20in%20both%20%60evictionHard%60%20and%20%60evictionSoft%60%20validation%20rules%20here%20and%20in%20the%20corresponding%20CRD%20YAML%20files%20%28%60charts%2Fkarpenter-crd%2F%E2%80%A6%60%20and%20%60charts%2Fkarpenter%2Fcrds%2F%E2%80%A6%60%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=400&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fapis%2Fv1alpha1%2Fgcenodeclass.go%0ALine%3A%20147%0A%0AComment%3A%0A**Empty%20string%20passes%20eviction%20value%20validation%2C%20triggering%20a%20panic**%0A%0AThe%20CEL%20regex%20for%20%60evictionHard%60%20%28and%20%60evictionSoft%60%20below%29%20contains%20%60%7C%7C%60%20%E2%80%94%20two%20consecutive%20pipe%20characters%20%E2%80%94%20between%20the%20percentage%20alternative%20and%20the%20quantity%20alternative.%20In%20RE2%20%28which%20CEL%20uses%29%2C%20%60A%7C%7CB%60%20is%20three%20alternatives%3A%20A%2C%20the%20empty%20string%2C%20and%20B.%20Because%20%60%5E%60%20and%20%60%24%60%20anchor%20the%20match%2C%20%60%5E%28A%7C%7CB%29%24%60%20also%20matches%20%60%22%22%60.%20A%20user%20who%20sets%20%60evictionHard%3A%20%7B%22memory.available%22%3A%20%22%22%7D%60%20passes%20admission%2C%20but%20%60computeEvictionSignal%60%20then%20calls%20%60resource.MustParse%28%22%22%29%60%2C%20which%20panics.%20The%20comment%20in%20that%20function%20explicitly%20says%20%22CRD%20pattern%20restricts%20inputs%20%E2%80%A6%20MustParse%20is%20safe%22%2C%20so%20the%20code%20relies%20entirely%20on%20this%20validation%20being%20correct.%0A%0AChange%20%60%7C%7C%60%20to%20%60%7C%60%20in%20both%20%60evictionHard%60%20and%20%60evictionSoft%60%20validation%20rules%20here%20and%20in%20the%20corresponding%20CRD%20YAML%20files%20%28%60charts%2Fkarpenter-crd%2F%E2%80%A6%60%20and%20%60charts%2Fkarpenter%2Fcrds%2F%E2%80%A6%60%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=400&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22feat%2Fkubelet-config-honour-all-fields%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fkubelet-config-honour-all-fields%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fapis%2Fv1alpha1%2Fgcenodeclass.go%0ALine%3A%20147%0A%0AComment%3A%0A**Empty%20string%20passes%20eviction%20value%20validation%2C%20triggering%20a%20panic**%0A%0AThe%20CEL%20regex%20for%20%60evictionHard%60%20%28and%20%60evictionSoft%60%20below%29%20contains%20%60%7C%7C%60%20%E2%80%94%20two%20consecutive%20pipe%20characters%20%E2%80%94%20between%20the%20percentage%20alternative%20and%20the%20quantity%20alternative.%20In%20RE2%20%28which%20CEL%20uses%29%2C%20%60A%7C%7CB%60%20is%20three%20alternatives%3A%20A%2C%20the%20empty%20string%2C%20and%20B.%20Because%20%60%5E%60%20and%20%60%24%60%20anchor%20the%20match%2C%20%60%5E%28A%7C%7CB%29%24%60%20also%20matches%20%60%22%22%60.%20A%20user%20who%20sets%20%60evictionHard%3A%20%7B%22memory.available%22%3A%20%22%22%7D%60%20passes%20admission%2C%20but%20%60computeEvictionSignal%60%20then%20calls%20%60resource.MustParse%28%22%22%29%60%2C%20which%20panics.%20The%20comment%20in%20that%20function%20explicitly%20says%20%22CRD%20pattern%20restricts%20inputs%20%E2%80%A6%20MustParse%20is%20safe%22%2C%20so%20the%20code%20relies%20entirely%20on%20this%20validation%20being%20correct.%0A%0AChange%20%60%7C%7C%60%20to%20%60%7C%60%20in%20both%20%60evictionHard%60%20and%20%60evictionSoft%60%20validation%20rules%20here%20and%20in%20the%20corresponding%20CRD%20YAML%20files%20%28%60charts%2Fkarpenter-crd%2F%E2%80%A6%60%20and%20%60charts%2Fkarpenter%2Fcrds%2F%E2%80%A6%60%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Apkg%2Fapis%2Fv1alpha1%2Fgcenodeclass.go%3A239%0A**Empty%20string%20bypasses%20eviction%20value%20validation%20and%20triggers%20a%20panic**%0A%0AThe%20CEL%20regex%20contains%20%60%25%7C%7C%60%20%E2%80%94%20two%20consecutive%20pipe%20characters%20%E2%80%94%20which%20in%20RE2%20creates%20three%20alternation%20arms%3A%20the%20percentage%20arm%2C%20the%20**empty%20string**%2C%20and%20the%20quantity%20arm.%20Because%20%60%5E%60%20and%20%60%24%60%20anchor%20the%20match%2C%20%60%5E%28A%7C%7CB%29%24%60%20also%20matches%20%60%22%22%60.%20A%20user%20who%20sets%20%60evictionHard%3A%20%7B%22memory.available%22%3A%20%22%22%7D%60%20passes%20admission%2C%20but%20%60computeEvictionSignal%60%20then%20falls%20through%20to%20%60resource.MustParse%28%22%22%29%60%2C%20which%20panics.%20The%20comment%20on%20that%20line%20explicitly%20states%20%22MustParse%20is%20safe%22%20only%20because%20it%20trusts%20this%20CRD%20guard%20%E2%80%94%20that%20trust%20is%20broken.%20Apply%20the%20same%20single-%60%7C%60%20fix%20to%20%60evictionSoft%60%20below%20and%20to%20both%20generated%20CRD%20YAML%20files%20%28%60charts%2Fkarpenter-crd%2F%E2%80%A6%60%20and%20%60charts%2Fkarpenter%2Fcrds%2F%E2%80%A6%60%29.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20%2Bkubebuilder%3Avalidation%3AXValidation%3Amessage%3D%22evictionHard%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%22%2Crule%3D%22self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5C%5Cd%7B1%2C2%7D%28%5C%5C.%5C%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C%5C.%5B0-9%5D*%29%3F%29%7C%28%5C%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C%5C.%5B0-9%5D*%29%3F%29%7C%28%5C%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%206%0Apkg%2Fapis%2Fv1alpha1%2Fgcenodeclass.go%3A245%0ASame%20%60%25%7C%7C%60%20%E2%86%92%20empty-string%20bug%20as%20%60evictionHard%60%20above.%20Replace%20the%20double%20%60%7C%7C%60%20with%20a%20single%20%60%7C%60%20here%20too.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20%2Bkubebuilder%3Avalidation%3AXValidation%3Amessage%3D%22evictionSoft%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%22%2Crule%3D%22self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5C%5Cd%7B1%2C2%7D%28%5C%5C.%5C%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C%5C.%5B0-9%5D*%29%3F%29%7C%28%5C%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C%5C.%5B0-9%5D*%29%3F%29%7C%28%5C%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%22%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%206%0Acharts%2Fkarpenter-crd%2Ftemplates%2Fkarpenter.k8s.gcp_gcenodeclasses.yaml%3A303-304%0ASame%20%60%25%7C%7C%60%20regex%20bug%20in%20the%20generated%20CRD%20template%20%E2%80%94%20%60%7C%7C%60%20creates%20an%20empty-string%20alternative%20that%20passes%20admission%20for%20%60%22%22%60.%20Change%20to%20single%20%60%7C%60%20to%20match%20the%20fix%20in%20%60gcenodeclass.go%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20message%3A%20evictionHard%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rule%3A%20self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5Cd%7B1%2C2%7D%28%5C.%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%206%0Acharts%2Fkarpenter-crd%2Ftemplates%2Fkarpenter.k8s.gcp_gcenodeclasses.yaml%3A321-322%0ASame%20%60%25%7C%7C%60%20regex%20bug%20for%20%60evictionSoft%60%20%E2%80%94%20fix%20to%20single%20%60%7C%60%20to%20close%20the%20empty-string%20admission%20hole.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20message%3A%20evictionSoft%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rule%3A%20self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5Cd%7B1%2C2%7D%28%5C.%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%206%0Acharts%2Fkarpenter%2Fcrds%2Fkarpenter.k8s.gcp_gcenodeclasses.yaml%3A300-301%0ASame%20%60%25%7C%7C%60%20regex%20bug%20in%20the%20second%20CRD%20location%20%E2%80%94%20fix%20to%20single%20%60%7C%60%20for%20%60evictionHard%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20message%3A%20evictionHard%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rule%3A%20self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5Cd%7B1%2C2%7D%28%5C.%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%206%20of%206%0Acharts%2Fkarpenter%2Fcrds%2Fkarpenter.k8s.gcp_gcenodeclasses.yaml%3A318-319%0ASame%20%60%25%7C%7C%60%20regex%20bug%20%E2%80%94%20fix%20to%20single%20%60%7C%60%20for%20%60evictionSoft%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20message%3A%20evictionSoft%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rule%3A%20self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5Cd%7B1%2C2%7D%28%5C.%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%0A%60%60%60%0A%0A&pr=400&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Apkg%2Fapis%2Fv1alpha1%2Fgcenodeclass.go%3A239%0A**Empty%20string%20bypasses%20eviction%20value%20validation%20and%20triggers%20a%20panic**%0A%0AThe%20CEL%20regex%20contains%20%60%25%7C%7C%60%20%E2%80%94%20two%20consecutive%20pipe%20characters%20%E2%80%94%20which%20in%20RE2%20creates%20three%20alternation%20arms%3A%20the%20percentage%20arm%2C%20the%20**empty%20string**%2C%20and%20the%20quantity%20arm.%20Because%20%60%5E%60%20and%20%60%24%60%20anchor%20the%20match%2C%20%60%5E%28A%7C%7CB%29%24%60%20also%20matches%20%60%22%22%60.%20A%20user%20who%20sets%20%60evictionHard%3A%20%7B%22memory.available%22%3A%20%22%22%7D%60%20passes%20admission%2C%20but%20%60computeEvictionSignal%60%20then%20falls%20through%20to%20%60resource.MustParse%28%22%22%29%60%2C%20which%20panics.%20The%20comment%20on%20that%20line%20explicitly%20states%20%22MustParse%20is%20safe%22%20only%20because%20it%20trusts%20this%20CRD%20guard%20%E2%80%94%20that%20trust%20is%20broken.%20Apply%20the%20same%20single-%60%7C%60%20fix%20to%20%60evictionSoft%60%20below%20and%20to%20both%20generated%20CRD%20YAML%20files%20%28%60charts%2Fkarpenter-crd%2F%E2%80%A6%60%20and%20%60charts%2Fkarpenter%2Fcrds%2F%E2%80%A6%60%29.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20%2Bkubebuilder%3Avalidation%3AXValidation%3Amessage%3D%22evictionHard%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%22%2Crule%3D%22self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5C%5Cd%7B1%2C2%7D%28%5C%5C.%5C%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C%5C.%5B0-9%5D*%29%3F%29%7C%28%5C%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C%5C.%5B0-9%5D*%29%3F%29%7C%28%5C%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%206%0Apkg%2Fapis%2Fv1alpha1%2Fgcenodeclass.go%3A245%0ASame%20%60%25%7C%7C%60%20%E2%86%92%20empty-string%20bug%20as%20%60evictionHard%60%20above.%20Replace%20the%20double%20%60%7C%7C%60%20with%20a%20single%20%60%7C%60%20here%20too.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20%2Bkubebuilder%3Avalidation%3AXValidation%3Amessage%3D%22evictionSoft%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%22%2Crule%3D%22self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5C%5Cd%7B1%2C2%7D%28%5C%5C.%5C%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C%5C.%5B0-9%5D*%29%3F%29%7C%28%5C%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C%5C.%5B0-9%5D*%29%3F%29%7C%28%5C%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%22%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%206%0Acharts%2Fkarpenter-crd%2Ftemplates%2Fkarpenter.k8s.gcp_gcenodeclasses.yaml%3A303-304%0ASame%20%60%25%7C%7C%60%20regex%20bug%20in%20the%20generated%20CRD%20template%20%E2%80%94%20%60%7C%7C%60%20creates%20an%20empty-string%20alternative%20that%20passes%20admission%20for%20%60%22%22%60.%20Change%20to%20single%20%60%7C%60%20to%20match%20the%20fix%20in%20%60gcenodeclass.go%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20message%3A%20evictionHard%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rule%3A%20self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5Cd%7B1%2C2%7D%28%5C.%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%206%0Acharts%2Fkarpenter-crd%2Ftemplates%2Fkarpenter.k8s.gcp_gcenodeclasses.yaml%3A321-322%0ASame%20%60%25%7C%7C%60%20regex%20bug%20for%20%60evictionSoft%60%20%E2%80%94%20fix%20to%20single%20%60%7C%60%20to%20close%20the%20empty-string%20admission%20hole.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20message%3A%20evictionSoft%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rule%3A%20self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5Cd%7B1%2C2%7D%28%5C.%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%0A%60%60%60%0A%0A%282%20more%20issues%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=400&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22feat%2Fkubelet-config-honour-all-fields%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fkubelet-config-honour-all-fields%22.%0A%0AFix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Apkg%2Fapis%2Fv1alpha1%2Fgcenodeclass.go%3A239%0A**Empty%20string%20bypasses%20eviction%20value%20validation%20and%20triggers%20a%20panic**%0A%0AThe%20CEL%20regex%20contains%20%60%25%7C%7C%60%20%E2%80%94%20two%20consecutive%20pipe%20characters%20%E2%80%94%20which%20in%20RE2%20creates%20three%20alternation%20arms%3A%20the%20percentage%20arm%2C%20the%20**empty%20string**%2C%20and%20the%20quantity%20arm.%20Because%20%60%5E%60%20and%20%60%24%60%20anchor%20the%20match%2C%20%60%5E%28A%7C%7CB%29%24%60%20also%20matches%20%60%22%22%60.%20A%20user%20who%20sets%20%60evictionHard%3A%20%7B%22memory.available%22%3A%20%22%22%7D%60%20passes%20admission%2C%20but%20%60computeEvictionSignal%60%20then%20falls%20through%20to%20%60resource.MustParse%28%22%22%29%60%2C%20which%20panics.%20The%20comment%20on%20that%20line%20explicitly%20states%20%22MustParse%20is%20safe%22%20only%20because%20it%20trusts%20this%20CRD%20guard%20%E2%80%94%20that%20trust%20is%20broken.%20Apply%20the%20same%20single-%60%7C%60%20fix%20to%20%60evictionSoft%60%20below%20and%20to%20both%20generated%20CRD%20YAML%20files%20%28%60charts%2Fkarpenter-crd%2F%E2%80%A6%60%20and%20%60charts%2Fkarpenter%2Fcrds%2F%E2%80%A6%60%29.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20%2Bkubebuilder%3Avalidation%3AXValidation%3Amessage%3D%22evictionHard%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%22%2Crule%3D%22self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5C%5Cd%7B1%2C2%7D%28%5C%5C.%5C%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C%5C.%5B0-9%5D*%29%3F%29%7C%28%5C%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C%5C.%5B0-9%5D*%29%3F%29%7C%28%5C%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%206%0Apkg%2Fapis%2Fv1alpha1%2Fgcenodeclass.go%3A245%0ASame%20%60%25%7C%7C%60%20%E2%86%92%20empty-string%20bug%20as%20%60evictionHard%60%20above.%20Replace%20the%20double%20%60%7C%7C%60%20with%20a%20single%20%60%7C%60%20here%20too.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20%2Bkubebuilder%3Avalidation%3AXValidation%3Amessage%3D%22evictionSoft%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%22%2Crule%3D%22self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5C%5Cd%7B1%2C2%7D%28%5C%5C.%5C%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C%5C.%5B0-9%5D*%29%3F%29%7C%28%5C%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C%5C.%5B0-9%5D*%29%3F%29%7C%28%5C%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%22%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%206%0Acharts%2Fkarpenter-crd%2Ftemplates%2Fkarpenter.k8s.gcp_gcenodeclasses.yaml%3A303-304%0ASame%20%60%25%7C%7C%60%20regex%20bug%20in%20the%20generated%20CRD%20template%20%E2%80%94%20%60%7C%7C%60%20creates%20an%20empty-string%20alternative%20that%20passes%20admission%20for%20%60%22%22%60.%20Change%20to%20single%20%60%7C%60%20to%20match%20the%20fix%20in%20%60gcenodeclass.go%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20message%3A%20evictionHard%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rule%3A%20self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5Cd%7B1%2C2%7D%28%5C.%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%206%0Acharts%2Fkarpenter-crd%2Ftemplates%2Fkarpenter.k8s.gcp_gcenodeclasses.yaml%3A321-322%0ASame%20%60%25%7C%7C%60%20regex%20bug%20for%20%60evictionSoft%60%20%E2%80%94%20fix%20to%20single%20%60%7C%60%20to%20close%20the%20empty-string%20admission%20hole.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20message%3A%20evictionSoft%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rule%3A%20self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5Cd%7B1%2C2%7D%28%5C.%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%206%0Acharts%2Fkarpenter%2Fcrds%2Fkarpenter.k8s.gcp_gcenodeclasses.yaml%3A300-301%0ASame%20%60%25%7C%7C%60%20regex%20bug%20in%20the%20second%20CRD%20location%20%E2%80%94%20fix%20to%20single%20%60%7C%60%20for%20%60evictionHard%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20message%3A%20evictionHard%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rule%3A%20self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5Cd%7B1%2C2%7D%28%5C.%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%0A%60%60%60%0A%0A%23%23%23%20Issue%206%20of%206%0Acharts%2Fkarpenter%2Fcrds%2Fkarpenter.k8s.gcp_gcenodeclasses.yaml%3A318-319%0ASame%20%60%25%7C%7C%60%20regex%20bug%20%E2%80%94%20fix%20to%20single%20%60%7C%60%20for%20%60evictionSoft%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20-%20message%3A%20evictionSoft%20values%20must%20be%20a%20percentage%20or%20a%20resource.Quantity%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20rule%3A%20self.all%28x%2C%20self%5Bx%5D.matches%28'%5E%28%28%5Cd%7B1%2C2%7D%28%5C.%5Cd%7B1%2C2%7D%29%3F%7C100%28%5C.0%7B1%2C2%7D%29%3F%29%25%7C%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%28%28%5BKMGTPE%5Di%29%7C%5BnumkMGTPE%5D%7C%28%5BeE%5D%28%5C%2B%7C-%29%3F%28%28%5B0-9%5D%2B%28%5C.%5B0-9%5D*%29%3F%29%7C%28%5C.%5B0-9%5D%2B%29%29%29%29%3F%29%24'%29%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["test(e2e): kubeletConfiguration honoured..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/532b3d5c5d6d42e2b9335492a47fb52c1db03a7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35345424)</sub>

> Greptile also left **6 inline comments** on this PR.

<!-- /greptile_comment -->