### PR TITLE
chore(ci): pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/cloudpilot-latest-build.yaml
+++ b/.github/workflows/cloudpilot-latest-build.yaml
@@ -27,13 +27,13 @@ jobs:
           echo "AWS_DEFAULT_REGION=us-east-2" >> $GITHUB_ENV
 
       - name: AWS CLI Init
-        uses: unfor19/install-aws-cli-action@v1
+        uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # v1.0.8
 
       - name: Config ECR
         run: |
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/cloudpilotai
 
-      - uses: ko-build/setup-ko@v0.9
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
       - name: build and publish image
         run: |

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -29,7 +29,7 @@ jobs:
         run: make toolchain
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.12.2
           only-new-issues: true

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -34,13 +34,13 @@ jobs:
           echo "AWS_DEFAULT_REGION=us-east-2" >> $GITHUB_ENV
 
       - name: AWS CLI Init
-        uses: unfor19/install-aws-cli-action@v1
+        uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # v1.0.8
 
       - name: Config ECR
         run: |
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/cloudpilotai
 
-      - uses: ko-build/setup-ko@v0.9
+      - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
 
       - name: build and publish image
         run: |

--- a/.github/workflows/update-pricing.yaml
+++ b/.github/workflows/update-pricing.yaml
@@ -46,7 +46,7 @@ jobs:
           cache: false
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.GCP_PRICING_SA_KEY }}
 
@@ -64,7 +64,7 @@ jobs:
 
       - name: Create PR if pricing changed
         if: ${{ !inputs.dry_run }}
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "chore(pricing): update initial-prices.json"
           title: "chore(pricing): scheduled pricing data refresh"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Resolves CodeQL "Unpinned tag for a non-immutable Action" alerts (#8–#14) by pinning all third-party Actions in `.github/workflows/` to commit SHAs with a version comment.

Pinned to current resolved SHAs:
- `google-github-actions/auth` → `v3.0.0`
- `peter-evans/create-pull-request` → `v8.1.1`
- `unfor19/install-aws-cli-action` → `v1.0.8`
- `ko-build/setup-ko` → `v0.9`
- `golangci/golangci-lint-action` → `v9.2.1`

`actions/*` and `github/*` references are left on version tags — GitHub-published Actions are immutable and not flagged by CodeQL.

#### Related proposal (if applicable):
N/A

#### Which issue(s) this PR fixes:
Fixes CodeQL findings

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens supply-chain security in all four workflow files by replacing mutable version tags on third-party Actions with pinned commit SHAs annotated with the corresponding version comment, addressing CodeQL "Unpinned tag" alerts. First-party `actions/*` Actions are intentionally left on tags, consistent with GitHub's immutability guarantee for its own published Actions.

- `unfor19/install-aws-cli-action`, `ko-build/setup-ko`, and `golangci/golangci-lint-action` are pinned in the build and presubmit workflows; the commit SHAs for `setup-ko` (`d006021`) and `golangci-lint-action` (`82606bf`) were independently verified against the respective GitHub release pages.
- `google-github-actions/auth` and `peter-evans/create-pull-request` are pinned in `update-pricing.yaml` with in-line version comments for auditability.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all changes are mechanical SHA pins with no logic or behaviour modifications.

Every changed line is a one-for-one replacement of a mutable version tag with a pinned commit SHA. Two of the five SHAs (ko-build/setup-ko@d006021 and golangci/golangci-lint-action@82606bf) were confirmed against the published GitHub release pages; the remaining three are consistent with the version comments attached. No workflow logic, permissions, secrets handling, or runtime behaviour was modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/cloudpilot-latest-build.yaml | Pins unfor19/install-aws-cli-action and ko-build/setup-ko to verified commit SHAs; no logic changes. |
| .github/workflows/presubmit.yaml | Pins golangci/golangci-lint-action to verified commit SHA 82606bf (v9.2.1); no logic changes. |
| .github/workflows/release-build.yaml | Pins unfor19/install-aws-cli-action and ko-build/setup-ko to the same verified SHAs as cloudpilot-latest-build.yaml; no logic changes. |
| .github/workflows/update-pricing.yaml | Pins google-github-actions/auth and peter-evans/create-pull-request to commit SHAs; no logic changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before
        A1["unfor19/install-aws-cli-action@v1"]
        A2["ko-build/setup-ko@v0.9"]
        A3["golangci/golangci-lint-action@v9"]
        A4["google-github-actions/auth@v3"]
        A5["peter-evans/create-pull-request@v8"]
    end

    subgraph After["After (SHA-pinned)"]
        B1["unfor19/install-aws-cli-action@f5b46b7... #v1.0.8"]
        B2["ko-build/setup-ko@d006021... #v0.9"]
        B3["golangci/golangci-lint-action@82606bf... #v9.2.1"]
        B4["google-github-actions/auth@7c6bc77... #v3.0.0"]
        B5["peter-evans/create-pull-request@5f6978f... #v8.1.1"]
    end

    A1 -->|pin SHA| B1
    A2 -->|pin SHA| B2
    A3 -->|pin SHA| B3
    A4 -->|pin SHA| B4
    A5 -->|pin SHA| B5
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): pin third-party Actions to co..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/fc5938211bdd41d12fe02fefeb4fb75f4db1b50e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35011450)</sub>

<!-- /greptile_comment -->