### PR TITLE
doc: Add the content that was accidentally deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/cloudpilot-ai/karpenter-provider-gcp/issues)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/karpenter-provider-gcp)](https://artifacthub.io/packages/search?repo=karpenter-provider-gcp)
 
+> [!NOTE]
+> A live version is now available.
+>
+> **Feedback welcome!** Join our [Slack](https://kubernetes.slack.com/archives/C0B20K4KWP8) to share your ideas, ask questions, and discuss with the community.
+
 ## Introduction
 
 Karpenter is an open-source node provisioning project built for Kubernetes.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Additional labels (applied directly, not via /kind):
  dependencies  — dependency update PRs
  release-prep  — release preparation PRs (see RELEASE.md)
-->

#### What this PR does / why we need it:
none

#### Related proposal (if applicable):
<!--
Link the proposal this PR implements, e.g. proposals/0001-short-title.md
Leave blank if this PR does not correspond to a design proposal.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #none

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores a `[!NOTE]` admonition block that was accidentally deleted from `README.md`, re-adding the announcement of the live version and a Slack community link.

- Adds back a GitHub-flavored Markdown `[!NOTE]` callout between the badge row and the Introduction section, containing a live-version notice and a Kubernetes Slack invite link.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — restores a small documentation block with no code or configuration changes.

The change is a pure documentation restoration of four lines: a GitHub admonition block with a live-version note and a Slack link. The Slack URL points to the established Kubernetes Slack workspace. Nothing in the codebase or runtime behavior is affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Restores a previously deleted `[!NOTE]` admonition block with a live version notice and Slack link — no functional or logic changes. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["doc: Add the content that was accidental..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/831912afcc5328b5f53417d5ef5cfa3d2521d6e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35298512)</sub>

<!-- /greptile_comment -->