### PR TITLE
test(e2e): make Karpenter namespace and deployment name configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,10 @@ E2E_SA_PATH      ?=
 E2E_LOCATION     ?=
 E2E_PREFIX       ?= karpenter-e2e
 E2E_REGION       ?= us-central1
-E2E_CLUSTER_NAME ?= $(E2E_PREFIX)-cluster
-E2E_PODS_RANGE   ?= $(E2E_PREFIX)-pods
+E2E_CLUSTER_NAME         ?= $(E2E_PREFIX)-cluster
+E2E_PODS_RANGE           ?= $(E2E_PREFIX)-pods
+E2E_KARPENTER_NAMESPACE  ?=
+E2E_KARPENTER_DEPLOYMENT ?=
 
 e2e-setup: require-e2e-vars ## Create (or reuse) the e2e GKE cluster and supporting GCP infra
 	GOOGLE_APPLICATION_CREDENTIALS=$(E2E_SA_PATH) \
@@ -135,6 +137,8 @@ e2e-tests: require-e2e-vars ## Run all e2e test suites in parallel (GINKGO_PROCS
 	CLUSTER_NAME=$(E2E_CLUSTER_NAME) \
 	CLUSTER_LOCATION=$(E2E_LOCATION) \
 	PODS_RANGE_NAME=$(E2E_PODS_RANGE) \
+	KARPENTER_NAMESPACE=$(E2E_KARPENTER_NAMESPACE) \
+	KARPENTER_DEPLOYMENT=$(E2E_KARPENTER_DEPLOYMENT) \
 	go run github.com/onsi/ginkgo/v2/ginkgo --procs=$(GINKGO_PROCS) --timeout=2h -v ./test/suites/...
 
 FOCUS ?=
@@ -145,6 +149,8 @@ e2e-test: require-e2e-vars ## Run a single e2e suite or focused spec (SUITE=<nam
 	CLUSTER_NAME=$(E2E_CLUSTER_NAME) \
 	CLUSTER_LOCATION=$(E2E_LOCATION) \
 	PODS_RANGE_NAME=$(E2E_PODS_RANGE) \
+	KARPENTER_NAMESPACE=$(E2E_KARPENTER_NAMESPACE) \
+	KARPENTER_DEPLOYMENT=$(E2E_KARPENTER_DEPLOYMENT) \
 	go run github.com/onsi/ginkgo/v2/ginkgo --procs=$(GINKGO_PROCS) --timeout=30m -v \
 	$(if $(FOCUS),--focus="$(FOCUS)",) \
 	$(if $(SUITE),./test/suites/$(SUITE)/,./test/suites/...)

--- a/test/pkg/environment/environment.go
+++ b/test/pkg/environment/environment.go
@@ -39,9 +39,16 @@ import (
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 
+var (
+	// KarpenterNamespace is the namespace the Karpenter controller runs in.
+	// Override with KARPENTER_NAMESPACE.
+	KarpenterNamespace = envOr("KARPENTER_NAMESPACE", "karpenter-system")
+	// KarpenterDeployment is the name of the Karpenter controller Deployment.
+	// Override with KARPENTER_DEPLOYMENT.
+	KarpenterDeployment = envOr("KARPENTER_DEPLOYMENT", "karpenter")
+)
+
 const (
-	KarpenterNamespace  = "karpenter-system"
-	KarpenterDeployment = "karpenter"
 	// TestNamespace is the namespace used by all e2e test suites for workloads.
 	TestNamespace = "karpenter-e2e-test"
 
@@ -298,4 +305,13 @@ func mustEnv(key string) string {
 		panic(fmt.Sprintf("required environment variable %q is not set", key))
 	}
 	return v
+}
+
+// envOr returns the value of the environment variable named by key, trimmed of
+// surrounding whitespace, or fallback when the variable is unset or empty.
+func envOr(key, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return fallback
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The e2e harness hard-codes the Karpenter controller namespace (`karpenter-system`) and Deployment name (`karpenter`) in `test/pkg/environment`. Clusters that install Karpenter into a different namespace can't run the suites: `waitForControllerReady` (and the repair suite) look in the wrong namespace and `BeforeSuite` fails before any spec runs.

This makes both overridable via environment variables, defaulting to the current values so existing CI behavior is unchanged:

- `KARPENTER_NAMESPACE` (default `karpenter-system`)
- `KARPENTER_DEPLOYMENT` (default `karpenter`)

Surfaced in the Makefile as `E2E_KARPENTER_NAMESPACE` / `E2E_KARPENTER_DEPLOYMENT`, passed through to both `e2e-tests` and `e2e-test`, following the same pattern as the existing `E2E_*` vars.

Implementation mirrors the existing `mustEnv` helper with a new optional `envOr(key, fallback)`; the two values move from `const` to package-level `var` initialized from env. Names are unchanged so the repair suite compiles untouched.

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs) - test-only harness change, no user-facing docs affected
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps) - no migration steps required

#### Special notes for your reviewer:

- Backward compatible: with no env vars set, `envOr` returns the defaults, so values are identical to the previous consts.
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

#### Does this PR introduce a user-facing change?
No

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the Karpenter controller namespace and deployment name configurable in the e2e test harness via `KARPENTER_NAMESPACE` and `KARPENTER_DEPLOYMENT` environment variables, defaulting to `karpenter-system` and `karpenter` respectively so existing CI is unaffected.

- Introduces `envOr(key, fallback string) string` helper (mirrors the existing `mustEnv` pattern) and converts two `const` declarations to package-level `var` in `environment.go` — all existing callers in `waitForControllerReady` and the repair suite compile and behave identically with no env vars set.
- Surfaces the two new variables in the `Makefile` as `E2E_KARPENTER_NAMESPACE` / `E2E_KARPENTER_DEPLOYMENT` (defaulting to empty, which the `envOr` fallback handles) and threads them through both `e2e-tests` and `e2e-test` targets.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is purely additive and backward-compatible, with no altered runtime behavior when env vars are absent.

Both variables retain their original hardcoded values as defaults through envOr, so all existing CI paths are unaffected. The new envOr helper is a straightforward, well-tested pattern already mirrored by mustEnv. The Makefile correctly forwards empty strings when the new vars are unset, which envOr handles by falling back to the defaults. No logic was removed or altered — only opt-in configurability was added.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/pkg/environment/environment.go | Moves KarpenterNamespace and KarpenterDeployment from const to var initialized via new envOr() helper; backward-compatible, defaults preserved, repair suite callers unaffected. |
| Makefile | Adds optional E2E_KARPENTER_NAMESPACE and E2E_KARPENTER_DEPLOYMENT vars (default empty → envOr falls back to hardcoded defaults) and passes them to both e2e-tests and e2e-test targets. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["make e2e-tests / e2e-test"] --> B["E2E_KARPENTER_NAMESPACE\n(default: empty)"]
    A --> C["E2E_KARPENTER_DEPLOYMENT\n(default: empty)"]
    B --> D["KARPENTER_NAMESPACE env var\npassed to test process"]
    C --> E["KARPENTER_DEPLOYMENT env var\npassed to test process"]
    D --> F["envOr('KARPENTER_NAMESPACE', 'karpenter-system')"]
    E --> G["envOr('KARPENTER_DEPLOYMENT', 'karpenter')"]
    F -->|"empty → fallback"| H["KarpenterNamespace = 'karpenter-system'"]
    F -->|"set → use value"| I["KarpenterNamespace = custom value"]
    G -->|"empty → fallback"| J["KarpenterDeployment = 'karpenter'"]
    G -->|"set → use value"| K["KarpenterDeployment = custom value"]
    H & I --> L["waitForControllerReady()"]
    J & K --> L
    H & I --> M["repair suite BeforeSuite"]
    J & K --> M
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(e2e): make Karpenter namespace and ..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/2598d912bad7a2f456dcdbcbe9adc8139d9177a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35328855)</sub>

<!-- /greptile_comment -->