### PR TITLE
feat: set GKE disk type labels on Karpenter nodes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,3 +57,12 @@ updates:
       crd-tools:
         patterns:
           - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/hack/pdcsi-data"
+    schedule:
+      interval: "weekly"
+    groups:
+      pdcsi-data:
+        patterns:
+          - "sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ REGION ?= us-central1
 # Common Directories
 MOD_DIRS = $(shell find . -path "./website" -prune -o -name go.mod -type f -print | xargs dirname)
 KARPENTER_CORE_DIR = $(shell go list -m -f '{{ .Dir }}' sigs.k8s.io/karpenter)
+PDCSI_MODULE = sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
+PDCSI_DATA_DIR = hack/pdcsi-data
+PDCSI_NODE_LABELER_CONFIGMAP = deploy/kubernetes/overlays/node-labeler/configmap.yaml
 
 help: ## Display help
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -44,6 +47,7 @@ run: ## Run Karpenter controller binary against your local cluster
 		go run ./cmd/controller/main.go
 
 update: tidy download ## Update go files header, CRD and generated code
+	$(MAKE) update-pdcsi-compatibility
 	hack/boilerplate.sh
 	hack/update-generated.sh
 	hack/docs-generate.sh
@@ -185,6 +189,12 @@ tidy: ## Run "go mod tidy"
 download: ## Run "go mod download"
 	go mod download
 
+update-pdcsi-compatibility: ## Update vendored PDCSI disk compatibility data from the pinned Go module
+	@cd $(PDCSI_DATA_DIR) && go mod download $(PDCSI_MODULE)
+	@src="$$(cd $(PDCSI_DATA_DIR) && go list -mod=mod -m -f '{{ .Dir }}' $(PDCSI_MODULE))/$(PDCSI_NODE_LABELER_CONFIGMAP)"; \
+		test -f "$$src" || (echo "PDCSI node-labeler ConfigMap not found at $$src" >&2; exit 1); \
+		cp "$$src" pkg/providers/disktype/pdcsi/node-labeler-configmap.yaml
+
 update-pricing:
 	@tmpdir=$$(mktemp -d); \
 	trap "rm -rf $$tmpdir" EXIT; \
@@ -198,7 +208,7 @@ codegen: ## Auto generate files based on GCP APIs
 crds: ## Apply CRDs
 	kubectl apply -f charts/karpenter/crds/
 
-.PHONY: help presubmit ci run ut-test require-project-id e2e-setup e2e-tests e2e-test e2e-teardown e2e-check-clean e2e-deploy coverage update update-pricing verify-codegen verify verify-crds verify-deadcode image apply delete toolchain tidy download docs-lint docs-fix
+.PHONY: help presubmit ci run ut-test require-project-id e2e-setup e2e-tests e2e-test e2e-teardown e2e-check-clean e2e-deploy coverage update update-pdcsi-compatibility update-pricing verify-codegen verify verify-crds verify-deadcode image apply delete toolchain tidy download docs-lint docs-fix
 
 define newline
 

--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -128,6 +128,59 @@ If the chosen machine type does not support the requested confidential type, GCE
 
 The default `ContainerOptimizedOS` and `Ubuntu` images boot as Confidential VMs on supported families without any image change. GPU Confidential VMs are an exception: an A3 instance with an attached H100 GPU using Intel TDX requires a TDX-specific image (for example `cos-tdx-*`), which is not available through the `family` image selectors. Pin such an image by its full resource URL with `imageSelectorTerms[].id`; see the [GCP supported configurations](https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#supported-images-gpu).
 
+## Disk type scheduling
+
+Karpenter applies `disk-type.gke.io/*` labels to provisioned nodes based on the instance type's machine family. These labels indicate which persistent disk types the instance supports, enabling two capabilities:
+
+1. **NodePool requirements** — constrain scheduling to instance types that support specific disk types
+2. **PD CSI topology scheduling** — enable StorageClasses with `allowedTopologies` based on disk-type labels
+
+### Constraining instance types by disk support
+
+Use disk-type labels in NodePool requirements to ensure Karpenter selects only instance types that support the disk types your workloads need:
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: hyperdisk-workloads
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.gcp
+        kind: GCENodeClass
+        name: default-example
+      requirements:
+        - key: disk-type.gke.io/hyperdisk-balanced
+          operator: In
+          values: ["true"]
+```
+
+This NodePool provisions only instance types from families that support Hyperdisk Balanced (such as n2, n4, c3, c4). Instance types from families without Hyperdisk Balanced support (such as e2, n1) are excluded.
+
+### Available disk-type labels
+
+The supported labels correspond to GCP disk types:
+
+| Label                                                   | Disk type                            |
+|---------------------------------------------------------|--------------------------------------|
+| `disk-type.gke.io/pd-standard`                          | Standard persistent disk             |
+| `disk-type.gke.io/pd-balanced`                          | Balanced persistent disk             |
+| `disk-type.gke.io/pd-ssd`                               | SSD persistent disk                  |
+| `disk-type.gke.io/pd-extreme`                           | Extreme persistent disk              |
+| `disk-type.gke.io/hyperdisk-balanced`                   | Hyperdisk Balanced                   |
+| `disk-type.gke.io/hyperdisk-extreme`                    | Hyperdisk Extreme                    |
+| `disk-type.gke.io/hyperdisk-throughput`                 | Hyperdisk Throughput                 |
+| `disk-type.gke.io/hyperdisk-ml`                         | Hyperdisk ML                         |
+| `disk-type.gke.io/hyperdisk-balanced-high-availability` | Hyperdisk Balanced High Availability |
+
+Disk compatibility is determined at the machine family level (`n2`, `c3`, `e2`), not the specific instance size. See the [GCP machine family disk support matrix](https://cloud.google.com/compute/docs/disks#disk-types) for which families support which disk types.
+
+### PD CSI topology scheduling
+
+The disk-type labels are also published as topology keys by the GCE Persistent Disk CSI driver. StorageClasses with `allowedTopologies` or `volumeBindingMode: WaitForFirstConsumer` can use these labels to schedule volumes only on nodes that support the required disk type.
+
 ## Multiple NodePools
 
 Run independent pools for different workload tiers, each referencing a different GCENodeClass:

--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -179,7 +179,21 @@ Disk compatibility is determined at the machine family level (`n2`, `c3`, `e2`),
 
 ### PD CSI topology scheduling
 
-The disk-type labels are also published as topology keys by the GCE Persistent Disk CSI driver. StorageClasses with `allowedTopologies` or `volumeBindingMode: WaitForFirstConsumer` can use these labels to schedule volumes only on nodes that support the required disk type.
+The disk-type labels are also published as topology keys by the GCE Persistent Disk CSI driver when the StorageClass enables disk topology:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hyperdisk-balanced
+provisioner: pd.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: hyperdisk-balanced
+  use-allowed-disk-topology: "true"
+```
+
+StorageClasses with `use-allowed-disk-topology: "true"` can use disk-type labels in `allowedTopologies`, and bound PVs can carry these labels in node affinity so replacement pods schedule only on nodes that support the disk type.
 
 ## Multiple NodePools
 

--- a/hack/pdcsi-data/go.mod
+++ b/hack/pdcsi-data/go.mod
@@ -1,0 +1,5 @@
+module github.com/cloudpilot-ai/karpenter-provider-gcp/hack/pdcsi-data
+
+go 1.26.3
+
+require sigs.k8s.io/gcp-compute-persistent-disk-csi-driver v1.25.2

--- a/hack/pdcsi-data/go.sum
+++ b/hack/pdcsi-data/go.sum
@@ -1,0 +1,2 @@
+sigs.k8s.io/gcp-compute-persistent-disk-csi-driver v1.25.2 h1:TvsPGjmUdAEmGisDQx82BTJMkeMeT/HCpp5/eQokb7o=
+sigs.k8s.io/gcp-compute-persistent-disk-csi-driver v1.25.2/go.mod h1:ne7PPW/+GTl7u4j26lcCyR6gLyUx8qXXQxOzKB0kI8U=

--- a/pkg/apis/v1alpha1/labels.go
+++ b/pkg/apis/v1alpha1/labels.go
@@ -26,6 +26,7 @@ import (
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/disktype"
 )
 
 func init() {
@@ -53,6 +54,7 @@ func init() {
 		LabelGKEReadinessNodeLocalDNSReady,
 		LabelGKEAccelerator,
 	)
+	karpv1.WellKnownLabels = karpv1.WellKnownLabels.Insert(disktype.AllLabels()...)
 }
 
 var (

--- a/pkg/providers/disktype/compatibility.go
+++ b/pkg/providers/disktype/compatibility.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disktype
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const labelPrefix = "disk-type.gke.io/"
+
+//go:embed pdcsi/node-labeler-configmap.yaml
+var upstreamConfigMap embed.FS
+
+type configMap struct {
+	Data map[string]string `yaml:"data"`
+}
+
+var compatibility = mustLoadCompatibility()
+
+func mustLoadCompatibility() map[string][]string {
+	contents, err := upstreamConfigMap.ReadFile("pdcsi/node-labeler-configmap.yaml")
+	if err != nil {
+		panic(fmt.Sprintf("reading vendored PDCSI compatibility configmap: %v", err))
+	}
+
+	var cm configMap
+	if err := yaml.Unmarshal(contents, &cm); err != nil {
+		panic(fmt.Sprintf("parsing vendored PDCSI compatibility configmap: %v", err))
+	}
+
+	jsonText := cm.Data["machine-pd-compatibility.json"]
+	if jsonText == "" {
+		panic("vendored PDCSI compatibility configmap missing machine-pd-compatibility.json")
+	}
+
+	var raw map[string]map[string]bool
+	if err := json.Unmarshal([]byte(jsonText), &raw); err != nil {
+		panic(fmt.Sprintf("parsing machine-pd-compatibility.json: %v", err))
+	}
+
+	out := make(map[string][]string, len(raw))
+	for family, diskTypes := range raw {
+		labels := make([]string, 0, len(diskTypes))
+		for diskType, supported := range diskTypes {
+			if supported {
+				labels = append(labels, labelPrefix+diskType)
+			}
+		}
+		sort.Strings(labels)
+		out[family] = labels
+	}
+	return out
+}
+
+// Family returns the GCE machine family prefix from an instance type name.
+func Family(instanceType string) string {
+	if instanceType == "" {
+		return ""
+	}
+	family, _, _ := strings.Cut(instanceType, "-")
+	return family
+}
+
+// LabelsForInstanceType returns disk-type.gke.io labels for the instance type's family.
+func LabelsForInstanceType(instanceType string) (map[string]string, bool) {
+	return LabelsForFamily(Family(instanceType))
+}
+
+// LabelsForFamily returns disk-type.gke.io labels for a GCE machine family.
+func LabelsForFamily(family string) (map[string]string, bool) {
+	labels, ok := compatibility[family]
+	if !ok {
+		return nil, false
+	}
+	out := make(map[string]string, len(labels))
+	for _, label := range labels {
+		out[label] = "true"
+	}
+	return out, true
+}

--- a/pkg/providers/disktype/compatibility.go
+++ b/pkg/providers/disktype/compatibility.go
@@ -37,6 +37,22 @@ type configMap struct {
 
 var compatibility = mustLoadCompatibility()
 
+func AllLabels() []string {
+	labels := map[string]struct{}{}
+	for _, familyLabels := range compatibility {
+		for _, label := range familyLabels {
+			labels[label] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(labels))
+	for label := range labels {
+		out = append(out, label)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func mustLoadCompatibility() map[string][]string {
 	contents, err := upstreamConfigMap.ReadFile("pdcsi/node-labeler-configmap.yaml")
 	if err != nil {

--- a/pkg/providers/disktype/compatibility_test.go
+++ b/pkg/providers/disktype/compatibility_test.go
@@ -68,6 +68,18 @@ func TestLabelsForInstanceType(t *testing.T) {
 	}, labels)
 }
 
+func TestAllLabels(t *testing.T) {
+	t.Parallel()
+
+	labels := AllLabels()
+	require.Contains(t, labels, "disk-type.gke.io/pd-balanced")
+	require.Contains(t, labels, "disk-type.gke.io/pd-extreme")
+	require.Contains(t, labels, "disk-type.gke.io/pd-ssd")
+	require.Contains(t, labels, "disk-type.gke.io/pd-standard")
+	require.Contains(t, labels, "disk-type.gke.io/hyperdisk-throughput")
+	require.IsIncreasing(t, labels)
+}
+
 func TestLabelsForUnknownFamily(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/providers/disktype/compatibility_test.go
+++ b/pkg/providers/disktype/compatibility_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disktype
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFamily(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		instanceType string
+		want         string
+	}{
+		{name: "standard", instanceType: "n2-standard-4", want: "n2"},
+		{name: "highcpu", instanceType: "c3-highcpu-22", want: "c3"},
+		{name: "custom", instanceType: "n2-custom-4-8192", want: "n2"},
+		{name: "single token", instanceType: "n2", want: "n2"},
+		{name: "empty", instanceType: "", want: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, Family(tc.instanceType))
+		})
+	}
+}
+
+func TestLabelsForFamily(t *testing.T) {
+	t.Parallel()
+
+	labels, ok := LabelsForFamily("n2")
+	require.True(t, ok)
+	require.Equal(t, "true", labels["disk-type.gke.io/pd-balanced"])
+	require.Equal(t, "true", labels["disk-type.gke.io/pd-ssd"])
+	require.Equal(t, "true", labels["disk-type.gke.io/hyperdisk-throughput"])
+}
+
+func TestLabelsForInstanceType(t *testing.T) {
+	t.Parallel()
+
+	labels, ok := LabelsForInstanceType("e2-standard-4")
+	require.True(t, ok)
+	require.Equal(t, map[string]string{
+		"disk-type.gke.io/pd-balanced": "true",
+		"disk-type.gke.io/pd-extreme":  "true",
+		"disk-type.gke.io/pd-ssd":      "true",
+		"disk-type.gke.io/pd-standard": "true",
+	}, labels)
+}
+
+func TestLabelsForUnknownFamily(t *testing.T) {
+	t.Parallel()
+
+	labels, ok := LabelsForInstanceType("unknown-standard-4")
+	require.False(t, ok)
+	require.Nil(t, labels)
+}
+
+func TestLabelsForFamilyReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	labels, ok := LabelsForFamily("n2")
+	require.True(t, ok)
+	delete(labels, "disk-type.gke.io/pd-balanced")
+
+	labelsAgain, ok := LabelsForFamily("n2")
+	require.True(t, ok)
+	require.Equal(t, "true", labelsAgain["disk-type.gke.io/pd-balanced"])
+}

--- a/pkg/providers/disktype/pdcsi/README.md
+++ b/pkg/providers/disktype/pdcsi/README.md
@@ -1,0 +1,20 @@
+# PDCSI node-labeler machine/disk compatibility data
+
+This directory contains the upstream PDCSI node-labeler ConfigMap:
+`deploy/kubernetes/overlays/node-labeler/configmap.yaml` from
+`kubernetes-sigs/gcp-compute-persistent-disk-csi-driver`.
+
+Pinned upstream commit: `b6ce51692da2efe262acbc65132b15943eb2bfe0`.
+
+Karpenter Provider GCP embeds this ConfigMap and reads
+`data.machine-pd-compatibility.json` to compute `disk-type.gke.io/*` Node labels
+for Karpenter-created GKE nodes.
+
+Update process:
+
+1. Fetch the upstream PDCSI repository at the intended commit.
+2. Copy `deploy/kubernetes/overlays/node-labeler/configmap.yaml` to `node-labeler-configmap.yaml` in this directory.
+3. Update the pinned commit above.
+4. Run `go test ./pkg/providers/disktype ./pkg/providers/metadata ./pkg/providers/instance` and `make presubmit`.
+
+This update is manual by design. Do not call it from `make update`; required checks must be reproducible without fetching upstream `master`.

--- a/pkg/providers/disktype/pdcsi/README.md
+++ b/pkg/providers/disktype/pdcsi/README.md
@@ -2,19 +2,20 @@
 
 This directory contains the upstream PDCSI node-labeler ConfigMap:
 `deploy/kubernetes/overlays/node-labeler/configmap.yaml` from
-`kubernetes-sigs/gcp-compute-persistent-disk-csi-driver`.
-
-Pinned upstream commit: `b6ce51692da2efe262acbc65132b15943eb2bfe0`.
+`sigs.k8s.io/gcp-compute-persistent-disk-csi-driver`.
 
 Karpenter Provider GCP embeds this ConfigMap and reads
 `data.machine-pd-compatibility.json` to compute `disk-type.gke.io/*` Node labels
-for Karpenter-created GKE nodes.
+and scheduler requirements for Karpenter-created GKE nodes.
 
 Update process:
 
-1. Fetch the upstream PDCSI repository at the intended commit.
-2. Copy `deploy/kubernetes/overlays/node-labeler/configmap.yaml` to `node-labeler-configmap.yaml` in this directory.
-3. Update the pinned commit above.
-4. Run `go test ./pkg/providers/disktype ./pkg/providers/metadata ./pkg/providers/instance` and `make presubmit`.
+1. Dependabot updates the pinned `sigs.k8s.io/gcp-compute-persistent-disk-csi-driver`
+   module version in `hack/pdcsi-data/go.mod`.
+2. Run `make update`; the `update-pdcsi-compatibility` target copies the
+   node-labeler ConfigMap from the downloaded module into this directory.
+3. Commit the updated `node-labeler-configmap.yaml` with the data module bump.
+4. Run `go test ./pkg/providers/disktype ./pkg/providers/metadata ./pkg/providers/instancetype ./pkg/providers/instance` and `make presubmit`.
 
-This update is manual by design. Do not call it from `make update`; required checks must be reproducible without fetching upstream `master`.
+Do not fetch upstream `master` directly. The checked-in compatibility data must
+come from the module version recorded in `hack/pdcsi-data/go.mod` so updates are reproducible.

--- a/pkg/providers/disktype/pdcsi/node-labeler-configmap.yaml
+++ b/pkg/providers/disktype/pdcsi/node-labeler-configmap.yaml
@@ -1,0 +1,258 @@
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: machine-pd-compatibility
+  namespace: gce-pd-csi-driver
+data:
+  machine-pd-compatibility.json: |-
+    {
+      "a2": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-ml": true,
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "a3": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-ml": true,
+        "hyperdisk-throughput": true,
+        "pd-balanced": true,
+        "pd-ssd": true
+      },
+      "a4": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-ml": true
+      },
+      "a4x": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-ml": true,
+        "hyperdisk-throughput": true
+      },
+      "c2": {
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "c2d": {
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "c3": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-ml": true,
+        "hyperdisk-throughput": true,
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true
+      },
+      "c3d": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-ml": true,
+        "hyperdisk-throughput": true,
+        "pd-balanced": true,
+        "pd-ssd": true
+      },
+      "c4": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-throughput": true
+      },
+      "c4a": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-ml": true,
+        "hyperdisk-throughput": true,
+        "pd-balanced": true,
+        "pd-ssd": true
+      },
+      "c4d": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-throughput": true
+      },
+      "ct3": {
+        "pd-balanced": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "ct3p": {
+        "pd-balanced": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "ct4p": {
+        "hyperdisk-balanced": true,
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "ct5l": {
+        "hyperdisk-balanced": true,
+        "pd-balanced": true,
+        "pd-ssd": true
+      },
+      "ct5lp": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-ml": true,
+        "pd-balanced": true,
+        "pd-ssd": true
+      },
+      "ct5p": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-ml": true,
+        "pd-balanced": true,
+        "pd-ssd": true
+      },
+      "ct6e": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-ml": true
+      },
+      "e2": {
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "g2": {
+        "hyperdisk-ml": true,
+        "hyperdisk-throughput": true,
+        "pd-balanced": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "g4": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-ml": true,
+        "hyperdisk-throughput": true
+      },
+      "h3": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-throughput": true,
+        "pd-balanced": true
+      },
+      "h4d": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true
+      },
+      "m1": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-extreme": true,
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "m2": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-extreme": true,
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "m3": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-throughput": true,
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "m4": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-extreme": true
+      },
+      "n1": {
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "n2": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-throughput": true,
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "n2d": {
+        "hyperdisk-throughput": true,
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "n4": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-throughput": true,
+        "pd-balanced": true,
+        "pd-ssd": true
+      },
+      "n4a": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-ml": true,
+        "hyperdisk-throughput": true
+      },
+      "n4d": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-throughput": true
+      },
+      "t2a": {
+        "pd-balanced": true,
+        "pd-extreme": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "t2d": {
+        "hyperdisk-throughput": true,
+        "pd-balanced": true,
+        "pd-ssd": true,
+        "pd-standard": true
+      },
+      "tpu7x": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-ml": true,
+        "hyperdisk-throughput": true
+      },
+      "x4": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-extreme": true
+      },
+      "z3": {
+        "hyperdisk-balanced": true,
+        "hyperdisk-balanced-high-availability": true,
+        "hyperdisk-extreme": true,
+        "hyperdisk-throughput": true,
+        "pd-balanced": true,
+        "pd-ssd": true
+      }
+    }

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
 	pkgcache "github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/cache"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/disktype"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/gke"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/imagefamily"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/metadata"
@@ -862,10 +863,17 @@ func (p *DefaultProvider) setupInstanceMetadata(ctx context.Context, instanceMet
 
 	metadata.ApplyCustomMetadata(instanceMetadata, nodeClass.Spec.Metadata)
 
-	// GPU labels are injected last so that spec.gpuDriverVersion is always authoritative,
-	// overriding both the base template value and any spec.metadata entry.
+	// GPU labels override both the base template value and any spec.metadata entry.
 	if err := setupGPUMetadata(instanceMetadata, nodeClass, instanceType, isGPUInstance); err != nil {
 		return fmt.Errorf("failed to inject GPU metadata labels: %w", err)
+	}
+
+	diskLabels, ok := disktype.LabelsForInstanceType(instanceType.Name)
+	if !ok {
+		log.FromContext(ctx).V(1).Info("no PD disk compatibility labels found for instance type", "instanceType", instanceType.Name)
+	}
+	if err := metadata.SetDiskTypeLabels(instanceMetadata, diskLabels); err != nil {
+		return fmt.Errorf("failed to set disk type labels in metadata: %w", err)
 	}
 
 	return nil

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -1058,7 +1058,7 @@ func TestBuildInstance_UsesExternalCapacityTypeNotRecomputed(t *testing.T) {
 			Metadata: &compute.Metadata{
 				Items: []*compute.MetadataItems{
 					{Key: "kube-labels", Value: ptr.To("max-pods-per-node=110,max-pods=110")},
-					{Key: "kube-env", Value: ptr.To("KUBELET_ARGS: --max-pods=110\narch=amd64\n")},
+					{Key: "kube-env", Value: ptr.To("KUBELET_ARGS: --max-pods=110 --node-labels=max-pods-per-node=110,max-pods=110\narch=amd64\n")},
 					{Key: "kubelet-config", Value: ptr.To("nodeStatusUpdateFrequency: 10s\n")},
 				},
 			},
@@ -1359,6 +1359,55 @@ func kubeEnvFrom(t *testing.T, instance *compute.Instance) string {
 	}
 	t.Fatal("kube-env not found in instance metadata")
 	return ""
+}
+
+func TestBuildInstance_DiskTypeLabels(t *testing.T) {
+	t.Parallel()
+
+	p := makeProvider()
+	instanceType := &cloudprovider.InstanceType{
+		Name: "e2-standard-4",
+		Offerings: cloudprovider.Offerings{
+			{Available: true, Requirements: scheduling.NewRequirements(
+				scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, karpv1.CapacityTypeOnDemand),
+			)},
+		},
+		Requirements: scheduling.NewRequirements(
+			scheduling.NewRequirement(corev1.LabelArchStable, corev1.NodeSelectorOpIn, "amd64"),
+			scheduling.NewRequirement(v1alpha1.LabelInstanceFamily, corev1.NodeSelectorOpIn, "e2"),
+		),
+		Overhead: &cloudprovider.InstanceTypeOverhead{KubeReserved: corev1.ResourceList{}},
+	}
+
+	kubeLabels := "max-pods-per-node=110,max-pods=110,cloud.google.com/machine-family=n2,disk-type.gke.io/hyperdisk-throughput=true,disk-type.gke.io/pd-standard=true"
+	template := makeGPUTemplate(kubeLabels)
+	nodeClass := &v1alpha1.GCENodeClass{Spec: v1alpha1.GCENodeClassSpec{
+		Metadata: map[string]string{
+			"kube-labels": "disk-type.gke.io/hyperdisk-throughput=true",
+			"kube-env":    "disk-type.gke.io/hyperdisk-throughput=true",
+		},
+	}}
+	cluster := makeCluster("projects/p/global/networks/my-vpc", "regions/us-central1/subnetworks/my-subnet", "pods", false)
+
+	instance, err := p.buildInstance(
+		context.Background(),
+		spotOrOnDemandNodeClaim(),
+		nodeClass,
+		instanceType,
+		template,
+		cluster,
+		"default-pool", "us-central1-a", "karpenter-disk-label-test",
+		karpv1.CapacityTypeOnDemand,
+	)
+
+	require.NoError(t, err)
+	for _, value := range []string{kubeLabelsFrom(t, instance), kubeEnvFrom(t, instance)} {
+		require.Contains(t, value, "disk-type.gke.io/pd-balanced=true")
+		require.Contains(t, value, "disk-type.gke.io/pd-extreme=true")
+		require.Contains(t, value, "disk-type.gke.io/pd-ssd=true")
+		require.Contains(t, value, "disk-type.gke.io/pd-standard=true")
+		require.NotContains(t, value, "disk-type.gke.io/hyperdisk-throughput=true")
+	}
 }
 
 func TestBuildInstance_GPUDriverVersionLabel(t *testing.T) {

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -1384,7 +1384,7 @@ func TestBuildInstance_DiskTypeLabels(t *testing.T) {
 	nodeClass := &v1alpha1.GCENodeClass{Spec: v1alpha1.GCENodeClassSpec{
 		Metadata: map[string]string{
 			"kube-labels": "disk-type.gke.io/hyperdisk-throughput=true",
-			"kube-env":    "disk-type.gke.io/hyperdisk-throughput=true",
+			"kube-env":    "KUBELET_ARGS: --max-pods=110 --node-labels=disk-type.gke.io/hyperdisk-throughput=true\n",
 		},
 	}}
 	cluster := makeCluster("projects/p/global/networks/my-vpc", "regions/us-central1/subnetworks/my-subnet", "pods", false)

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/operator/options"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/providers/disktype"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils"
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils/localssd"
 )
@@ -141,6 +142,15 @@ func computeRequirements(mt *computepb.MachineType, offerings cloudprovider.Offe
 		scheduling.NewRequirement(v1alpha1.LabelInstanceGPUMemory, corev1.NodeSelectorOpDoesNotExist),
 		scheduling.NewRequirement(v1alpha1.LabelGKEAccelerator, corev1.NodeSelectorOpDoesNotExist),
 	)
+	for _, label := range disktype.AllLabels() {
+		requirements.Add(scheduling.NewRequirement(label, corev1.NodeSelectorOpDoesNotExist))
+	}
+	if diskLabels, ok := disktype.LabelsForInstanceType(lo.FromPtr(mt.Name)); ok {
+		for label := range diskLabels {
+			requirements.Get(label).Insert("true")
+		}
+	}
+
 	// Only add zone-id label when available in offerings. It may not be available if a user has upgraded from a
 	// previous version of Karpenter w/o zone-id support and the nodeclass vswitch status has not yet updated.
 	if zoneIDs := lo.FilterMap(offerings.Available(), func(o *cloudprovider.Offering, _ int) (string, bool) {

--- a/pkg/providers/instancetype/types_test.go
+++ b/pkg/providers/instancetype/types_test.go
@@ -186,6 +186,34 @@ func TestCalculateDiskConfiguration(t *testing.T) {
 	}
 }
 
+func TestComputeRequirementsIncludesDiskTypeCompatibility(t *testing.T) {
+	requirements := computeRequirements(&computepb.MachineType{
+		Name:      lo.ToPtr("e2-standard-4"),
+		GuestCpus: lo.ToPtr[int32](4),
+		MemoryMb:  lo.ToPtr[int32](16384),
+	}, cloudprovider.Offerings{{
+		Available: true,
+		Requirements: scheduling.NewRequirements(
+			scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-central1-a"),
+			scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, karpv1.CapacityTypeOnDemand),
+		),
+	}}, "us-central1")
+
+	assert.Equal(t, corev1.NodeSelectorOpIn, requirements.Get("disk-type.gke.io/pd-balanced").Operator())
+	assert.Equal(t, []string{"true"}, requirements.Get("disk-type.gke.io/pd-balanced").Values())
+	assert.Equal(t, corev1.NodeSelectorOpDoesNotExist, requirements.Get("disk-type.gke.io/hyperdisk-throughput").Operator())
+
+	supportedVolumeRequirement := scheduling.NewRequirements(
+		scheduling.NewRequirement("disk-type.gke.io/pd-balanced", corev1.NodeSelectorOpIn, "true"),
+	)
+	unsupportedVolumeRequirement := scheduling.NewRequirements(
+		scheduling.NewRequirement("disk-type.gke.io/hyperdisk-throughput", corev1.NodeSelectorOpIn, "true"),
+	)
+
+	assert.NoError(t, requirements.Intersects(supportedVolumeRequirement))
+	assert.Error(t, requirements.Intersects(unsupportedVolumeRequirement))
+}
+
 func TestComputeRequirements(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -40,9 +40,10 @@ var (
 	gkeProvisioningRegex    = regexp.MustCompile(`gke-provisioning=\w+`)
 	kubeEnvArchRegex        = regexp.MustCompile(`\barch=(amd64|arm64)\b`)
 	kubeEnvFamilyRegex      = regexp.MustCompile(`cloud\.google\.com/machine-family=[^,;\s]+`)
-	diskTypeLabelRegex      = regexp.MustCompile(`^disk-type\.gke\.io/`)
-	diskTypeLabelEntryRegex = regexp.MustCompile(`,?disk-type\.gke\.io/[^=,\s]+=[^,\s]*`)
-	registerWithTaintsRegex = regexp.MustCompile(`(--register-with-taints=)(\S+)`)
+	diskTypeLabelRegex            = regexp.MustCompile(`^disk-type\.gke\.io/`)
+	diskTypeLabelEntryRegex       = regexp.MustCompile(`,?disk-type\.gke\.io/[^=,\s]+=[^,\s]*`)
+	kubeEnvNodeLabelsEmptyOKRegex = regexp.MustCompile(`--node-labels=\S*`)
+	registerWithTaintsRegex       = regexp.MustCompile(`(--register-with-taints=)(\S+)`)
 	// kubeEnvNodeLabelsRegex matches the entire --node-labels=<value> flag in kube-env.
 	// The value is comma-separated Kubernetes labels with no whitespace.
 	kubeEnvNodeLabelsRegex    = regexp.MustCompile(`--node-labels=\S+`)
@@ -466,7 +467,7 @@ func replaceDiskTypeLabelsInKubeEnv(kubeEnv string, labels map[string]string) (s
 	}
 	stripped := diskTypeLabelEntryRegex.ReplaceAllString(kubeEnv, "")
 	stripped = strings.ReplaceAll(stripped, "--node-labels=,", "--node-labels=")
-	return regexp.MustCompile(`--node-labels=\S*`).ReplaceAllStringFunc(stripped, func(match string) string {
+	return kubeEnvNodeLabelsEmptyOKRegex.ReplaceAllStringFunc(stripped, func(match string) string {
 		return "--node-labels=" + replaceDiskTypeLabelsInNodeLabels(strings.TrimPrefix(match, "--node-labels="), labels)
 	}), nil
 }

--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -466,7 +466,7 @@ func replaceDiskTypeLabelsInKubeEnv(kubeEnv string, labels map[string]string) (s
 	}
 	stripped := diskTypeLabelEntryRegex.ReplaceAllString(kubeEnv, "")
 	stripped = strings.ReplaceAll(stripped, "--node-labels=,", "--node-labels=")
-	return kubeEnvNodeLabelsRegex.ReplaceAllStringFunc(stripped, func(match string) string {
+	return regexp.MustCompile(`--node-labels=\S*`).ReplaceAllStringFunc(stripped, func(match string) string {
 		return "--node-labels=" + replaceDiskTypeLabelsInCSV(strings.TrimPrefix(match, "--node-labels="), labels)
 	}), nil
 }

--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -441,7 +441,7 @@ func SetDiskTypeLabels(metadata *compute.Metadata, labels map[string]string) err
 		switch item.Key {
 		case "kube-labels":
 			kubeLabelsFound = true
-			item.Value = lo.ToPtr(replaceDiskTypeLabelsInCSV(lo.FromPtr(item.Value), labels))
+			item.Value = lo.ToPtr(replaceDiskTypeLabelsInNodeLabels(lo.FromPtr(item.Value), labels))
 		case "kube-env":
 			kubeEnvFound = true
 			updated, err := replaceDiskTypeLabelsInKubeEnv(lo.FromPtr(item.Value), labels)
@@ -467,11 +467,11 @@ func replaceDiskTypeLabelsInKubeEnv(kubeEnv string, labels map[string]string) (s
 	stripped := diskTypeLabelEntryRegex.ReplaceAllString(kubeEnv, "")
 	stripped = strings.ReplaceAll(stripped, "--node-labels=,", "--node-labels=")
 	return regexp.MustCompile(`--node-labels=\S*`).ReplaceAllStringFunc(stripped, func(match string) string {
-		return "--node-labels=" + replaceDiskTypeLabelsInCSV(strings.TrimPrefix(match, "--node-labels="), labels)
+		return "--node-labels=" + replaceDiskTypeLabelsInNodeLabels(strings.TrimPrefix(match, "--node-labels="), labels)
 	}), nil
 }
 
-func replaceDiskTypeLabelsInCSV(current string, labels map[string]string) string {
+func replaceDiskTypeLabelsInNodeLabels(current string, labels map[string]string) string {
 	parts := strings.Split(current, ",")
 	filtered := parts[:0]
 	for _, part := range parts {

--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/samber/lo"
@@ -39,6 +40,8 @@ var (
 	gkeProvisioningRegex    = regexp.MustCompile(`gke-provisioning=\w+`)
 	kubeEnvArchRegex        = regexp.MustCompile(`\barch=(amd64|arm64)\b`)
 	kubeEnvFamilyRegex      = regexp.MustCompile(`cloud\.google\.com/machine-family=[^,;\s]+`)
+	diskTypeLabelRegex      = regexp.MustCompile(`^disk-type\.gke\.io/`)
+	diskTypeLabelEntryRegex = regexp.MustCompile(`,?disk-type\.gke\.io/[^=,\s]+=[^,\s]*`)
 	registerWithTaintsRegex = regexp.MustCompile(`(--register-with-taints=)(\S+)`)
 	// kubeEnvNodeLabelsRegex matches the entire --node-labels=<value> flag in kube-env.
 	// The value is comma-separated Kubernetes labels with no whitespace.
@@ -425,6 +428,73 @@ func appendNodeLabelToKubeEnv(metadata *compute.Metadata, labelKey, labelValue s
 		return nil
 	}
 	return fmt.Errorf("kube-env metadata key not found in instance template")
+}
+
+func SetDiskTypeLabels(metadata *compute.Metadata, labels map[string]string) error {
+	if metadata == nil {
+		return fmt.Errorf("metadata must be non-nil")
+	}
+
+	kubeLabelsFound := false
+	kubeEnvFound := false
+	for _, item := range metadata.Items {
+		switch item.Key {
+		case "kube-labels":
+			kubeLabelsFound = true
+			item.Value = lo.ToPtr(replaceDiskTypeLabelsInCSV(lo.FromPtr(item.Value), labels))
+		case "kube-env":
+			kubeEnvFound = true
+			updated, err := replaceDiskTypeLabelsInKubeEnv(lo.FromPtr(item.Value), labels)
+			if err != nil {
+				return err
+			}
+			item.Value = lo.ToPtr(updated)
+		}
+	}
+	if !kubeLabelsFound {
+		return fmt.Errorf("kube-labels metadata key not found in instance template")
+	}
+	if !kubeEnvFound {
+		return fmt.Errorf("kube-env metadata key not found in instance template")
+	}
+	return nil
+}
+
+func replaceDiskTypeLabelsInKubeEnv(kubeEnv string, labels map[string]string) (string, error) {
+	if !strings.Contains(kubeEnv, "--node-labels=") {
+		return "", fmt.Errorf("--node-labels flag not found in kube-env KUBELET_ARGS")
+	}
+	stripped := diskTypeLabelEntryRegex.ReplaceAllString(kubeEnv, "")
+	stripped = strings.ReplaceAll(stripped, "--node-labels=,", "--node-labels=")
+	return kubeEnvNodeLabelsRegex.ReplaceAllStringFunc(stripped, func(match string) string {
+		return "--node-labels=" + replaceDiskTypeLabelsInCSV(strings.TrimPrefix(match, "--node-labels="), labels)
+	}), nil
+}
+
+func replaceDiskTypeLabelsInCSV(current string, labels map[string]string) string {
+	parts := strings.Split(current, ",")
+	filtered := parts[:0]
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, _, _ := strings.Cut(part, "=")
+		if diskTypeLabelRegex.MatchString(key) {
+			continue
+		}
+		filtered = append(filtered, part)
+	}
+
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		filtered = append(filtered, fmt.Sprintf("%s=%s", key, labels[key]))
+	}
+	return strings.Join(filtered, ",")
 }
 
 // SetGPUAcceleratorLabel sets cloud.google.com/gke-accelerator=<gpuName> in kube-labels and

--- a/pkg/providers/metadata/utils_test.go
+++ b/pkg/providers/metadata/utils_test.go
@@ -214,6 +214,57 @@ func kubeEnvValue(meta *compute.Metadata) string {
 	return ""
 }
 
+func TestSetDiskTypeLabelsReplacesInheritedLabels(t *testing.T) {
+	meta := gpuTestMeta(
+		"cloud.google.com/machine-family=n2,disk-type.gke.io/pd-balanced=true,disk-type.gke.io/pd-standard=true,karpenter.sh/nodepool=np",
+		"cloud.google.com/machine-family=n2,disk-type.gke.io/pd-standard=true,karpenter.sh/nodepool=np",
+	)
+
+	require.NoError(t, SetDiskTypeLabels(meta, map[string]string{
+		"disk-type.gke.io/hyperdisk-balanced": "true",
+		"disk-type.gke.io/pd-ssd":             "true",
+	}))
+
+	require.Equal(t,
+		"cloud.google.com/machine-family=n2,karpenter.sh/nodepool=np,disk-type.gke.io/hyperdisk-balanced=true,disk-type.gke.io/pd-ssd=true",
+		kubeLabelsValue(meta),
+	)
+	require.Contains(t, kubeEnvValue(meta), "--node-labels=cloud.google.com/machine-family=n2,karpenter.sh/nodepool=np,disk-type.gke.io/hyperdisk-balanced=true,disk-type.gke.io/pd-ssd=true")
+	require.NotContains(t, kubeEnvValue(meta), "disk-type.gke.io/pd-standard=true")
+}
+
+func TestSetDiskTypeLabelsHandlesMultilineKubeletArgs(t *testing.T) {
+	meta := &compute.Metadata{Items: []*compute.MetadataItems{
+		{Key: "kube-labels", Value: lo.ToPtr("cloud.google.com/machine-family=n2,disk-type.gke.io/pd-standard=true")},
+		{Key: "kube-env", Value: lo.ToPtr(`KUBELET_ARGS: --v=2 --cloud-provider=external
+  --cert-dir=/var/lib/kubelet/pki/ --node-labels=cloud.google.com/machine-family=n2,disk-type.gke.io/pd-standard=true,karpenter.sh/nodepool=np
+  --volume-plugin-dir=/home/kubernetes/flexvolume
+`)},
+	}}
+
+	require.NoError(t, SetDiskTypeLabels(meta, map[string]string{
+		"disk-type.gke.io/pd-balanced": "true",
+	}))
+
+	got := kubeEnvValue(meta)
+	require.Contains(t, got, "--node-labels=cloud.google.com/machine-family=n2,karpenter.sh/nodepool=np,disk-type.gke.io/pd-balanced=true")
+	require.Contains(t, got, "--volume-plugin-dir=/home/kubernetes/flexvolume")
+	require.NotContains(t, got, "disk-type.gke.io/pd-standard=true")
+}
+
+func TestSetDiskTypeLabelsAllowsEmptySet(t *testing.T) {
+	meta := gpuTestMeta(
+		"disk-type.gke.io/pd-standard=true,karpenter.sh/nodepool=np",
+		"disk-type.gke.io/pd-standard=true,karpenter.sh/nodepool=np",
+	)
+
+	require.NoError(t, SetDiskTypeLabels(meta, nil))
+
+	require.Equal(t, "karpenter.sh/nodepool=np", kubeLabelsValue(meta))
+	require.Contains(t, kubeEnvValue(meta), "--node-labels=karpenter.sh/nodepool=np")
+	require.NotContains(t, kubeEnvValue(meta), "disk-type.gke.io/")
+}
+
 func TestSetGPUDriverVersionLabel_InjectsLabel(t *testing.T) {
 	meta := gpuTestMeta("max-pods-per-node=110", "max-pods-per-node=110")
 	require.NoError(t, SetGPUDriverVersionLabel(meta, "latest"))

--- a/test/suites/storage/helpers_test.go
+++ b/test/suites/storage/helpers_test.go
@@ -18,11 +18,20 @@ package storage_test
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"time"
 
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/test/pkg/environment"
 )
 
 func expectDiskTypeLabelsAndTopology(ctx context.Context, nodeName string, expected []string) {
@@ -38,6 +47,69 @@ func expectDiskTypeLabelsAndTopology(ctx context.Context, nodeName string, expec
 		g.Expect(err).NotTo(HaveOccurred())
 		return topologyKeysForDriver(csiNode, "pd.csi.storage.gke.io")
 	}, "2m", "5s").Should(ContainElements(expected), "expected PDCSI topology keys for Node %s", nodeName)
+}
+
+func createDeploymentWithNodeSelector(ctx context.Context, name, appLabel, nodePoolName string, extraNodeSelector map[string]string) {
+	replicas := int32(1)
+	zero := int64(0)
+	nodeSelector := map[string]string{karpv1.NodePoolLabelKey: nodePoolName}
+	for key, value := range extraNodeSelector {
+		nodeSelector[key] = value
+	}
+
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: environment.TestNamespace},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": appLabel}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": appLabel}},
+				Spec: corev1.PodSpec{
+					NodeSelector:                  nodeSelector,
+					TerminationGracePeriodSeconds: &zero,
+					Tolerations: []corev1.Toleration{{
+						Key:      "karpenter-e2e/nodepool",
+						Value:    nodePoolName,
+						Effect:   corev1.TaintEffectNoSchedule,
+						Operator: corev1.TolerationOpEqual,
+					}},
+					Containers: []corev1.Container{{
+						Name:  "inflate",
+						Image: environment.PauseImage,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100m"),
+								corev1.ResourceMemory: resource.MustParse("128Mi"),
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	_ = env.KubeClient.AppsV1().Deployments(environment.TestNamespace).Delete(ctx, name, metav1.DeleteOptions{})
+	Eventually(func(g Gomega) {
+		_, err := env.KubeClient.AppsV1().Deployments(environment.TestNamespace).Get(ctx, name, metav1.GetOptions{})
+		g.Expect(errors.IsNotFound(err)).To(BeTrue(), "waiting for stale Deployment %s to be deleted", name)
+	}).WithTimeout(environment.NodeCleanupTimeout).WithPolling(environment.DefaultPollInterval).Should(Succeed())
+
+	_, err := env.KubeClient.AppsV1().Deployments(environment.TestNamespace).Create(ctx, dep, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "creating Deployment %s", name)
+}
+
+func expectNoNodeClaimForNodePool(ctx context.Context, nodePoolName string, duration time.Duration) {
+	Consistently(func(g Gomega) int {
+		claims, err := env.ListNodeClaims(ctx)
+		g.Expect(err).NotTo(HaveOccurred(), "listing NodeClaims")
+		count := 0
+		for _, claim := range claims {
+			if claim.GetLabels()[karpv1.NodePoolLabelKey] == nodePoolName {
+				count++
+			}
+		}
+		return count
+	}, duration, environment.DefaultPollInterval).Should(Equal(0), fmt.Sprintf("expected no NodeClaims for NodePool %s", nodePoolName))
 }
 
 func topologyKeysForDriver(csiNode *storagev1.CSINode, driverName string) []string {

--- a/test/suites/storage/helpers_test.go
+++ b/test/suites/storage/helpers_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage_test
+
+import (
+	"context"
+	"sort"
+
+	. "github.com/onsi/gomega"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func expectDiskTypeLabelsAndTopology(ctx context.Context, nodeName string, expected []string) {
+	node, err := env.KubeClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, label := range expected {
+		Expect(node.Labels).To(HaveKeyWithValue(label, "true"), "expected Node %s to have %s=true", nodeName, label)
+	}
+
+	Eventually(func(g Gomega) []string {
+		csiNode, err := env.KubeClient.StorageV1().CSINodes().Get(ctx, nodeName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
+		return topologyKeysForDriver(csiNode, "pd.csi.storage.gke.io")
+	}, "2m", "5s").Should(ContainElements(expected), "expected PDCSI topology keys for Node %s", nodeName)
+}
+
+func topologyKeysForDriver(csiNode *storagev1.CSINode, driverName string) []string {
+	for _, driver := range csiNode.Spec.Drivers {
+		if driver.Name == driverName {
+			keys := append([]string(nil), driver.TopologyKeys...)
+			sort.Strings(keys)
+			return keys
+		}
+	}
+	return nil
+}

--- a/test/suites/storage/storage_test.go
+++ b/test/suites/storage/storage_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	gcpv1alpha1 "github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/test/pkg/environment"
+)
+
+var _ = Describe("PDCSI Disk Type Labels", func() {
+	It("should register disk type labels and topology for the selected machine family", func(ctx SpecContext) {
+		prefix := "amd64-od-disk-labels"
+		suffix := environment.UniqueSuffix()
+		name := prefix + "-" + suffix
+
+		initialNodes := env.AllNodeNames(ctx)
+		var provisionedNodeName string
+		DeferCleanup(func(ctx context.Context) {
+			env.DeleteDeployment(ctx, name)
+			env.DeleteNodePool(ctx, name)
+			env.DeleteNodeClass(ctx, name)
+			if provisionedNodeName != "" {
+				Expect(env.WaitForNodeRemoval(ctx, provisionedNodeName)).To(Succeed())
+			}
+		})
+
+		env.CreateNodeClass(ctx, name, gcpv1alpha1.ImageFamilyContainerOptimizedOS)
+		env.WaitForNodeClassReady(ctx, name)
+		env.CreateNodePool(ctx, name, name, environment.TestCase{
+			CapacityType:  karpv1.CapacityTypeOnDemand,
+			Arch:          karpv1.ArchitectureAmd64,
+			Families:      []string{"e2"},
+			InstanceTypes: []string{"e2-standard-4"},
+		})
+		env.WaitForNodePoolReady(ctx, name)
+		env.CreateDeployment(ctx, name, name, name, karpv1.ArchitectureAmd64)
+
+		env.WaitForNodeClaimLaunched(ctx, name)
+		pod := env.WaitForRunningPod(ctx, name)
+		Expect(pod.Spec.NodeName).NotTo(BeEmpty())
+		provisionedNodeName = pod.Spec.NodeName
+
+		_, existedBefore := initialNodes[provisionedNodeName]
+		Expect(existedBefore).To(BeFalse(), "expected a newly provisioned node, got a pre-existing one")
+
+		expectDiskTypeLabelsAndTopology(ctx, provisionedNodeName, []string{
+			"disk-type.gke.io/pd-balanced",
+			"disk-type.gke.io/pd-extreme",
+			"disk-type.gke.io/pd-ssd",
+			"disk-type.gke.io/pd-standard",
+		})
+	}, SpecTimeout(15*time.Minute))
+})

--- a/test/suites/storage/storage_test.go
+++ b/test/suites/storage/storage_test.go
@@ -29,6 +29,72 @@ import (
 )
 
 var _ = Describe("PDCSI Disk Type Labels", func() {
+	It("should schedule a pod that requires a supported disk type label before the node exists", func(ctx SpecContext) {
+		prefix := "amd64-od-disk-label-sched"
+		suffix := environment.UniqueSuffix()
+		name := prefix + "-" + suffix
+
+		initialNodes := env.AllNodeNames(ctx)
+		var provisionedNodeName string
+		DeferCleanup(func(ctx context.Context) {
+			env.DeleteDeployment(ctx, name)
+			env.DeleteNodePool(ctx, name)
+			env.DeleteNodeClass(ctx, name)
+			if provisionedNodeName != "" {
+				Expect(env.WaitForNodeRemoval(ctx, provisionedNodeName)).To(Succeed())
+			}
+		})
+
+		env.CreateNodeClass(ctx, name, gcpv1alpha1.ImageFamilyContainerOptimizedOS)
+		env.WaitForNodeClassReady(ctx, name)
+		env.CreateNodePool(ctx, name, name, environment.TestCase{
+			CapacityType:  karpv1.CapacityTypeOnDemand,
+			Arch:          karpv1.ArchitectureAmd64,
+			Families:      []string{"e2"},
+			InstanceTypes: []string{"e2-standard-4"},
+		})
+		env.WaitForNodePoolReady(ctx, name)
+		createDeploymentWithNodeSelector(ctx, name, name, name, map[string]string{
+			"disk-type.gke.io/pd-balanced": "true",
+		})
+
+		env.WaitForNodeClaimLaunched(ctx, name)
+		pod := env.WaitForRunningPod(ctx, name)
+		Expect(pod.Spec.NodeName).NotTo(BeEmpty())
+		provisionedNodeName = pod.Spec.NodeName
+
+		_, existedBefore := initialNodes[provisionedNodeName]
+		Expect(existedBefore).To(BeFalse(), "expected a newly provisioned node, got a pre-existing one")
+		expectDiskTypeLabelsAndTopology(ctx, provisionedNodeName, []string{"disk-type.gke.io/pd-balanced"})
+	}, SpecTimeout(15*time.Minute))
+
+	It("should not schedule a pod that requires an unsupported disk type label", func(ctx SpecContext) {
+		prefix := "amd64-od-disk-label-no-sched"
+		suffix := environment.UniqueSuffix()
+		name := prefix + "-" + suffix
+
+		DeferCleanup(func(ctx context.Context) {
+			env.DeleteDeployment(ctx, name)
+			env.DeleteNodePool(ctx, name)
+			env.DeleteNodeClass(ctx, name)
+		})
+
+		env.CreateNodeClass(ctx, name, gcpv1alpha1.ImageFamilyContainerOptimizedOS)
+		env.WaitForNodeClassReady(ctx, name)
+		env.CreateNodePool(ctx, name, name, environment.TestCase{
+			CapacityType:  karpv1.CapacityTypeOnDemand,
+			Arch:          karpv1.ArchitectureAmd64,
+			Families:      []string{"e2"},
+			InstanceTypes: []string{"e2-standard-4"},
+		})
+		env.WaitForNodePoolReady(ctx, name)
+		createDeploymentWithNodeSelector(ctx, name, name, name, map[string]string{
+			"disk-type.gke.io/hyperdisk-throughput": "true",
+		})
+
+		expectNoNodeClaimForNodePool(ctx, name, 2*time.Minute)
+	}, SpecTimeout(5*time.Minute))
+
 	It("should register disk type labels and topology for the selected machine family", func(ctx SpecContext) {
 		prefix := "amd64-od-disk-labels"
 		suffix := environment.UniqueSuffix()

--- a/test/suites/storage/suite_test.go
+++ b/test/suites/storage/suite_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/test/pkg/environment"
+)
+
+var env *environment.Environment
+
+func TestStorage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	BeforeSuite(func() {
+		env = environment.NewEnvironment()
+	})
+	AfterSuite(func() {
+		if env != nil {
+			env.Cleanup()
+		}
+	})
+	RunSpecs(t, "Storage Suite")
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds GKE PD CSI disk-type compatibility labels for Karpenter-provisioned nodes.

This PR:
- sets `disk-type.gke.io/*=true` in `kube-labels` and kube-env `--node-labels`,
- exposes the same labels in `InstanceType.Requirements` for pre-launch scheduling,
- registers the labels as well-known Karpenter labels,
- updates PDCSI compatibility data through `make update`, sourced from `hack/pdcsi-data`,
- adds positive/negative storage e2e coverage for disk-type label scheduling,
- documents disk-type scheduling and the PD CSI `use-allowed-disk-topology` opt-in.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

Fixes #402

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

- PDCSI compatibility data is pinned by `hack/pdcsi-data/go.mod` and copied by `make update`.
- Non-GPU e2e suites passed on commit `5c2f1510`; later commits are docs/update-flow changes validated with focused provider tests and `make docs-lint`.
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds GKE PD CSI disk-type compatibility labels (`disk-type.gke.io/*=true`) to Karpenter-provisioned GKE nodes. Compatibility data is sourced from the upstream PDCSI node-labeler ConfigMap, vendored via a dedicated `hack/pdcsi-data` Go module and refreshed by `make update`.

- **Label injection**: `SetDiskTypeLabels` idempotently strips inherited disk-type labels and writes the correct set for the instance type's machine family into both `kube-labels` and `kube-env --node-labels=`.
- **Scheduling requirements**: `computeRequirements` marks every known disk-type label as `DoesNotExist` by default, then upgrades supported labels for the matched machine family to `In: [\"true\"]`, allowing pre-launch pod scheduling against disk-type nodeSelectors.
- **Well-known registration**: `disktype.AllLabels()` is inserted into `karpv1.WellKnownLabels` at startup, enabling Karpenter's DaemonSet overhead simulation to count pods using these labels as selectors.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change adds a new metadata-patching step that is well-tested, correctly ordered after all other patches, and gracefully handles unknown machine families by stripping any inherited disk-type labels rather than propagating potentially wrong ones.

The compatibility data load panics at startup if the embedded YAML is malformed — correct fail-fast behaviour — and the YAML is vendored and tested. The label-injection path is covered by unit tests across all three affected layers (disktype, metadata, instance), including edge cases for multiline KUBELET_ARGS, nil labels, and idempotent re-application. No runtime logic errors were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/providers/disktype/compatibility.go | New package: loads the upstream PDCSI node-labeler ConfigMap via embed.FS and exposes AllLabels(), LabelsForFamily(), and LabelsForInstanceType(). Logic is clean; LabelsForFamily returns a defensive copy, preventing callers from mutating the cached slice. |
| pkg/providers/metadata/utils.go | Adds SetDiskTypeLabels, replaceDiskTypeLabelsInKubeEnv, and replaceDiskTypeLabelsInNodeLabels; all three regexes are now package-level. Logic correctly handles the empty-value edge case (--node-labels= with all disk-type labels stripped) via the \S* regex and strips/re-adds labels idempotently. |
| pkg/providers/instance/instance.go | SetDiskTypeLabels is called last in setupInstanceMetadata (after ApplyCustomMetadata and GPU label injection), ensuring disk-type labels always reflect the actual instance type family regardless of user-supplied metadata overrides. |
| pkg/providers/instancetype/types.go | computeRequirements seeds all known disk-type labels as DoesNotExist, then upgrades the applicable family's labels to In:["true"] via the established Get().Insert() pattern also used for GPU labels. |
| pkg/apis/v1alpha1/labels.go | Registers all disk-type labels from AllLabels() as well-known Karpenter labels at init time, enabling DaemonSet overhead simulation for pods with disk-type nodeSelectors. |
| pkg/providers/disktype/compatibility_test.go | Good unit coverage: Family extraction, LabelsForFamily/LabelsForInstanceType happy-paths, unknown-family nil return, AllLabels sorted invariant, and a defensive-copy test. |
| pkg/providers/metadata/utils_test.go | New tests cover: replacement of inherited labels, multiline KUBELET_ARGS continuation lines, and the nil-labels (strip-all) case; all pass with correct assertions. |
| pkg/providers/instance/instance_test.go | TestBuildInstance_DiskTypeLabels exercises the full buildInstance path for e2-standard-4, confirming correct e2 labels are injected and non-e2 labels inherited from the template are stripped. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant IC as instance.Create()
    participant SIM as setupInstanceMetadata()
    participant DT as disktype pkg
    participant MU as metadata/utils.go

    IC->>SIM: buildInstance(instanceType, nodeClass, ...)
    SIM->>SIM: RemoveGKEBuiltinLabels
    SIM->>SIM: SetMaxPodsPerNode
    SIM->>SIM: PatchUnregisteredTaints
    SIM->>SIM: patchKubeEnv (arch/family/OS)
    SIM->>SIM: AppendNodeClaimLabel / AppendRegisteredLabel
    SIM->>SIM: ApplyCustomMetadata (user overrides)
    SIM->>SIM: setupGPUMetadata (GPU labels)
    SIM->>DT: LabelsForInstanceType(instanceType.Name)
    DT-->>SIM: "map[disk-type.gke.io/*]=true, ok"
    SIM->>MU: SetDiskTypeLabels(metadata, diskLabels)
    MU->>MU: replaceDiskTypeLabelsInNodeLabels(kube-labels)
    MU->>MU: replaceDiskTypeLabelsInKubeEnv(kube-env)
    MU-->>SIM: nil (success)
    SIM-->>IC: instance ready
```
</details>

<sub>Reviews (4): Last reviewed commit: ["chore: reuse kube-env node labels regex"](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/a0c03978c68e267758ccb38aaefd7f0230e40bf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35469296)</sub>

<!-- /greptile_comment -->