### PR TITLE
Expand kubeletConfiguration documentation

### DIFF
--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -18,21 +18,82 @@ See [`examples/nodeclass/secondary-disk-gcenodeclass.yaml`](https://github.com/c
 
 ## Custom kubelet settings
 
-Override pod density and resource reservations:
+Configure kubelet behavior on provisioned nodes using `spec.kubeletConfiguration`. These settings apply at boot time and inform Karpenter's scheduler for bin-packing calculations.
+
+### Resource reservations
+
+Reserve resources for system daemons and Kubernetes components:
+
+```yaml
+kubeletConfiguration:
+  systemReserved:
+    cpu: "1"
+    memory: 1Gi
+  kubeReserved:
+    cpu: 500m
+    memory: 200Mi
+```
+
+- `systemReserved` — resources reserved for OS system daemons and kernel memory
+- `kubeReserved` — resources reserved for Kubernetes components (kubelet, container runtime)
+
+Both settings reduce node allocatable capacity. The scheduler accounts for these when bin-packing workloads.
+
+When you set a partial `kubeReserved` (for example, only `cpu`), Karpenter preserves provider-computed defaults for unspecified keys like `ephemeral-storage` based on boot disk size.
+
+### Eviction thresholds
+
+Configure kubelet eviction behavior:
+
+```yaml
+kubeletConfiguration:
+  evictionHard:
+    memory.available: 200Mi
+    nodefs.available: 10%
+  evictionSoft:
+    memory.available: 500Mi
+    nodefs.available: 15%
+  evictionSoftGracePeriod:
+    memory.available: 30s
+    nodefs.available: 1m
+  evictionMaxPodGracePeriod: 60
+```
+
+For scheduler bin-packing, only `evictionHard` for `memory.available` and `nodefs.available` reduce calculated allocatable capacity. This matches the AWS Karpenter provider and the [Kubernetes node-pressure-eviction documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/).
+
+`evictionSoft` thresholds are enforced by the kubelet at runtime but do not affect allocatable calculations.
+
+### Pod density
+
+Control the maximum number of pods per node:
 
 ```yaml
 kubeletConfiguration:
   maxPods: 50
-  systemReserved:
-    cpu: 100m
-    memory: 100Mi
-  kubeReserved:
-    cpu: 100m
-    memory: 200Mi
-  evictionHard:
-    memory.available: 200Mi
-    nodefs.available: 10%
+  podsPerCore: 8
 ```
+
+- `maxPods` — absolute cap on pods per node
+- `podsPerCore` — caps pods at `podsPerCore × cpu_cores`; cannot exceed `maxPods`
+
+Both values are reflected in `node.status.capacity.pods` and used by the scheduler.
+
+### Other settings
+
+Additional kubelet configuration options:
+
+```yaml
+kubeletConfiguration:
+  clusterDNS:
+    - 10.0.1.100
+  cpuCFSQuota: false
+  imageGCHighThresholdPercent: 85
+  imageGCLowThresholdPercent: 80
+```
+
+- `clusterDNS` — override cluster DNS server addresses
+- `cpuCFSQuota` — enable or disable CPU CFS quota enforcement for containers with CPU limits
+- `imageGCHighThresholdPercent` / `imageGCLowThresholdPercent` — control when kubelet garbage-collects unused container images
 
 ## Shielded VM
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/aaaddc2c-76e0-4af3-8a2c-725ed7f30cd0)

Expands the "Custom kubelet settings" section in docs/examples/advanced.md to explain how all kubeletConfiguration fields work now that they are actually honored by Karpenter (PR #400). Covers resource reservations, eviction thresholds, pod density controls, and other settings.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #400: fix(kubeletConfiguration): honour systemReserved, kubeReserved, eviction* and other fields](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/400)

---

_Tip: Whenever you leave a comment tagged `@Promptless` on a Promptless PR, Promptless will remember it for future suggestions 🧠_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands the "Custom kubelet settings" section in `docs/examples/advanced.md` into four documented sub-sections now that the corresponding fields are actually honoured by the GCP Karpenter provider (PR #400).

- **Resource reservations** (`systemReserved`, `kubeReserved`) — adds examples, explains allocatable impact, and correctly notes that partial `kubeReserved` merges with provider-computed defaults (e.g. `ephemeral-storage` derived from boot disk size), while `systemReserved` starts from an empty baseline.
- **Eviction thresholds** — accurately documents that only `evictionHard` for `memory.available` and `nodefs.available` reduce allocatable capacity for bin-packing; `evictionSoft` affects runtime kubelet behaviour only.
- **Pod density** — documents `maxPods` and `podsPerCore`; the claim that the result "cannot exceed `maxPods`" matches the `min(maxPods, podsPerCore × cpus)` logic in `pkg/providers/instancetype/overhead.go`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change; all technical claims were verified against the implementation in overhead.go and the CRD spec.

The documented behaviour for every field — allocatable reduction from evictionHard, the min(maxPods, podsPerCore×cores) pod cap, and partial kubeReserved merging with provider-computed defaults — matches the actual Go implementation. No code is modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/examples/advanced.md | Expands the 'Custom kubelet settings' section with four sub-sections covering resource reservations, eviction thresholds, pod density, and other options; no code changes |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    KC[kubeletConfiguration] --> RR[Resource Reservations]
    KC --> ET[Eviction Thresholds]
    KC --> PD[Pod Density]
    KC --> OS[Other Settings]

    RR --> SR[systemReserved\ncpu, memory]
    RR --> KR[kubeReserved\ncpu, memory]

    ET --> EH[evictionHard\nmemory.available, nodefs.available]
    ET --> ES[evictionSoft\nmemory.available, nodefs.available]
    ET --> EMP[evictionMaxPodGracePeriod]
    ET --> ESGP[evictionSoftGracePeriod]

    PD --> MP[maxPods]
    PD --> PPC[podsPerCore]

    OS --> DNS[clusterDNS]
    OS --> CFS[cpuCFSQuota]
    OS --> IGC[imageGCHighThresholdPercent\nimageGCLowThresholdPercent]

    SR -->|reduces| ALLOC[Node Allocatable Capacity]
    KR -->|merges with provider defaults, reduces| ALLOC
    EH -->|memory.available + nodefs.available reduce| ALLOC
    MP -->|min with podsPerCore×cores| PODS[node.status.capacity.pods]
    PPC -->|min with maxPods| PODS
    PODS -->|used by| SCHED[Karpenter Scheduler Bin-packing]
    ALLOC -->|used by| SCHED
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into promptless/expa..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/61e5a6172a4f77a8ef0a42e0197b5c4130dec758) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35358503)</sub>

<!-- /greptile_comment -->