### PR TITLE
Add Confidential VM to index page feature lists

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Key capabilities:
 
 ## GCP-specific features
 
-- **GCENodeClass** — a custom resource that captures all GCP-specific node configuration: image family, disk type and size, service account, network tags, Shielded VM settings, kubelet configuration, and network overrides
+- **GCENodeClass** — a custom resource that captures all GCP-specific node configuration: image family, disk type and size, service account, network tags, Shielded VM and Confidential VM settings, kubelet configuration, and network overrides
 - **Bootstrap pool discovery** — Karpenter discovers and reuses an existing cluster node pool for bootstrap metadata, avoiding the need to create dedicated template pools (see [Bootstrap pool selection](bootstrap-pool.md))
 - **Direct image catalog queries** — image resolution queries GCP image catalogs directly (`gke-node-images` for Container-Optimized OS, `ubuntu-os-gke-cloud` for Ubuntu), independent of the bootstrap pool
 - **Node repair policies** — integrates with GKE's node problem detection to trigger replacement of unhealthy nodes (see [Node repair](node-repair.md))
@@ -61,7 +61,7 @@ Key capabilities:
 - [GPU](examples/gpu.md) — GPU workloads
 - [Networking](examples/networking.md) — private nodes, custom subnetwork, pod IP range
 - [Static capacity](examples/static-capacity.md) — fixed node count with `spec.replicas`
-- [Advanced](examples/advanced.md) — kubelet config, Shielded VM, metadata, secondary disk, multiple pools
+- [Advanced](examples/advanced.md) — kubelet config, Shielded VM, Confidential VM, metadata, secondary disk, multiple pools
 
 ## Community
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/bbaa20e7-907f-4809-81a5-bd67398d1d66)

Mentions Confidential VM alongside Shielded VM in the GCENodeClass description and Advanced examples listing on the index page. This improves discoverability of the feature added in PR #391.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #391: feat: add confidentialInstanceType support to GCENodeClass](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/391)

---

_Tip: Request one-off documentation tasks in the Dashboard under [New Task](https://app.gopromptless.ai/new-task) 🚀_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves discoverability of the Confidential VM feature (added in PR #391) by mentioning it on the index page, both in the `GCENodeClass` capability description and in the Advanced examples listing.

- The `GCENodeClass` bullet now reads "Shielded VM and Confidential VM settings," matching the two separate sections already present in `docs/examples/advanced.md`.
- The Advanced example link description now lists "Confidential VM" as one of the topics covered, consistent with the existing `## Confidential VM` section in that page.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — pure documentation change with no code impact.

Both added mentions of "Confidential VM" are accurate: docs/examples/advanced.md already contains a full ## Confidential VM section documenting confidentialInstanceType, so the index page is now consistent with what the linked page actually covers.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/index.md | Two-line documentation update adding "Confidential VM" alongside "Shielded VM" in the GCENodeClass feature bullet and the Advanced examples description; both additions accurately reflect existing content in advanced.md. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[docs/index.md] -->|links to| B[docs/examples/advanced.md]
    B --> C[## Shielded VM]
    B --> D[## Confidential VM]
    A1["GCENodeClass bullet\n(was: 'Shielded VM settings'\nnow: 'Shielded VM and Confidential VM settings')"] -.->|updated| A
    A2["Advanced examples entry\n(added: 'Confidential VM')"] -.->|updated| A
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Add Confidential VM to index page featur..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/5f65f5f91af50e82420f9e19ef1268dbf451fb34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35447911)</sub>

<!-- /greptile_comment -->