### PR TITLE
chore: release 0.4.0

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,6 +5,9 @@
 
 ## Unreleased
 
+---
+## v0.4.0
+
 ### `kubeletConfiguration` fields now take effect
 
 `spec.kubeletConfiguration` fields on `GCENodeClass` that were previously accepted by the CRD but silently dropped at provisioning time are now applied to the kubelet on every Karpenter-provisioned node and to Karpenter's scheduler bin-packing. The previously honoured fields (`maxPods`) are unchanged.
@@ -19,6 +22,7 @@ Newly honoured fields:
 
 The CRD value schema for `systemReserved`, `kubeReserved`, `evictionHard`, and `evictionSoft` is now validated against the `resource.Quantity` regex (and percentage syntax for the eviction fields). Existing values that already parsed as `resource.Quantity` are unaffected.
 
+---
 ### GPU node provisioning (`gpuDriverVersion`)
 
 Karpenter now automatically sets the two node labels required by the GKE GPU software stack
@@ -295,6 +299,8 @@ The service account resolution order is now:
 
 The fallback to the template's service account list has been removed. If your NodeClass and operator flag are both unset, provisioned nodes will use the Compute Engine default SA. This matches GKE's own default, but GKE recommends using a dedicated SA with minimal permissions ([`roles/container.nodeServiceAccount`](https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa)) for production clusters. Set `DEFAULT_NODEPOOL_SERVICE_ACCOUNT` or `spec.serviceAccount` accordingly.
 
+---
+
 ## v0.3.0
 
 ### CRDs moved to a separate Helm chart (`karpenter-crd`)
@@ -408,8 +414,6 @@ The upgrade itself requires no action. The steps below are **optional** and only
 if you want to clean up orphaned instances that may have accumulated before this release
 (see #242). Future orphaned instances on new-style nodes are handled automatically.
 
----
-
 #### Step 1 (optional) — rotate live nodes
 
 Trigger a rolling replacement of your NodePools so that every replacement instance is
@@ -422,8 +426,6 @@ kubectl annotate nodepool <NODEPOOL_NAME> "karpenter.k8s.gcp/force-rollout=$(dat
 ```
 
 Repeat for each NodePool. Wait for all nodes to finish replacing before proceeding.
-
----
 
 #### Step 2 (optional) — find and delete orphaned instances
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,6 +6,7 @@
 ## Unreleased
 
 ---
+
 ## v0.4.0
 
 ### `kubeletConfiguration` fields now take effect


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR promotes the `## Unreleased` migration content into a formal `## v0.4.0` section and adjusts the `---` horizontal-rule separators throughout `MIGRATION.md` to match the new structure. It also removes two internal `---` dividers from within the v0.3.0 optional GC-cleanup steps.

- Adds `---` + `## v0.4.0` heading after the now-empty `## Unreleased` placeholder, and inserts `---` + `## v0.3.0` separator to clearly demarcate the two release sections.
- Removes two `---` dividers between \"Step 1 (optional)\" and \"Step 2 (optional)\" inside the v0.3.0 GC section, letting those subsections flow together under their headings without extra visual breaks.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to restructuring markdown headings and horizontal-rule dividers in MIGRATION.md with no code or configuration touched.

The diff is purely documentation: it adds a version heading, adjusts `---` separators, and removes two dividers inside an optional-steps subsection. No logic, configuration, or runtime behavior is changed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| MIGRATION.md | Adds v0.4.0 section heading and reorganizes `---` dividers; removes two internal dividers from v0.3.0's optional GC steps. Pure documentation change with no functional impact. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["# Migration Guide"] --> B["## Unreleased\n(empty placeholder)"]
    B --> C["---"]
    C --> D["## v0.4.0\n(NEW — promoted from Unreleased)"]
    D --> D1["### kubeletConfiguration fields"]
    D --> D2["### GPU node provisioning"]
    D --> D3["### Image selection redesigned"]
    D --> D4["### Image alias version pinning"]
    D --> D5["### Bootstrap pool discovery"]
    D --> D6["### Replace roles/compute.admin"]
    D --> D7["### Scope iam.serviceAccountUser"]
    D --> D8["### Node service account"]
    D --> E["---"]
    E --> F["## v0.3.0\n(existing)"]
    F --> F1["### CRDs moved to karpenter-crd"]
    F --> F2["### Network config and tags"]
    F --> F3["### GC controller\n(Step 1 & Step 2 — dividers removed)"]
    F --> G["---"]
    G --> H["## v0.2.0\n(existing)"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Update MIGRATION.md"](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/61bb81c33b97068c4d789cb3143cf1b3de677d4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35872349)</sub>

<!-- /greptile_comment -->