### PR TITLE
docs: fix ECR public release verification

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -95,12 +95,19 @@ gh release edit vX.Y.0 --repo cloudpilot-ai/karpenter-provider-gcp --draft=false
 ### 5. Verify published artefacts
 
 ```bash
+RELEASE_VERSION=X.Y.0
+
 # Docker image (ECR Public)
-curl -s "https://public.ecr.aws/v2/cloudpilotai/gcp/karpenter/tags/list"
+TOKEN=$(curl -s "https://public.ecr.aws/token/?scope=repository:cloudpilotai/gcp/karpenter:pull" | jq -r '.token')
+curl -fsS \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Accept: application/vnd.oci.image.index.v1+json" \
+  "https://public.ecr.aws/v2/cloudpilotai/gcp/karpenter/manifests/v${RELEASE_VERSION}" \
+  | jq -r '.mediaType'
 
 # Helm charts (GitHub Pages)
 curl -s "https://cloudpilot-ai.github.io/karpenter-provider-gcp/index.yaml" \
-  | grep -A3 "version: X.Y.0"
+  | grep -A3 "version: ${RELEASE_VERSION}"
 ```
 
 Also confirm the new version appears on [ArtifactHub](https://artifacthub.io/packages/helm/karpenter-provider-gcp/karpenter).


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Fixes the ECR Public image verification command in `RELEASE.md` by fetching an anonymous registry token before calling the tags API.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

N/A

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes the ECR Public image verification step in `RELEASE.md` by first fetching an anonymous bearer token before calling the manifests API, which resolves the previous unauthenticated request that would return a 401.

- Replaces the unauthenticated `tags/list` call with a two-step flow: fetch an anonymous pull token via the ECR Public token endpoint, then query the specific version's manifest using that token.
- Introduces a `RELEASE_VERSION` shell variable so the version placeholder is defined once and reused across both the Docker and Helm verification commands.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — documentation-only change with no impact on runtime behaviour.

The change is confined to a single shell snippet in a release runbook. The two-step token fetch is the correct approach for anonymous access to ECR Public's v2 API, and the use of a shared RELEASE_VERSION variable is a straightforward improvement. No production code is touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| RELEASE.md | Documentation-only fix: adds ECR Public token acquisition before manifests API call and extracts version into a reusable variable. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant R as Releaser (shell)
    participant ECR as ECR Public (public.ecr.aws)
    participant GHP as GitHub Pages

    R->>ECR: "GET /token/?scope=repository:cloudpilotai/gcp/karpenter:pull"
    ECR-->>R: "{"token": "<anon-token>"}"
    R->>ECR: "GET /v2/cloudpilotai/gcp/karpenter/manifests/v{RELEASE_VERSION}"
    ECR-->>R: OCI image index manifest (mediaType)
    R->>GHP: GET /karpenter-provider-gcp/index.yaml
    GHP-->>R: Helm index YAML
    R->>R: "grep -A3 "version: ${RELEASE_VERSION}""
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs: fix ECR public release verificatio..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/60091cb949769239f90af9a6dec45bc25fc43435) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35879709)</sub>

<!-- /greptile_comment -->