### PR TITLE
fix: reject empty eviction thresholds

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -301,7 +301,7 @@ spec:
                     - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
                       rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
                     - message: evictionHard values must be a percentage or a resource.Quantity
-                      rule: self.all(x, self[x].matches('^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$'))
+                      rule: self.all(x, self[x].matches('^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%|(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$'))
                   evictionMaxPodGracePeriod:
                     description: |-
                       EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
@@ -319,7 +319,7 @@ spec:
                     - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
                       rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
                     - message: evictionSoft values must be a percentage or a resource.Quantity
-                      rule: self.all(x, self[x].matches('^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$'))
+                      rule: self.all(x, self[x].matches('^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%|(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$'))
                   evictionSoftGracePeriod:
                     additionalProperties:
                       type: string

--- a/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -298,7 +298,7 @@ spec:
                     - message: valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
                       rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
                     - message: evictionHard values must be a percentage or a resource.Quantity
-                      rule: self.all(x, self[x].matches('^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$'))
+                      rule: self.all(x, self[x].matches('^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%|(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$'))
                   evictionMaxPodGracePeriod:
                     description: |-
                       EvictionMaxPodGracePeriod is the maximum allowed grace period (in seconds) to use when terminating pods in
@@ -316,7 +316,7 @@ spec:
                     - message: valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']
                       rule: self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])
                     - message: evictionSoft values must be a percentage or a resource.Quantity
-                      rule: self.all(x, self[x].matches('^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%||(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$'))
+                      rule: self.all(x, self[x].matches('^((\d{1,2}(\.\d{1,2})?|100(\.0{1,2})?)%|(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?)$'))
                   evictionSoftGracePeriod:
                     additionalProperties:
                       type: string

--- a/pkg/apis/v1alpha1/gcenodeclass.go
+++ b/pkg/apis/v1alpha1/gcenodeclass.go
@@ -236,13 +236,13 @@ type KubeletConfiguration struct {
 	KubeReserved map[string]string `json:"kubeReserved,omitempty"`
 	// EvictionHard is the map of signal names to quantities that define hard eviction thresholds
 	// +kubebuilder:validation:XValidation:message="valid keys for evictionHard are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']",rule="self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])"
-	// +kubebuilder:validation:XValidation:message="evictionHard values must be a percentage or a resource.Quantity",rule="self.all(x, self[x].matches('^((\\d{1,2}(\\.\\d{1,2})?|100(\\.0{1,2})?)%||(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?)$'))"
+	// +kubebuilder:validation:XValidation:message="evictionHard values must be a percentage or a resource.Quantity",rule="self.all(x, self[x].matches('^((\\d{1,2}(\\.\\d{1,2})?|100(\\.0{1,2})?)%|(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?)$'))"
 	// +kubebuilder:validation:MaxProperties=10
 	// +optional
 	EvictionHard map[string]string `json:"evictionHard,omitempty"`
 	// EvictionSoft is the map of signal names to quantities that define soft eviction thresholds
 	// +kubebuilder:validation:XValidation:message="valid keys for evictionSoft are ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available']",rule="self.all(x, x in ['memory.available','nodefs.available','nodefs.inodesFree','imagefs.available','imagefs.inodesFree','pid.available'])"
-	// +kubebuilder:validation:XValidation:message="evictionSoft values must be a percentage or a resource.Quantity",rule="self.all(x, self[x].matches('^((\\d{1,2}(\\.\\d{1,2})?|100(\\.0{1,2})?)%||(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?)$'))"
+	// +kubebuilder:validation:XValidation:message="evictionSoft values must be a percentage or a resource.Quantity",rule="self.all(x, self[x].matches('^((\\d{1,2}(\\.\\d{1,2})?|100(\\.0{1,2})?)%|(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?)$'))"
 	// +kubebuilder:validation:MaxProperties=10
 	// +optional
 	EvictionSoft map[string]string `json:"evictionSoft,omitempty"`


### PR DESCRIPTION
## Summary
- remove the empty alternative from evictionHard and evictionSoft threshold validation
- regenerate the GCENodeClass CRDs in both Helm charts

Follow-up to https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/400#discussion_r3347332374

## Tests
- git diff --check
- rg -n "%\|\|" pkg/apis/v1alpha1/gcenodeclass.go charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml (no matches)
- node regex sample check
- go test ./pkg/apis/v1alpha1 ./pkg/providers/instancetype
- helm lint charts/karpenter
- helm lint charts/karpenter-crd

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where empty strings were accepted as valid eviction threshold values (`evictionHard`, `evictionSoft`) in the `GCENodeClass` CRD validation. The root cause was an unintended `||` (double pipe) in the CEL regex, which introduced an empty-string alternative between the percentage branch and the `resource.Quantity` branch.

- Removes the spurious `||` → `|` in the kubebuilder marker comment in `gcenodeclass.go` for both `EvictionHard` and `EvictionSoft` fields.
- Regenerates the CRD YAML for both Helm charts (`charts/karpenter` and `charts/karpenter-crd`) so the fix is consistently applied across all deployment paths.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-character regex correction that is consistently applied across the Go source and both generated CRD files.

The fix correctly collapses `||` to `|` in four regex patterns (two fields × two CRD outputs + the Go source), closing the loophole that allowed empty strings past validation. The regex is identical across the Go marker and both YAML artifacts, confirming the CRDs were properly regenerated from source. No other code paths are touched.

No files require special attention — all three changed files are in sync.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/apis/v1alpha1/gcenodeclass.go | Removes the empty-string alternative (`||` → `|`) from both the evictionHard and evictionSoft regex validators; the fix is minimal, targeted, and correct. |
| charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml | CRD YAML regenerated to match the Go source fix; both evictionHard and evictionSoft regex rules updated consistently. |
| charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml | CRD template regenerated to match the Go source fix; both evictionHard and evictionSoft regex rules updated consistently. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User applies GCENodeClass with evictionHard/evictionSoft] --> B{CEL validation rule}
    B --> C{Value matches regex?}
    C -->|Percentage branch| D["percentage e.g. '10%', '99.99%'"]
    C -->|Quantity branch| E["resource.Quantity e.g. '100Mi', '1Gi', '500'"]
    C -->|Empty string - OLD only| F["'' — was allowed by '||' — NOW REJECTED"]
    D --> G[Valid — accepted]
    E --> G
    F --> H[Invalid — rejected after fix]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reject empty eviction thresholds"](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/b2698898c5440600810f5a376e03a46baeabbbc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35358682)</sub>

<!-- /greptile_comment -->