### PR TITLE
fix(iam): drop non-existent container.clusters.getServerConfig permission

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -77,7 +77,7 @@ imageSelectorTerms:
 
 See [Image selection](docs/image-selection.md) for the full field reference and [Image management](docs/image-management.md#legacy-image-alias-format) for the complete migration table.
 
-**IAM note:** `container.clusters.getServerConfig` is included in `deploy/iam/karpenter-controller-role.yaml` and in the Terraform module. No additional action is required for users who followed the standard installation guide. Users on custom roles that predate this release may need to add the permission manually if they enable `channel:` terms.
+**IAM note:** GKE release-channel image resolution calls the `projects.locations.getServerConfig` API method. Custom IAM roles must include `container.clusters.list`; update your controller role before using the `channel:` term.
 
 ---
 

--- a/deploy/iam/karpenter-controller-role.yaml
+++ b/deploy/iam/karpenter-controller-role.yaml
@@ -31,5 +31,5 @@ includedPermissions:
   # nodePools.get is covered by container.clusters.get
   # nodePools.create/delete map to container.clusters.update in GCP IAM
   - container.clusters.get
-  - container.clusters.getServerConfig  # required for release-channel image resolution
+  - container.clusters.list  # required for release-channel image resolution
   - container.clusters.update


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`container.clusters.getServerConfig` is not a valid GCP IAM permission. Because of that, `make e2e-setup` fails while updating the minimal `karpenter_controller` custom role.

This PR removes the invalid permission, adds `container.clusters.list` for release-channel image resolution, and updates `MIGRATION.md` with the required custom-role change.

#### Related proposal (if applicable):

N/A — fixes the minimal IAM role update from [#342](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/342).

#### Which issue(s) this PR fixes:

Fixes N/A — found during e2e setup on a fresh project.

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

- Verified with `iam.permissions.queryTestablePermissions`: `container.clusters.getServerConfig` is not valid; `container.clusters.list` is valid.
- Verified by re-running `make e2e-setup` against a fresh `dm3ch-karpenter-dev` project.
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the non-existent `container.clusters.getServerConfig` IAM permission from the Karpenter controller role definition and replaces it with `container.clusters.list`, the actual valid permission required by the `projects.locations.getServerConfig` GKE API endpoint used for release-channel image resolution. The Terraform module in `deploy/terraform/iam.tf` dynamically reads from the YAML via `yamldecode`, so it is automatically corrected.

- **`deploy/iam/karpenter-controller-role.yaml`**: drops the invalid permission entry and adds `container.clusters.list` with a matching comment.
- **`MIGRATION.md`**: rewrites the IAM note to correctly name `container.clusters.list` as the required permission and removes the now-incorrect claim that the standard installation role already covered this case.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — removes an invalid IAM permission entry that was causing `make e2e-setup` to fail and replaces it with the correct valid permission.

The change is a two-line diff: one invalid permission out, one valid permission in. The Terraform module reads the YAML dynamically so it is automatically corrected. The only observation is a doc clarification in MIGRATION.md that could help existing standard-install users understand they need to re-apply the updated role YAML.

MIGRATION.md — the updated IAM note could more explicitly call out that standard-install users also need to re-apply the role YAML, since GCP was silently discarding the old invalid permission.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| deploy/iam/karpenter-controller-role.yaml | Replaces the invalid IAM permission `container.clusters.getServerConfig` with the valid `container.clusters.list`, which is the actual permission required by the GKE `projects.locations.getServerConfig` API. The Terraform module in `deploy/terraform/iam.tf` reads this YAML dynamically via `yamldecode`, so it is automatically fixed without a separate change. |
| MIGRATION.md | Updates the IAM note for the `channel:` image-selector term. The new text correctly names `container.clusters.list` as the required permission and drops the now-invalid reference to `container.clusters.getServerConfig`. However, users who previously applied the standard `karpenter-controller-role.yaml` are not explicitly told they must re-apply it, since GCP silently rejected the old invalid permission and their roles were effectively missing the needed grant all along. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Controller: channel: image selector] --> B[GetServerConfig\nprojects.locations.getServerConfig]
    B --> C{IAM check}
    C -- "OLD: container.clusters.getServerConfig\n(invalid, silently rejected by GCP)" --> D[Permission error, make e2e-setup fails]
    C -- "NEW: container.clusters.list\n(valid GCP IAM permission)" --> E[ServerConfig returned]
    E --> F[ResolveVersionForChannel\nmatches cluster minor version]
    F --> G[GCENodeClass status.images updated]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AMIGRATION.md%3A80%0AThe%20updated%20IAM%20note%20tells%20users%20with%20custom%20roles%20to%20add%20%60container.clusters.list%60%2C%20but%20doesn't%20mention%20that%20users%20who%20followed%20the%20*standard*%20installation%20guide%20and%20applied%20the%20previous%20%60karpenter-controller-role.yaml%60%20are%20also%20affected.%20Because%20GCP%20silently%20rejected%20the%20old%20invalid%20%60container.clusters.getServerConfig%60%20permission%2C%20those%20roles%20never%20had%20an%20effective%20grant%20for%20%60getServerConfig%60%3B%20they%20will%20need%20to%20re-apply%20the%20updated%20YAML%20or%20add%20%60container.clusters.list%60%20manually%20before%20enabling%20any%20%60channel%3A%60%20image%20selector%20term.%0A%0A%60%60%60suggestion%0A**IAM%20note%3A**%20GKE%20release-channel%20image%20resolution%20calls%20the%20%60projects.locations.getServerConfig%60%20API%20method.%20This%20requires%20the%20%60container.clusters.list%60%20IAM%20permission.%20Users%20on%20the%20standard%20%60deploy%2Fiam%2Fkarpenter-controller-role.yaml%60-based%20role%20must%20re-apply%20it%20%28or%20run%20%60gcloud%20iam%20roles%20update%60%29%20before%20using%20the%20%60channel%3A%60%20term%2C%20because%20the%20previous%20YAML%20contained%20the%20invalid%20permission%20%60container.clusters.getServerConfig%60%20that%20GCP%20silently%20rejected.%20Users%20on%20fully%20custom%20roles%20must%20add%20%60container.clusters.list%60%20manually.%0A%60%60%60%0A%0A&pr=403&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AMIGRATION.md%3A80%0AThe%20updated%20IAM%20note%20tells%20users%20with%20custom%20roles%20to%20add%20%60container.clusters.list%60%2C%20but%20doesn't%20mention%20that%20users%20who%20followed%20the%20*standard*%20installation%20guide%20and%20applied%20the%20previous%20%60karpenter-controller-role.yaml%60%20are%20also%20affected.%20Because%20GCP%20silently%20rejected%20the%20old%20invalid%20%60container.clusters.getServerConfig%60%20permission%2C%20those%20roles%20never%20had%20an%20effective%20grant%20for%20%60getServerConfig%60%3B%20they%20will%20need%20to%20re-apply%20the%20updated%20YAML%20or%20add%20%60container.clusters.list%60%20manually%20before%20enabling%20any%20%60channel%3A%60%20image%20selector%20term.%0A%0A%60%60%60suggestion%0A**IAM%20note%3A**%20GKE%20release-channel%20image%20resolution%20calls%20the%20%60projects.locations.getServerConfig%60%20API%20method.%20This%20requires%20the%20%60container.clusters.list%60%20IAM%20permission.%20Users%20on%20the%20standard%20%60deploy%2Fiam%2Fkarpenter-controller-role.yaml%60-based%20role%20must%20re-apply%20it%20%28or%20run%20%60gcloud%20iam%20roles%20update%60%29%20before%20using%20the%20%60channel%3A%60%20term%2C%20because%20the%20previous%20YAML%20contained%20the%20invalid%20permission%20%60container.clusters.getServerConfig%60%20that%20GCP%20silently%20rejected.%20Users%20on%20fully%20custom%20roles%20must%20add%20%60container.clusters.list%60%20manually.%0A%60%60%60%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=403&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22fix%2Fiam-remove-invalid-getserverconfig%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fiam-remove-invalid-getserverconfig%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AMIGRATION.md%3A80%0AThe%20updated%20IAM%20note%20tells%20users%20with%20custom%20roles%20to%20add%20%60container.clusters.list%60%2C%20but%20doesn't%20mention%20that%20users%20who%20followed%20the%20*standard*%20installation%20guide%20and%20applied%20the%20previous%20%60karpenter-controller-role.yaml%60%20are%20also%20affected.%20Because%20GCP%20silently%20rejected%20the%20old%20invalid%20%60container.clusters.getServerConfig%60%20permission%2C%20those%20roles%20never%20had%20an%20effective%20grant%20for%20%60getServerConfig%60%3B%20they%20will%20need%20to%20re-apply%20the%20updated%20YAML%20or%20add%20%60container.clusters.list%60%20manually%20before%20enabling%20any%20%60channel%3A%60%20image%20selector%20term.%0A%0A%60%60%60suggestion%0A**IAM%20note%3A**%20GKE%20release-channel%20image%20resolution%20calls%20the%20%60projects.locations.getServerConfig%60%20API%20method.%20This%20requires%20the%20%60container.clusters.list%60%20IAM%20permission.%20Users%20on%20the%20standard%20%60deploy%2Fiam%2Fkarpenter-controller-role.yaml%60-based%20role%20must%20re-apply%20it%20%28or%20run%20%60gcloud%20iam%20roles%20update%60%29%20before%20using%20the%20%60channel%3A%60%20term%2C%20because%20the%20previous%20YAML%20contained%20the%20invalid%20permission%20%60container.clusters.getServerConfig%60%20that%20GCP%20silently%20rejected.%20Users%20on%20fully%20custom%20roles%20must%20add%20%60container.clusters.list%60%20manually.%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(iam): drop non-existent container.cl..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/42ba7fc27c9dbf01a58223d0011b608758dc2caf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35280462)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->