### PR TITLE
Add disk type scheduling documentation

### DIFF
--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -128,6 +128,59 @@ If the chosen machine type does not support the requested confidential type, GCE
 
 The default `ContainerOptimizedOS` and `Ubuntu` images boot as Confidential VMs on supported families without any image change. GPU Confidential VMs are an exception: an A3 instance with an attached H100 GPU using Intel TDX requires a TDX-specific image (for example `cos-tdx-*`), which is not available through the `family` image selectors. Pin such an image by its full resource URL with `imageSelectorTerms[].id`; see the [GCP supported configurations](https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#supported-images-gpu).
 
+## Disk type scheduling
+
+Karpenter applies `disk-type.gke.io/*` labels to provisioned nodes based on the instance type's machine family. These labels indicate which persistent disk types the instance supports, enabling two capabilities:
+
+1. **NodePool requirements** — constrain scheduling to instance types that support specific disk types
+2. **PD CSI topology scheduling** — enable StorageClasses with `allowedTopologies` based on disk-type labels
+
+### Constraining instance types by disk support
+
+Use disk-type labels in NodePool requirements to ensure Karpenter selects only instance types that support the disk types your workloads need:
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: hyperdisk-workloads
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.gcp
+        kind: GCENodeClass
+        name: default-example
+      requirements:
+        - key: disk-type.gke.io/hyperdisk-balanced
+          operator: In
+          values: ["true"]
+```
+
+This NodePool provisions only instance types from families that support Hyperdisk Balanced (such as n2, n4, c3, c4). Instance types from families without Hyperdisk Balanced support (such as e2, n1) are excluded.
+
+### Available disk-type labels
+
+The supported labels correspond to GCP disk types:
+
+| Label | Disk type |
+| --- | --- |
+| `disk-type.gke.io/pd-standard` | Standard persistent disk |
+| `disk-type.gke.io/pd-balanced` | Balanced persistent disk |
+| `disk-type.gke.io/pd-ssd` | SSD persistent disk |
+| `disk-type.gke.io/pd-extreme` | Extreme persistent disk |
+| `disk-type.gke.io/hyperdisk-balanced` | Hyperdisk Balanced |
+| `disk-type.gke.io/hyperdisk-extreme` | Hyperdisk Extreme |
+| `disk-type.gke.io/hyperdisk-throughput` | Hyperdisk Throughput |
+| `disk-type.gke.io/hyperdisk-ml` | Hyperdisk ML |
+| `disk-type.gke.io/hyperdisk-balanced-high-availability` | Hyperdisk Balanced High Availability |
+
+Disk compatibility is determined at the machine family level (`n2`, `c3`, `e2`), not the specific instance size. See the [GCP machine family disk support matrix](https://cloud.google.com/compute/docs/disks#disk-types) for which families support which disk types.
+
+### PD CSI topology scheduling
+
+The disk-type labels are also published as topology keys by the GCE Persistent Disk CSI driver. StorageClasses with `allowedTopologies` or `volumeBindingMode: WaitForFirstConsumer` can use these labels to schedule volumes only on nodes that support the required disk type.
+
 ## Multiple NodePools
 
 Run independent pools for different workload tiers, each referencing a different GCENodeClass:


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/b9cede55-40dc-4c5a-8ff9-13131461e7f7)

Documents the new disk-type.gke.io/* labels that Karpenter applies to provisioned nodes, enabling users to constrain instance type selection by disk compatibility and leverage PD CSI topology scheduling.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #404: feat: set GKE disk type labels on Karpenter nodes](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/404)

---

_Tip: Tell your friends working on non-commercial open-source projects to apply for free Promptless access at [promptless.ai/oss](https://promptless.ai/oss) ❤️_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Disk type scheduling" section to `docs/examples/advanced.md` documenting new `disk-type.gke.io/*` node labels, an example NodePool that constrains scheduling to Hyperdisk-compatible families, a table of all supported labels, and a brief note on PD CSI topology scheduling.

- The new section describes `disk-type.gke.io/*` labels, a NodePool requirements example, and a reference table mapping label keys to GCP disk types.
- The trigger for this documentation is PR #404, which has not been merged; no code in the repository currently sets these labels on nodes.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The documentation describes a feature that does not yet exist in the codebase — merging it now will mislead users into writing NodePool requirements that silently match nothing.

The entire new section documents node labels (disk-type.gke.io/*) that are never set by Karpenter in the current code. PR #404, which was supposed to add this behavior, is not merged. A user following the example would add a NodePool requirement that can never be satisfied, preventing node provisioning with no obvious error.

docs/examples/advanced.md — the new section should be held until PR #404 lands and the labels are verifiably set by the provider.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/examples/advanced.md | Adds a "Disk type scheduling" section documenting disk-type.gke.io/* NodePool labels and PD CSI topology scheduling, but the underlying feature (PR #404) has not yet been merged — the labels are not set anywhere in the codebase. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as User / Workload
    participant KP as Karpenter Scheduler
    participant IT as InstanceType Provider
    participant GCE as GCE API
    participant Node as Provisioned Node

    User->>KP: "Pod with nodeSelector disk-type.gke.io/hyperdisk-balanced=true"
    KP->>IT: List compatible instance types
    Note over IT: computeRequirements() sets NO disk-type.gke.io/* labels today
    IT-->>KP: Instance types (no disk-type labels)
    KP-->>User: No matching instance type found (requirement unsatisfiable)
    Note over KP,Node: With PR 404 merged (future state):
    IT->>GCE: Fetch machine family capabilities
    GCE-->>IT: Disk support per family
    IT-->>KP: "Instance types WITH disk-type.gke.io/* requirements"
    KP->>GCE: Provision compatible instance
    GCE-->>Node: Node with disk-type labels applied
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fexamples%2Fadvanced.md%3A131-182%0A**Documentation%20references%20unimplemented%20feature**%0A%0AThis%20entire%20section%20documents%20%60disk-type.gke.io%2F*%60%20labels%2C%20but%20those%20labels%20are%20never%20set%20anywhere%20in%20the%20current%20codebase.%20The%20referenced%20trigger%2C%20PR%20%23404%20%28%60feat%3A%20set%20GKE%20disk%20type%20labels%20on%20Karpenter%20nodes%60%29%2C%20has%20not%20been%20merged%20into%20%60main%60.%20The%20%60computeRequirements%60%20function%20in%20%60pkg%2Fproviders%2Finstancetype%2Ftypes.go%60%2C%20which%20is%20the%20sole%20source%20of%20per-instance-type%20scheduling%20labels%2C%20contains%20no%20disk-type%20label%20logic.%20If%20a%20user%20adds%20the%20shown%20NodePool%20requirement%20today%20%28%60disk-type.gke.io%2Fhyperdisk-balanced%3A%20In%20%5B%22true%22%5D%60%29%2C%20no%20instance%20type%20will%20ever%20match%20it%20%28none%20carry%20that%20label%29%2C%20so%20Karpenter%20will%20never%20provision%20a%20node%20for%20those%20workloads.%0A%0A&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fexamples%2Fadvanced.md%3A131-182%0A**Documentation%20references%20unimplemented%20feature**%0A%0AThis%20entire%20section%20documents%20%60disk-type.gke.io%2F*%60%20labels%2C%20but%20those%20labels%20are%20never%20set%20anywhere%20in%20the%20current%20codebase.%20The%20referenced%20trigger%2C%20PR%20%23404%20%28%60feat%3A%20set%20GKE%20disk%20type%20labels%20on%20Karpenter%20nodes%60%29%2C%20has%20not%20been%20merged%20into%20%60main%60.%20The%20%60computeRequirements%60%20function%20in%20%60pkg%2Fproviders%2Finstancetype%2Ftypes.go%60%2C%20which%20is%20the%20sole%20source%20of%20per-instance-type%20scheduling%20labels%2C%20contains%20no%20disk-type%20label%20logic.%20If%20a%20user%20adds%20the%20shown%20NodePool%20requirement%20today%20%28%60disk-type.gke.io%2Fhyperdisk-balanced%3A%20In%20%5B%22true%22%5D%60%29%2C%20no%20instance%20type%20will%20ever%20match%20it%20%28none%20carry%20that%20label%29%2C%20so%20Karpenter%20will%20never%20provision%20a%20node%20for%20those%20workloads.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22promptless%2Fdisk-type-labels%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22promptless%2Fdisk-type-labels%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fexamples%2Fadvanced.md%3A131-182%0A**Documentation%20references%20unimplemented%20feature**%0A%0AThis%20entire%20section%20documents%20%60disk-type.gke.io%2F*%60%20labels%2C%20but%20those%20labels%20are%20never%20set%20anywhere%20in%20the%20current%20codebase.%20The%20referenced%20trigger%2C%20PR%20%23404%20%28%60feat%3A%20set%20GKE%20disk%20type%20labels%20on%20Karpenter%20nodes%60%29%2C%20has%20not%20been%20merged%20into%20%60main%60.%20The%20%60computeRequirements%60%20function%20in%20%60pkg%2Fproviders%2Finstancetype%2Ftypes.go%60%2C%20which%20is%20the%20sole%20source%20of%20per-instance-type%20scheduling%20labels%2C%20contains%20no%20disk-type%20label%20logic.%20If%20a%20user%20adds%20the%20shown%20NodePool%20requirement%20today%20%28%60disk-type.gke.io%2Fhyperdisk-balanced%3A%20In%20%5B%22true%22%5D%60%29%2C%20no%20instance%20type%20will%20ever%20match%20it%20%28none%20carry%20that%20label%29%2C%20so%20Karpenter%20will%20never%20provision%20a%20node%20for%20those%20workloads.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: add disk type scheduling section t..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/6e0f08c599af89bce6df4403dad76ff4f69976ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35470469)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->