### PR TITLE
Fix bootstrap label and taint inheritance

### DIFF
--- a/docs/bootstrap-pool.md
+++ b/docs/bootstrap-pool.md
@@ -1,6 +1,6 @@
 # Bootstrap Pool Selection
 
-Karpenter requires a GKE node pool to read bootstrap metadata (instance templates, network configuration, kubelet settings). Rather than creating dedicated template pools, Karpenter discovers and reuses an existing cluster pool automatically.
+Karpenter requires a GKE node pool to read bootstrap metadata (instance templates and kubelet settings). Rather than creating dedicated template pools, Karpenter discovers and reuses an existing cluster pool automatically.
 
 ## How it works
 
@@ -52,6 +52,22 @@ Karpenter patches the source pool's kube-env metadata when provisioning nodes wi
 
 This allows a single source pool to bootstrap nodes of any OS and architecture combination.
 
+## Metadata sources
+
+Karpenter reads kubelet bootstrap metadata from the bootstrap pool's instance template. Other instance settings are derived from GCENodeClass, cluster config, or Karpenter/provider defaults.
+
+| Metadata                               | Source                                                                                                                 |
+|----------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| Kubelet configuration (max-pods, etc.) | Bootstrap pool template, then patched by GCENodeClass settings                                                         |
+| Subnetwork                             | GCENodeClass `spec.networkConfig.subnetwork`; defaults to cluster subnetwork from GKE cluster config                   |
+| Private-node setting                   | GCENodeClass `spec.networkConfig.enablePrivateNodes`; defaults to cluster private-node setting from GKE cluster config |
+| Service account                        | GCENodeClass `spec.serviceAccount`, `DEFAULT_NODEPOOL_SERVICE_ACCOUNT`, or Compute Engine default service account      |
+| Service account scopes                 | Karpenter sets `cloud-platform`                                                                                        |
+| Node labels                            | Rebuilt from Karpenter/provider target state                                                                           |
+| Node taints                            | Rebuilt from Karpenter/provider target state                                                                           |
+
+Labels and taints configured on the bootstrap pool (such as `workload=karpenter` or `dedicated=karpenter:NoSchedule`) are intentionally discarded. Karpenter-provisioned nodes receive only labels and taints that Karpenter explicitly controls.
+
 ## Upgrading from template pools
 
 Previous Karpenter versions created up to four template pools (`karpenter-default`, `karpenter-ubuntu`, `karpenter-cos-arm64`, `karpenter-ubuntu-arm64`) at startup. These are no longer needed.
@@ -96,7 +112,7 @@ If fallback creation fails due to org policy violations, the error message ident
 
 **Nodes fail to join the cluster after switching bootstrap pools**
 
-If the new source pool has materially different metadata (service account, scopes, labels), existing Karpenter nodes may have stale configuration. Trigger a rolling replacement:
+If the new source pool has materially different kubelet bootstrap metadata, existing Karpenter nodes may have stale configuration. Trigger a rolling replacement:
 
 ```bash
 kubectl annotate nodepool NODEPOOL_NAME "karpenter.k8s.gcp/force-rollout=$(date +%s)" --overwrite

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -393,7 +393,7 @@ func (p *DefaultProvider) tryCreateInstance(ctx context.Context, nodeClass *v1al
 		return nil, "", nil, &retryableError{err}
 	}
 
-	instance, retryable, err := p.getOrCreateInstance(ctx, nodeClaim, nodeClass, instanceType, template, clusterConfig, sourcePoolName, zone, capacityType)
+	instance, retryable, err := p.getOrCreateInstance(ctx, nodeClaim, nodeClass, instanceType, template, clusterConfig, zone, capacityType)
 	if err != nil {
 		if retryable {
 			return nil, "", nil, &retryableError{err}
@@ -404,7 +404,7 @@ func (p *DefaultProvider) tryCreateInstance(ctx context.Context, nodeClass *v1al
 	return instance, zone, template, nil
 }
 
-func (p *DefaultProvider) getOrCreateInstance(ctx context.Context, nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, template *compute.InstanceTemplate, clusterConfig *container.Cluster, nodePoolName, zone, capacityType string) (*compute.Instance, bool, error) {
+func (p *DefaultProvider) getOrCreateInstance(ctx context.Context, nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, template *compute.InstanceTemplate, clusterConfig *container.Cluster, zone, capacityType string) (*compute.Instance, bool, error) {
 	instanceName := fmt.Sprintf("karpenter-%s", nodeClaim.Name)
 	instance, exists, err := p.isInstanceExists(ctx, zone, instanceName)
 	if err != nil {
@@ -416,7 +416,7 @@ func (p *DefaultProvider) getOrCreateInstance(ctx context.Context, nodeClaim *ka
 		return instance, false, nil
 	}
 
-	instance, err = p.buildInstance(ctx, nodeClaim, nodeClass, instanceType, template, clusterConfig, nodePoolName, zone, instanceName, capacityType)
+	instance, err = p.buildInstance(ctx, nodeClaim, nodeClass, instanceType, template, clusterConfig, zone, instanceName, capacityType)
 	if err != nil {
 		return nil, false, fmt.Errorf("building instance %s: %w", instanceName, err)
 	}
@@ -669,7 +669,7 @@ func (p *DefaultProvider) renderDiskProperties(instanceType *cloudprovider.Insta
 	return attachedDisks, nil
 }
 
-func (p *DefaultProvider) buildInstance(ctx context.Context, nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, template *compute.InstanceTemplate, clusterConfig *container.Cluster, nodePoolName, zone, instanceName, capacityType string) (*compute.Instance, error) {
+func (p *DefaultProvider) buildInstance(ctx context.Context, nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, template *compute.InstanceTemplate, clusterConfig *container.Cluster, zone, instanceName, capacityType string) (*compute.Instance, error) {
 	attachedDisks, err := p.renderDiskProperties(instanceType, nodeClass, zone)
 	if err != nil {
 		return nil, fmt.Errorf("rendering disk properties: %w", err)
@@ -678,7 +678,7 @@ func (p *DefaultProvider) buildInstance(ctx context.Context, nodeClaim *karpv1.N
 	isGPUInstance := len(template.Properties.GuestAccelerators) > 0 || instanceTypeHasGPU(instanceType)
 
 	// Setup metadata
-	if err := p.setupInstanceMetadata(ctx, template.Properties.Metadata, nodeClass, instanceType, nodeClaim, nodePoolName, zone, capacityType, isGPUInstance); err != nil {
+	if err := p.setupInstanceMetadata(ctx, template.Properties.Metadata, nodeClass, instanceType, nodeClaim, zone, capacityType, isGPUInstance); err != nil {
 		return nil, fmt.Errorf("setting up instance metadata: %w", err)
 	}
 
@@ -830,13 +830,7 @@ func podCIDRRange(maxPods int32) int32 {
 }
 
 // setupInstanceMetadata configures all metadata-related settings for the instance.
-// sourcePoolName is the pool whose template was used as the bootstrap source; it is
-// stripped from GKE built-in labels so the provisioned node is not associated with it.
-func (p *DefaultProvider) setupInstanceMetadata(ctx context.Context, instanceMetadata *compute.Metadata, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, nodeClaim *karpv1.NodeClaim, sourcePoolName string, zone string, capacityType string, isGPUInstance bool) error {
-	if err := metadata.RemoveGKEBuiltinLabels(instanceMetadata, sourcePoolName); err != nil {
-		return fmt.Errorf("failed to remove GKE builtin labels from metadata: %w", err)
-	}
-
+func (p *DefaultProvider) setupInstanceMetadata(ctx context.Context, instanceMetadata *compute.Metadata, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, nodeClaim *karpv1.NodeClaim, zone string, capacityType string, isGPUInstance bool) error {
 	if err := metadata.SetNodeLabels(instanceMetadata, metadata.BaselineKubeLabels(nodeClaim, nodeClass), metadata.BaselineKubeEnvLabels(nodeClaim, nodeClass)); err != nil {
 		return fmt.Errorf("failed to set baseline node labels in metadata: %w", err)
 	}
@@ -860,6 +854,12 @@ func (p *DefaultProvider) setupInstanceMetadata(ctx context.Context, instanceMet
 	metadata.AppendSecondaryBootDisks(p.projectID, nodeClass, instanceMetadata)
 
 	metadata.ApplyCustomMetadata(instanceMetadata, nodeClass.Spec.Metadata)
+
+	// Custom metadata may replace kube-labels or kube-env; re-apply target-derived
+	// instance-type labels so Kubernetes scheduling labels remain accurate.
+	if err := metadata.PatchKubeEnvForInstanceType(instanceMetadata, instanceType); err != nil {
+		return fmt.Errorf("failed to patch kube-env metadata for instance type: %w", err)
+	}
 
 	// GPU labels override both the base template value and any spec.metadata entry.
 	if err := setupGPUMetadata(instanceMetadata, nodeClass, instanceType, isGPUInstance); err != nil {

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -19,6 +19,8 @@ package instance
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base32"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -676,7 +678,7 @@ func (p *DefaultProvider) buildInstance(ctx context.Context, nodeClaim *karpv1.N
 	isGPUInstance := len(template.Properties.GuestAccelerators) > 0 || instanceTypeHasGPU(instanceType)
 
 	// Setup metadata
-	if err := p.setupInstanceMetadata(ctx, template.Properties.Metadata, nodeClass, instanceType, nodeClaim, nodePoolName, capacityType, isGPUInstance); err != nil {
+	if err := p.setupInstanceMetadata(ctx, template.Properties.Metadata, nodeClass, instanceType, nodeClaim, nodePoolName, zone, capacityType, isGPUInstance); err != nil {
 		return nil, fmt.Errorf("setting up instance metadata: %w", err)
 	}
 
@@ -692,7 +694,7 @@ func (p *DefaultProvider) buildInstance(ctx context.Context, nodeClaim *karpv1.N
 		NetworkInterfaces: p.setupNetworkInterfaces(clusterConfig, nodeClass),
 		ServiceAccounts:   serviceAccounts,
 		Metadata:          template.Properties.Metadata,
-		Labels:            p.initializeInstanceLabels(nodeClass),
+		Labels:            initializeInstanceLabels(nodeClass),
 		Scheduling:        setupScheduling(capacityType),
 		Tags:              buildInstanceTags(p.clusterName, clusterConfig.Id, nodeClass.Spec.NetworkTags),
 	}
@@ -726,7 +728,7 @@ func (p *DefaultProvider) buildInstance(ctx context.Context, nodeClaim *karpv1.N
 	p.configureConfidentialInstance(instance, nodeClass)
 
 	// Setup karpenter built-in labels
-	p.setupInstanceLabels(instance, nodeClaim, nodeClass, instanceType)
+	p.setupInstanceLabels(instance, nodeClaim, nodeClass, clusterConfig.Id)
 
 	return instance, nil
 }
@@ -830,9 +832,13 @@ func podCIDRRange(maxPods int32) int32 {
 // setupInstanceMetadata configures all metadata-related settings for the instance.
 // sourcePoolName is the pool whose template was used as the bootstrap source; it is
 // stripped from GKE built-in labels so the provisioned node is not associated with it.
-func (p *DefaultProvider) setupInstanceMetadata(ctx context.Context, instanceMetadata *compute.Metadata, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, nodeClaim *karpv1.NodeClaim, sourcePoolName string, capacityType string, isGPUInstance bool) error {
+func (p *DefaultProvider) setupInstanceMetadata(ctx context.Context, instanceMetadata *compute.Metadata, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, nodeClaim *karpv1.NodeClaim, sourcePoolName string, zone string, capacityType string, isGPUInstance bool) error {
 	if err := metadata.RemoveGKEBuiltinLabels(instanceMetadata, sourcePoolName); err != nil {
 		return fmt.Errorf("failed to remove GKE builtin labels from metadata: %w", err)
+	}
+
+	if err := metadata.SetNodeLabels(instanceMetadata, metadata.BaselineKubeLabels(nodeClaim, nodeClass), metadata.BaselineKubeEnvLabels(nodeClaim, nodeClass)); err != nil {
+		return fmt.Errorf("failed to set baseline node labels in metadata: %w", err)
 	}
 
 	if err := metadata.SetMaxPodsPerNode(instanceMetadata, nodeClass); err != nil {
@@ -843,22 +849,14 @@ func (p *DefaultProvider) setupInstanceMetadata(ctx context.Context, instanceMet
 		return fmt.Errorf("failed to render kubelet config metadata: %w", err)
 	}
 
-	if err := metadata.PatchUnregisteredTaints(instanceMetadata); err != nil {
-		return fmt.Errorf("failed to append unregistered taint to kube-env: %w", err)
+	if err := metadata.SetRegisterWithTaints(instanceMetadata, []string{strings.TrimPrefix(metadata.UnregisteredTaintArg, "--register-with-taints=")}); err != nil {
+		return fmt.Errorf("failed to set register-with-taints in metadata: %w", err)
 	}
 
-	if err := p.patchKubeEnv(ctx, instanceMetadata, nodeClass, instanceType); err != nil {
+	if err := p.patchTargetKubeEnv(ctx, instanceMetadata, nodeClass, instanceType, zone, capacityType); err != nil {
 		return err
 	}
 
-	if capacityType == karpv1.CapacityTypeSpot {
-		if err := metadata.SetProvisioningModel(instanceMetadata, capacityType); err != nil {
-			return fmt.Errorf("failed to set provisioning model in metadata: %w", err)
-		}
-	}
-
-	metadata.AppendNodeClaimLabel(nodeClaim, nodeClass, instanceMetadata)
-	metadata.AppendRegisteredLabel(instanceMetadata)
 	metadata.AppendSecondaryBootDisks(p.projectID, nodeClass, instanceMetadata)
 
 	metadata.ApplyCustomMetadata(instanceMetadata, nodeClass.Spec.Metadata)
@@ -876,6 +874,30 @@ func (p *DefaultProvider) setupInstanceMetadata(ctx context.Context, instanceMet
 		return fmt.Errorf("failed to set disk type labels in metadata: %w", err)
 	}
 
+	return nil
+}
+
+func (p *DefaultProvider) patchTargetKubeEnv(ctx context.Context, instanceMetadata *compute.Metadata, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType, zone, capacityType string) error {
+	if err := p.patchKubeEnv(ctx, instanceMetadata, nodeClass, instanceType); err != nil {
+		return err
+	}
+	if err := metadata.SetKubeEnvZone(instanceMetadata, zone); err != nil {
+		return fmt.Errorf("failed to set kube-env zone in metadata: %w", err)
+	}
+	if err := setProvisioningModel(instanceMetadata, capacityType); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setProvisioningModel(instanceMetadata *compute.Metadata, capacityType string) error {
+	model := "standard"
+	if capacityType == karpv1.CapacityTypeSpot {
+		model = capacityType
+	}
+	if err := metadata.SetProvisioningModel(instanceMetadata, model); err != nil {
+		return fmt.Errorf("failed to set provisioning model in metadata: %w", err)
+	}
 	return nil
 }
 
@@ -1005,8 +1027,10 @@ func setupScheduling(capacityType string) *compute.Scheduling {
 	return sched
 }
 
-// initializeInstanceLabels initializes the instance labels map
-func (p *DefaultProvider) initializeInstanceLabels(nodeClass *v1alpha1.GCENodeClass) map[string]string {
+// initializeInstanceLabels initializes the instance labels map from target-owned
+// labels only. Template labels come from the bootstrap source pool and must not
+// be inherited by the provisioned instance.
+func initializeInstanceLabels(nodeClass *v1alpha1.GCENodeClass) map[string]string {
 	labels := make(map[string]string)
 	for k, v := range nodeClass.Spec.Labels {
 		labels[k] = v
@@ -1019,8 +1043,13 @@ func (p *DefaultProvider) configureInstanceCapacityProvision(instance *compute.I
 	if instance.Scheduling == nil {
 		instance.Scheduling = &compute.Scheduling{}
 	}
+	if instance.Labels == nil {
+		instance.Labels = map[string]string{}
+	}
+	instance.Labels["goog-gke-node-pool-provisioning-model"] = "on-demand"
 
 	if capacityType == karpv1.CapacityTypeSpot {
+		instance.Labels["goog-gke-node-pool-provisioning-model"] = "spot"
 		instance.Scheduling.ProvisioningModel = "SPOT"
 		instance.Scheduling.Preemptible = true
 		instance.Scheduling.AutomaticRestart = ptr.To(false)
@@ -1045,25 +1074,32 @@ func (p *DefaultProvider) configureConfidentialInstance(instance *compute.Instan
 	instance.Scheduling.OnHostMaintenance = "TERMINATE"
 }
 
-// setupInstanceLabels writes all GCE labels for a new instance. Cluster-identity labels
-// (goog-k8s-cluster-name and goog-k8s-cluster-location) are always written last so that
-// user-supplied NodePool requirement labels with the same key cannot overwrite them.
-func (p *DefaultProvider) setupInstanceLabels(instance *compute.Instance, nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, instanceType *cloudprovider.InstanceType) {
+// setupInstanceLabels writes controller-owned GCE labels for a new instance.
+// Kubernetes node labels are rebuilt separately in bootstrap metadata and must
+// not be copied to GCE instance labels.
+func (p *DefaultProvider) setupInstanceLabels(instance *compute.Instance, nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, clusterID string) {
+	if id, ok := clusterIDBase32(clusterID); ok {
+		instance.Labels["goog-gke-cluster-id-base32"] = id
+	}
+	instance.Labels["goog-gke-cost-management"] = ""
+	instance.Labels["goog-gke-node"] = ""
 	instance.Labels[utils.SanitizeGCELabelValue(utils.LabelNodePoolKey)] = nodeClaim.Labels[karpv1.NodePoolLabelKey]
 	instance.Labels[utils.SanitizeGCELabelValue(utils.LabelGCENodeClassKey)] = nodeClass.Name
 
-	for key, req := range instanceType.Requirements {
-		if req.Operator() == corev1.NodeSelectorOpIn && req.Len() == 1 {
-			// GCP label keys only allow [a-z0-9_-]; Kubernetes label keys may contain '/' and '.'.
-			instance.Labels[utils.SanitizeGCELabelValue(key)] = utils.SanitizeGCELabelValue(req.Any())
-		}
-	}
-
-	// Stamp both cluster-identity labels last so NodePool labels cannot overwrite them.
+	// Do not set goog-k8s-node-pool-name. That is GKE-managed node pool identity;
+	// Karpenter ownership is tracked with karpenter.sh/nodepool instead.
 	// LabelClusterNameKey is used by the syncInstances API filter; LabelClusterLocationKey
 	// is checked by belongsToCluster to distinguish same-named clusters in different locations.
 	instance.Labels[utils.SanitizeGCELabelValue(utils.LabelClusterNameKey)] = p.clusterName
 	instance.Labels[utils.SanitizeGCELabelValue(utils.LabelClusterLocationKey)] = p.clusterLocation
+}
+
+func clusterIDBase32(clusterID string) (string, bool) {
+	decoded, err := hex.DecodeString(clusterID)
+	if err != nil || len(decoded) == 0 {
+		return "", false
+	}
+	return strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(decoded)), true
 }
 
 // belongsToCluster reports whether inst should be tracked in this controller's instance

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -142,6 +142,71 @@ func writeJSON(w http.ResponseWriter, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
+func metadataValue(meta *compute.Metadata, key string) string {
+	for _, item := range meta.Items {
+		if item.Key == key {
+			return ptr.Deref(item.Value, "")
+		}
+	}
+	return ""
+}
+
+func TestSetupInstanceMetadata_RebuildsLabelsAndTaintsFromTarget(t *testing.T) {
+	p := &DefaultProvider{}
+	meta := &compute.Metadata{Items: []*compute.MetadataItems{
+		{Key: "kube-labels", Value: ptr.To("cloud.google.com/gke-nodepool=bootstrap,workload=karpenter,max-pods-per-node=110")},
+		{Key: "kube-env", Value: ptr.To("KUBELET_ARGS: --v=2 --max-pods=110 --node-labels=cloud.google.com/gke-nodepool=bootstrap,workload=karpenter,max-pods-per-node=110 --register-with-taints=dedicated=karpenter:NoSchedule\n")},
+		{Key: "kubelet-config", Value: ptr.To("maxPods: 110\n")},
+	}}
+	maxPods := int32(32)
+	nodeClass := &v1alpha1.GCENodeClass{}
+	nodeClass.Name = "default"
+	nodeClass.Spec.KubeletConfiguration = &v1alpha1.KubeletConfiguration{MaxPods: &maxPods}
+	nodeClaim := &karpv1.NodeClaim{}
+	nodeClaim.Labels = map[string]string{karpv1.NodePoolLabelKey: "default"}
+	instanceType := &cloudprovider.InstanceType{
+		Name: "e2-standard-2",
+		Requirements: scheduling.NewRequirements(
+			scheduling.NewRequirement(corev1.LabelArchStable, corev1.NodeSelectorOpIn, "amd64"),
+			scheduling.NewRequirement(v1alpha1.LabelInstanceFamily, corev1.NodeSelectorOpIn, "e2"),
+		),
+		Overhead: &cloudprovider.InstanceTypeOverhead{KubeReserved: corev1.ResourceList{}},
+	}
+
+	require.NoError(t, p.setupInstanceMetadata(context.Background(), meta, nodeClass, instanceType, nodeClaim, "bootstrap", "europe-west4-c", karpv1.CapacityTypeOnDemand, false))
+
+	kubeLabels := metadataValue(meta, "kube-labels")
+	kubeEnv := metadataValue(meta, "kube-env")
+	require.NotContains(t, kubeLabels, "workload=karpenter")
+	require.NotContains(t, kubeEnv, "workload=karpenter")
+	require.NotContains(t, kubeEnv, "dedicated=karpenter:NoSchedule")
+	require.NotContains(t, kubeLabels, "cloud.google.com/gke-nodepool=bootstrap")
+	require.NotContains(t, kubeEnv, "cloud.google.com/gke-nodepool=bootstrap")
+	require.Contains(t, kubeLabels, "max-pods-per-node=32")
+	require.Contains(t, kubeEnv, "max-pods-per-node=32")
+	require.Contains(t, kubeEnv, "max-pods=32")
+	require.Contains(t, kubeLabels, "cloud.google.com/gke-os-distribution=cos")
+	require.Contains(t, kubeEnv, "cloud.google.com/gke-os-distribution=cos")
+	require.Contains(t, kubeLabels, karpv1.NodePoolLabelKey+"=default")
+	require.Contains(t, kubeLabels, v1alpha1.LabelNodeClass+"=default")
+	require.Contains(t, kubeLabels, v1alpha1.LabelGKEReadinessNetdReady+"=true")
+	require.Contains(t, kubeLabels, v1alpha1.LabelGKEReadinessNodeLocalDNSReady+"=true")
+	require.Contains(t, kubeLabels, v1alpha1.LabelGKEReadinessMetadataServerEnabled+"=true")
+	require.Contains(t, kubeEnv, v1alpha1.LabelGKEReadinessNetdReady+"=true")
+	require.Contains(t, kubeEnv, v1alpha1.LabelGKEReadinessNodeLocalDNSReady+"=true")
+	require.Contains(t, kubeEnv, v1alpha1.LabelGKEReadinessMetadataServerEnabled+"=true")
+	require.NotContains(t, kubeLabels, v1alpha1.LabelGKEReadinessKubeProxyReady+"=true")
+	require.NotContains(t, kubeEnv, v1alpha1.LabelGKEReadinessKubeProxyReady+"=true")
+	require.Contains(t, kubeLabels, karpv1.NodeRegisteredLabelKey+"=true")
+	require.NotContains(t, kubeEnv, karpv1.NodeRegisteredLabelKey+"=true")
+	require.Contains(t, kubeLabels, "gke-provisioning=standard")
+	require.Contains(t, kubeEnv, "gke-provisioning=standard")
+	require.Contains(t, kubeEnv, "ZONE: europe-west4-c")
+	require.NotContains(t, kubeEnv, "ZONE: europe-west4-a")
+	require.Contains(t, kubeEnv, "karpenter.sh/unregistered=true:NoExecute")
+	require.Equal(t, 1, strings.Count(kubeEnv, "--register-with-taints="))
+}
+
 func TestDelete_ReturnsNotFoundWhenInstanceMissing(t *testing.T) {
 	t.Parallel()
 
@@ -1410,6 +1475,47 @@ func TestBuildInstance_DiskTypeLabels(t *testing.T) {
 	}
 }
 
+func TestBuildInstance_RebuildsGCELabelsWithoutTemplateIdentityLabelInheritance(t *testing.T) {
+	t.Parallel()
+
+	p := makeProvider()
+	template := makeGPUTemplate("max-pods-per-node=110")
+	template.Properties.Labels = map[string]string{
+		"goog-gke-cluster-id-base32":            "source-cluster-id",
+		"goog-gke-cost-management":              "source-cost-management",
+		"goog-gke-node":                         "source-node-marker",
+		"goog-gke-node-pool-provisioning-model": "source-provisioning-model",
+		"goog-k8s-node-pool-name":               "source-bootstrap-pool",
+		"workload-label-from-bootstrap-pool":    "must-not-leak",
+		"goog-k8s-cluster-name":                 "source-cluster-name",
+		"goog-k8s-cluster-location":             "source-cluster-location",
+	}
+	nodeClass := &v1alpha1.GCENodeClass{Spec: v1alpha1.GCENodeClassSpec{Labels: map[string]string{"user-label": "value"}}}
+	instance, err := p.buildInstance(
+		context.Background(),
+		spotOrOnDemandNodeClaim(), nodeClass, makeGPUIT(), template,
+		makeCluster("net", "subnet", "pods", false),
+		"default-pool", "us-central1-a", "karpenter-identity-test",
+		karpv1.CapacityTypeOnDemand,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "value", instance.Labels["user-label"])
+	require.Equal(t, "aerukz4jvpg66ajdivtytk6n54asgrlhrgv433ybencwpcnlzxxq", instance.Labels["goog-gke-cluster-id-base32"])
+	require.Contains(t, instance.Labels, "goog-gke-cost-management")
+	require.Equal(t, "", instance.Labels["goog-gke-cost-management"])
+	require.Contains(t, instance.Labels, "goog-gke-node")
+	require.Equal(t, "", instance.Labels["goog-gke-node"])
+	require.Equal(t, "on-demand", instance.Labels["goog-gke-node-pool-provisioning-model"])
+	require.Equal(t, spotOrOnDemandNodeClaim().Labels[karpv1.NodePoolLabelKey], instance.Labels[utils.SanitizeGCELabelValue(utils.LabelNodePoolKey)])
+	require.Equal(t, nodeClass.Name, instance.Labels[utils.SanitizeGCELabelValue(utils.LabelGCENodeClassKey)])
+	require.Equal(t, p.clusterName, instance.Labels[utils.SanitizeGCELabelValue(utils.LabelClusterNameKey)])
+	require.Equal(t, p.clusterLocation, instance.Labels[utils.SanitizeGCELabelValue(utils.LabelClusterLocationKey)])
+	require.NotEqual(t, "source-cluster-id", instance.Labels["goog-gke-cluster-id-base32"])
+	require.NotContains(t, instance.Labels, "goog-k8s-node-pool-name")
+	require.NotContains(t, instance.Labels, "workload-label-from-bootstrap-pool")
+}
+
 func TestBuildInstance_GPUDriverVersionLabel(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -1555,11 +1661,48 @@ func TestSetupInstanceLabels_StampsClusterLocation(t *testing.T) {
 	p := &DefaultProvider{clusterName: "my-cluster", clusterLocation: "us-central1-f"}
 	inst, nodeClaim, nodeClass := instanceLabelsFixture()
 
-	p.setupInstanceLabels(inst, nodeClaim, nodeClass, amd64InstanceType())
+	p.setupInstanceLabels(inst, nodeClaim, nodeClass, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 
 	locationKey := utils.SanitizeGCELabelValue(utils.LabelClusterLocationKey)
 	require.Equal(t, "us-central1-f", inst.Labels[locationKey],
 		"cluster location must be stamped on the instance label %q", locationKey)
+}
+
+func TestBuildInstance_DoesNotCopyKubernetesSchedulingLabelsToGCELabels(t *testing.T) {
+	t.Parallel()
+
+	p := makeProvider()
+	nodeClass := &v1alpha1.GCENodeClass{}
+	nodeClass.Name = "default"
+	instanceType := &cloudprovider.InstanceType{
+		Name: "n2-standard-2",
+		Requirements: scheduling.NewRequirements(
+			scheduling.NewRequirement(corev1.LabelArchStable, corev1.NodeSelectorOpIn, "amd64"),
+			scheduling.NewRequirement(corev1.LabelOSStable, corev1.NodeSelectorOpIn, "linux"),
+			scheduling.NewRequirement(corev1.LabelInstanceTypeStable, corev1.NodeSelectorOpIn, "n2-standard-2"),
+			scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, "us-central1-f"),
+			scheduling.NewRequirement(v1alpha1.LabelInstanceFamily, corev1.NodeSelectorOpIn, "n2"),
+		),
+		Overhead: &cloudprovider.InstanceTypeOverhead{KubeReserved: corev1.ResourceList{}},
+	}
+	instance, err := p.buildInstance(
+		context.Background(),
+		spotOrOnDemandNodeClaim(), nodeClass, instanceType, makeGPUTemplate("max-pods-per-node=110"),
+		makeCluster("net", "subnet", "pods", false),
+		"default-pool", "us-central1-f", "karpenter-no-label-leak",
+		karpv1.CapacityTypeOnDemand,
+	)
+
+	require.NoError(t, err)
+	for _, key := range []string{
+		corev1.LabelArchStable,
+		corev1.LabelOSStable,
+		corev1.LabelInstanceTypeStable,
+		corev1.LabelTopologyZone,
+		v1alpha1.LabelInstanceFamily,
+	} {
+		require.NotContains(t, instance.Labels, utils.SanitizeGCELabelValue(key), "Kubernetes node label %q must not be copied to GCE instance labels", key)
+	}
 }
 
 func TestSetupInstanceLabels_ClusterNameNotOverwrittenByRequirements(t *testing.T) {
@@ -1567,14 +1710,7 @@ func TestSetupInstanceLabels_ClusterNameNotOverwrittenByRequirements(t *testing.
 
 	p := &DefaultProvider{clusterName: "real-cluster", clusterLocation: "us-central1-f"}
 	inst, nodeClaim, nodeClass := instanceLabelsFixture()
-	it := &cloudprovider.InstanceType{
-		Requirements: scheduling.NewRequirements(
-			scheduling.NewRequirement(corev1.LabelArchStable, corev1.NodeSelectorOpIn, "amd64"),
-			scheduling.NewRequirement(utils.LabelClusterNameKey, corev1.NodeSelectorOpIn, "attacker-cluster"),
-		),
-	}
-
-	p.setupInstanceLabels(inst, nodeClaim, nodeClass, it)
+	p.setupInstanceLabels(inst, nodeClaim, nodeClass, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 
 	nameKey := utils.SanitizeGCELabelValue(utils.LabelClusterNameKey)
 	require.Equal(t, "real-cluster", inst.Labels[nameKey],
@@ -1586,14 +1722,7 @@ func TestSetupInstanceLabels_ClusterLocationNotOverwrittenByRequirements(t *test
 
 	p := &DefaultProvider{clusterName: "my-cluster", clusterLocation: "us-central1-f"}
 	inst, nodeClaim, nodeClass := instanceLabelsFixture()
-	it := &cloudprovider.InstanceType{
-		Requirements: scheduling.NewRequirements(
-			scheduling.NewRequirement(corev1.LabelArchStable, corev1.NodeSelectorOpIn, "amd64"),
-			scheduling.NewRequirement(utils.LabelClusterLocationKey, corev1.NodeSelectorOpIn, "attacker-region"),
-		),
-	}
-
-	p.setupInstanceLabels(inst, nodeClaim, nodeClass, it)
+	p.setupInstanceLabels(inst, nodeClaim, nodeClass, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 
 	locationKey := utils.SanitizeGCELabelValue(utils.LabelClusterLocationKey)
 	require.Equal(t, "us-central1-f", inst.Labels[locationKey],

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -173,7 +173,7 @@ func TestSetupInstanceMetadata_RebuildsLabelsAndTaintsFromTarget(t *testing.T) {
 		Overhead: &cloudprovider.InstanceTypeOverhead{KubeReserved: corev1.ResourceList{}},
 	}
 
-	require.NoError(t, p.setupInstanceMetadata(context.Background(), meta, nodeClass, instanceType, nodeClaim, "bootstrap", "europe-west4-c", karpv1.CapacityTypeOnDemand, false))
+	require.NoError(t, p.setupInstanceMetadata(context.Background(), meta, nodeClass, instanceType, nodeClaim, "europe-west4-c", karpv1.CapacityTypeOnDemand, false))
 
 	kubeLabels := metadataValue(meta, "kube-labels")
 	kubeEnv := metadataValue(meta, "kube-env")
@@ -1138,7 +1138,7 @@ func TestBuildInstance_UsesExternalCapacityTypeNotRecomputed(t *testing.T) {
 		onDemandOnlyIT,
 		template,
 		cluster,
-		"default-pool", "us-central1-a", "karpenter-test",
+		"us-central1-a", "karpenter-test",
 		karpv1.CapacityTypeSpot, // externally decided by Create() — must not be recomputed
 	)
 	require.NoError(t, err)
@@ -1222,7 +1222,7 @@ func TestBuildInstance_GPUTaintInjected(t *testing.T) {
 		gpuIT,
 		template,
 		cluster,
-		"default-pool", "us-central1-a", "karpenter-gpu-test",
+		"us-central1-a", "karpenter-gpu-test",
 		karpv1.CapacityTypeOnDemand,
 	)
 
@@ -1280,7 +1280,7 @@ func TestBuildInstance_GPUTaintNotInjectedWhenDisabled(t *testing.T) {
 		gpuIT,
 		template,
 		cluster,
-		"default-pool", "us-central1-a", "karpenter-gpu-test",
+		"us-central1-a", "karpenter-gpu-test",
 		karpv1.CapacityTypeOnDemand,
 	)
 
@@ -1342,7 +1342,7 @@ func TestBuildInstance_GPUTaintInjected_AttachedGPU(t *testing.T) {
 		nonGPUIT,
 		template,
 		cluster,
-		"default-pool", "us-central1-a", "karpenter-gpu-test",
+		"us-central1-a", "karpenter-gpu-test",
 		karpv1.CapacityTypeOnDemand,
 	)
 
@@ -1461,12 +1461,13 @@ func TestBuildInstance_DiskTypeLabels(t *testing.T) {
 		instanceType,
 		template,
 		cluster,
-		"default-pool", "us-central1-a", "karpenter-disk-label-test",
+		"us-central1-a", "karpenter-disk-label-test",
 		karpv1.CapacityTypeOnDemand,
 	)
 
 	require.NoError(t, err)
 	for _, value := range []string{kubeLabelsFrom(t, instance), kubeEnvFrom(t, instance)} {
+		require.Contains(t, value, "cloud.google.com/machine-family=e2")
 		require.Contains(t, value, "disk-type.gke.io/pd-balanced=true")
 		require.Contains(t, value, "disk-type.gke.io/pd-extreme=true")
 		require.Contains(t, value, "disk-type.gke.io/pd-ssd=true")
@@ -1495,7 +1496,7 @@ func TestBuildInstance_RebuildsGCELabelsWithoutTemplateIdentityLabelInheritance(
 		context.Background(),
 		spotOrOnDemandNodeClaim(), nodeClass, makeGPUIT(), template,
 		makeCluster("net", "subnet", "pods", false),
-		"default-pool", "us-central1-a", "karpenter-identity-test",
+		"us-central1-a", "karpenter-identity-test",
 		karpv1.CapacityTypeOnDemand,
 	)
 
@@ -1537,7 +1538,7 @@ func TestBuildInstance_GPUDriverVersionLabel(t *testing.T) {
 				context.Background(),
 				spotOrOnDemandNodeClaim(), nc, makeGPUIT(), makeGPUTemplate("max-pods-per-node=110"),
 				makeCluster("net", "subnet", "pods", false),
-				"default-pool", "us-central1-a", "karpenter-gpu-test",
+				"us-central1-a", "karpenter-gpu-test",
 				karpv1.CapacityTypeOnDemand,
 			)
 			require.NoError(t, err)
@@ -1575,7 +1576,7 @@ func TestBuildInstance_GPUDriverVersionNotInjectedForNonGPU(t *testing.T) {
 		context.Background(),
 		spotOrOnDemandNodeClaim(), nc, nonGPUIT, makeGPUTemplate("max-pods-per-node=110"),
 		makeCluster("net", "subnet", "pods", false),
-		"default-pool", "us-central1-a", "karpenter-test",
+		"us-central1-a", "karpenter-test",
 		karpv1.CapacityTypeOnDemand,
 	)
 	require.NoError(t, err)
@@ -1596,7 +1597,7 @@ func TestBuildInstance_GPUDriverVersionOverridesTemplate(t *testing.T) {
 		spotOrOnDemandNodeClaim(), nc, makeGPUIT(),
 		makeGPUTemplate("max-pods-per-node=110,cloud.google.com/gke-gpu-driver-version=default"),
 		makeCluster("net", "subnet", "pods", false),
-		"default-pool", "us-central1-a", "karpenter-gpu-test",
+		"us-central1-a", "karpenter-gpu-test",
 		karpv1.CapacityTypeOnDemand,
 	)
 	require.NoError(t, err)
@@ -1632,7 +1633,7 @@ func TestBuildInstance_NodePoolLabelDoesNotOverrideGPUDriverAtBootTime(t *testin
 		context.Background(),
 		nodeClaim, nc, makeGPUIT(), makeGPUTemplate("max-pods-per-node=110"),
 		makeCluster("net", "subnet", "pods", false),
-		"default-pool", "us-central1-a", "karpenter-gpu-test",
+		"us-central1-a", "karpenter-gpu-test",
 		karpv1.CapacityTypeOnDemand,
 	)
 	require.NoError(t, err)
@@ -1689,7 +1690,7 @@ func TestBuildInstance_DoesNotCopyKubernetesSchedulingLabelsToGCELabels(t *testi
 		context.Background(),
 		spotOrOnDemandNodeClaim(), nodeClass, instanceType, makeGPUTemplate("max-pods-per-node=110"),
 		makeCluster("net", "subnet", "pods", false),
-		"default-pool", "us-central1-f", "karpenter-no-label-leak",
+		"us-central1-f", "karpenter-no-label-leak",
 		karpv1.CapacityTypeOnDemand,
 	)
 
@@ -1976,7 +1977,7 @@ func buildConfidentialInstance(t *testing.T, nc *v1alpha1.GCENodeClass) *compute
 		makeNonGPUIT(),
 		makeGPUTemplate("max-pods-per-node=110"),
 		makeCluster("projects/p/global/networks/my-vpc", "regions/us-central1/subnetworks/my-subnet", "pods", false),
-		"default-pool", "us-central1-a", "karpenter-confidential-test",
+		"us-central1-a", "karpenter-confidential-test",
 		karpv1.CapacityTypeOnDemand,
 	)
 	require.NoError(t, err)

--- a/pkg/providers/metadata/metadata.go
+++ b/pkg/providers/metadata/metadata.go
@@ -16,12 +16,6 @@ limitations under the License.
 
 package metadata
 
-import (
-	"fmt"
-
-	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
-)
-
 const (
 	ClusterNameLabel     = "cluster-name"
 	GKENodePoolLabel     = "cloud.google.com/gke-nodepool"
@@ -31,8 +25,4 @@ const (
 	GPUTaintArg                     = "nvidia.com/gpu=present:NoSchedule"
 	KubeletConfigLabel              = "kubelet-config"
 	GKESecondaryBootDiskLabelPrefix = "cloud.google.com.node-restriction.kubernetes.io/gke-secondary-boot-disk-"
-)
-
-var (
-	RegisteredLabel = fmt.Sprintf("%s=%s", karpv1.NodeRegisteredLabelKey, "true")
 )

--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -35,7 +35,6 @@ import (
 )
 
 var (
-	maxPodsPerNodeRegex           = regexp.MustCompile(`max-pods-per-node=\d+`)
 	maxPodsRegex                  = regexp.MustCompile(`max-pods=\d+`)
 	gkeProvisioningRegex          = regexp.MustCompile(`gke-provisioning=\w+`)
 	kubeEnvArchRegex              = regexp.MustCompile(`\barch=(amd64|arm64)\b`)
@@ -177,72 +176,199 @@ func RemoveGKEBuiltinLabels(metadata *compute.Metadata, nodePoolName string) err
 	return nil
 }
 
+// SetNodeLabels replaces all Kubernetes node-label bootstrap surfaces with the
+// target node labels Karpenter/provider owns. It intentionally discards labels
+// inherited from the GKE bootstrap source pool. kubeLabels and kubeEnvLabels are
+// separate because lifecycle labels such as karpenter.sh/registered must not be
+// present at kubelet registration time.
+func SetNodeLabels(metadata *compute.Metadata, kubeLabels, kubeEnvLabels map[string]string) error {
+	if metadata == nil {
+		return fmt.Errorf("metadata must be non-nil")
+	}
+	kubeLabelString := formatLabels(kubeLabels)
+	kubeEnvLabelString := formatLabels(kubeEnvLabels)
+	kubeLabelsFound := false
+	kubeEnvFound := false
+
+	for _, item := range metadata.Items {
+		switch item.Key {
+		case "kube-labels":
+			kubeLabelsFound = true
+			item.Value = lo.ToPtr(kubeLabelString)
+		case "kube-env":
+			kubeEnvFound = true
+			item.Value = lo.ToPtr(setNodeLabelsInKubeEnv(lo.FromPtr(item.Value), kubeEnvLabelString))
+		}
+	}
+	if !kubeLabelsFound {
+		return fmt.Errorf("kube-labels metadata key not found in instance template")
+	}
+	if !kubeEnvFound {
+		return fmt.Errorf("kube-env metadata key not found in instance template")
+	}
+	return nil
+}
+
+func formatLabels(labels map[string]string) string {
+	keys := make([]string, 0, len(labels))
+	for key, value := range labels {
+		if key != "" && value != "" {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", key, labels[key]))
+	}
+	return strings.Join(parts, ",")
+}
+
+func setNodeLabelsInKubeEnv(kubeEnv, labels string) string {
+	flag := "--node-labels=" + labels
+	if kubeEnvNodeLabelsEmptyOKRegex.MatchString(kubeEnv) {
+		return kubeEnvNodeLabelsEmptyOKRegex.ReplaceAllString(kubeEnv, flag)
+	}
+	return appendKubeletArg(kubeEnv, flag)
+}
+
+func upsertLabelString(labels, key, value string) string {
+	parts := strings.Split(labels, ",")
+	updated := make([]string, 0, len(parts)+1)
+	prefix := key + "="
+	inserted := false
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if strings.HasPrefix(part, prefix) {
+			if !inserted {
+				updated = append(updated, prefix+value)
+				inserted = true
+			}
+			continue
+		}
+		updated = append(updated, part)
+	}
+	if !inserted {
+		updated = append(updated, prefix+value)
+	}
+	return strings.Join(updated, ",")
+}
+
+func upsertNodeLabelInKubeEnv(kubeEnv, key, value string) string {
+	if kubeEnvNodeLabelsEmptyOKRegex.MatchString(kubeEnv) {
+		return kubeEnvNodeLabelsEmptyOKRegex.ReplaceAllStringFunc(kubeEnv, func(match string) string {
+			labels := strings.TrimPrefix(match, "--node-labels=")
+			return "--node-labels=" + upsertLabelString(labels, key, value)
+		})
+	}
+	return appendKubeletArg(kubeEnv, "--node-labels="+key+"="+value)
+}
+
+// SetRegisterWithTaints replaces the kubelet register-with-taints flag with the
+// target node taints Karpenter/provider owns. It intentionally discards taints
+// inherited from the GKE bootstrap source pool.
+func SetRegisterWithTaints(metadata *compute.Metadata, taints []string) error {
+	if metadata == nil {
+		return fmt.Errorf("metadata must be non-nil")
+	}
+	kubeEnvFound := false
+	for _, item := range metadata.Items {
+		if item.Key != "kube-env" {
+			continue
+		}
+		kubeEnvFound = true
+		item.Value = lo.ToPtr(setRegisterWithTaintsInKubeEnv(lo.FromPtr(item.Value), taints))
+	}
+	if !kubeEnvFound {
+		return fmt.Errorf("kube-env metadata key not found in instance template")
+	}
+	return nil
+}
+
+func setRegisterWithTaintsInKubeEnv(kubeEnv string, taints []string) string {
+	cleaned := compactStrings(taints)
+	if len(cleaned) == 0 {
+		return registerWithTaintsRegex.ReplaceAllString(kubeEnv, "")
+	}
+	flag := "--register-with-taints=" + strings.Join(cleaned, ",")
+	if registerWithTaintsRegex.MatchString(kubeEnv) {
+		return registerWithTaintsRegex.ReplaceAllString(kubeEnv, flag)
+	}
+	return appendKubeletArg(kubeEnv, flag)
+}
+
+func compactStrings(values []string) []string {
+	ret := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		ret = append(ret, value)
+	}
+	return ret
+}
+
+func appendKubeletArg(kubeEnv, arg string) string {
+	lines := strings.Split(kubeEnv, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "KUBELET_ARGS:") {
+			lines[i] = line + " " + arg
+			return strings.Join(lines, "\n")
+		}
+	}
+	if strings.HasSuffix(kubeEnv, "\n") {
+		return kubeEnv + "KUBELET_ARGS: " + arg + "\n"
+	}
+	if kubeEnv == "" {
+		return "KUBELET_ARGS: " + arg + "\n"
+	}
+	return kubeEnv + "\nKUBELET_ARGS: " + arg + "\n"
+}
+
 func SetMaxPodsPerNode(metadata *compute.Metadata, nodeClass *v1alpha1.GCENodeClass) error {
 	maxPods := nodeClass.GetMaxPods()
-	keys := []string{"kube-labels", "kube-env"}
-	maxPodsPerNode := fmt.Sprintf("max-pods-per-node=%d", maxPods)
 	maxPodsStr := fmt.Sprintf("max-pods=%d", maxPods)
 
-	for _, key := range keys {
-		targetEntry, index, ok := lo.FindIndexOf(metadata.Items, func(item *compute.MetadataItems) bool {
-			return item.Key == key
-		})
-		if !ok || index == -1 {
-			return fmt.Errorf("%s metadata not found", key)
-		}
-		targetEntry.Value = lo.ToPtr(maxPodsPerNodeRegex.ReplaceAllString(*targetEntry.Value, maxPodsPerNode))
-		targetEntry.Value = lo.ToPtr(maxPodsRegex.ReplaceAllString(*targetEntry.Value, maxPodsStr))
-
-		metadata.Items[index] = targetEntry
+	targetEntry, index, ok := lo.FindIndexOf(metadata.Items, func(item *compute.MetadataItems) bool {
+		return item.Key == "kube-env"
+	})
+	if !ok || index == -1 {
+		return fmt.Errorf("kube-env metadata not found")
 	}
+	targetEntry.Value = lo.ToPtr(maxPodsRegex.ReplaceAllString(*targetEntry.Value, maxPodsStr))
+	metadata.Items[index] = targetEntry
 	return nil
 }
 
 func SetProvisioningModel(metadata *compute.Metadata, model string) error {
-	keys := []string{"kube-labels", "kube-env"}
-	gkeProvisioning := fmt.Sprintf("gke-provisioning=%s", model)
-
-	for _, key := range keys {
-		targetEntry, index, ok := lo.FindIndexOf(metadata.Items, func(item *compute.MetadataItems) bool {
-			return item.Key == key
-		})
-		if !ok || index == -1 {
-			return fmt.Errorf("%s metadata not found", key)
-		}
-		targetEntry.Value = lo.ToPtr(gkeProvisioningRegex.ReplaceAllString(*targetEntry.Value, gkeProvisioning))
-
-		metadata.Items[index] = targetEntry
-	}
-	return nil
-}
-
-func PatchUnregisteredTaints(metadata *compute.Metadata) error {
-	patchedDone := false
-
-	// Remove nodePoolLabelEntry from kube-labels and kube-env
+	kubeLabelsFound := false
+	kubeEnvFound := false
 	for _, item := range metadata.Items {
-		if item.Key == "kube-env" {
-			kubeEnv := lo.FromPtr(item.Value)
-
-			lines := strings.Split(kubeEnv, "\n")
-			for i, line := range lines {
-				if strings.HasPrefix(line, "KUBELET_ARGS:") {
-					if !strings.Contains(line, UnregisteredTaintArg) {
-						// Append the taint argument to the existing KUBELET_ARGS line
-						lines[i] = line + " " + UnregisteredTaintArg
-						patchedDone = true
-					}
-				}
-			}
-			// Rejoin the updated lines into a single string
-			item.Value = lo.ToPtr(strings.Join(lines, "\n"))
+		switch item.Key {
+		case "kube-labels":
+			kubeLabelsFound = true
+			item.Value = lo.ToPtr(upsertLabelString(lo.FromPtr(item.Value), "gke-provisioning", model))
+		case "kube-env":
+			kubeEnvFound = true
+			updated := gkeProvisioningRegex.ReplaceAllString(lo.FromPtr(item.Value), "gke-provisioning="+model)
+			item.Value = lo.ToPtr(upsertNodeLabelInKubeEnv(updated, "gke-provisioning", model))
 		}
 	}
-
-	if !patchedDone {
-		return fmt.Errorf("failed to patch unregistered taints")
+	if !kubeLabelsFound {
+		return fmt.Errorf("kube-labels metadata not found")
 	}
-
+	if !kubeEnvFound {
+		return fmt.Errorf("kube-env metadata not found")
+	}
 	return nil
 }
 
@@ -325,36 +451,52 @@ func patchKubeEnvKeyValue(kubeEnv string, re *regexp.Regexp, replacement string)
 	return re.ReplaceAllString(kubeEnv, replacement)
 }
 
-func AppendNodeClaimLabel(nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass, metadata *compute.Metadata) {
-	// Remove nodePoolLabelEntry from `kube-labels` and `kube-env`
+func SetKubeEnvZone(metadata *compute.Metadata, zone string) error {
+	if metadata == nil || zone == "" {
+		return fmt.Errorf("metadata and zone must be non-empty")
+	}
 	for _, item := range metadata.Items {
-		if item.Key == "kube-labels" {
-			labels := getNodeLabels(nodeClass, nodeClaim)
-			labelString := make([]string, 0, len(labels))
-			for k, v := range labels {
-				// Append the nodeclaim label to kube-labels
-				labelString = append(labelString, fmt.Sprintf("%s=%s", k, v))
-			}
-			item.Value = lo.ToPtr(*item.Value + "," + strings.Join(labelString, ","))
+		if item.Key != "kube-env" {
+			continue
 		}
+		kubeEnv := lo.FromPtr(item.Value)
+		if kubeEnv == "" {
+			return fmt.Errorf("kube-env metadata is empty")
+		}
+		zoneLine := "ZONE: " + zone
+		if regexp.MustCompile(`(?m)^ZONE: [^\n]+`).MatchString(kubeEnv) {
+			item.Value = lo.ToPtr(patchKubeEnvKeyValue(kubeEnv, regexp.MustCompile(`(?m)^ZONE: [^\n]+`), zoneLine))
+		} else {
+			item.Value = lo.ToPtr(kubeEnv + "\n" + zoneLine + "\n")
+		}
+		return nil
+	}
+	return fmt.Errorf("kube-env metadata key not found in instance template")
+}
+
+func BaselineKubeLabels(nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass) map[string]string {
+	labels := BaselineKubeEnvLabels(nodeClaim, nodeClass)
+	labels[karpv1.NodeRegisteredLabelKey] = "true"
+	return labels
+}
+
+func BaselineKubeEnvLabels(nodeClaim *karpv1.NodeClaim, nodeClass *v1alpha1.GCENodeClass) map[string]string {
+	return map[string]string{
+		"max-pods-per-node":                             fmt.Sprintf("%d", nodeClass.GetMaxPods()),
+		"cloud.google.com/gke-os-distribution":          gkeOSDistribution(nodeClass),
+		karpv1.NodePoolLabelKey:                         nodeClaim.Labels[karpv1.NodePoolLabelKey],
+		v1alpha1.LabelNodeClass:                         nodeClass.Name,
+		v1alpha1.LabelGKEReadinessMetadataServerEnabled: "true",
+		v1alpha1.LabelGKEReadinessNetdReady:             "true",
+		v1alpha1.LabelGKEReadinessNodeLocalDNSReady:     "true",
 	}
 }
 
-func AppendRegisteredLabel(metadata *compute.Metadata) {
-	// Add registered label in metadata
-	for _, item := range metadata.Items {
-		if item.Key == "kube-labels" {
-			item.Value = lo.ToPtr(*item.Value + "," + RegisteredLabel)
-		}
+func gkeOSDistribution(nodeClass *v1alpha1.GCENodeClass) string {
+	if nodeClass.ImageFamily() == v1alpha1.ImageFamilyUbuntu {
+		return "ubuntu"
 	}
-}
-
-func getNodeLabels(nodeClass *v1alpha1.GCENodeClass, nodeClaim *karpv1.NodeClaim) map[string]string {
-	staticTags := map[string]string{
-		karpv1.NodePoolLabelKey: nodeClaim.Labels[karpv1.NodePoolLabelKey],
-		v1alpha1.LabelNodeClass: nodeClass.Name,
-	}
-	return staticTags
+	return "cos"
 }
 
 func AppendSecondaryBootDisks(projectID string, nodeClass *v1alpha1.GCENodeClass, metadata *compute.Metadata) {

--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -163,19 +163,6 @@ func mergeUserKubeletConfig(config map[string]interface{}, kc *v1alpha1.KubeletC
 	return nil
 }
 
-func RemoveGKEBuiltinLabels(metadata *compute.Metadata, nodePoolName string) error {
-	nodePoolLabelEntry := fmt.Sprintf("%s=%s", GKENodePoolLabel, nodePoolName)
-	// Remove nodePoolLabelEntry from `kube-labels` and `kube-env`
-	for _, item := range metadata.Items {
-		if item.Key != "kube-labels" && item.Key != "kube-env" {
-			continue
-		}
-
-		item.Value = lo.ToPtr(strings.ReplaceAll(lo.FromPtr(item.Value), nodePoolLabelEntry, ""))
-	}
-	return nil
-}
-
 // SetNodeLabels replaces all Kubernetes node-label bootstrap surfaces with the
 // target node labels Karpenter/provider owns. It intentionally discards labels
 // inherited from the GKE bootstrap source pool. kubeLabels and kubeEnvLabels are
@@ -411,24 +398,29 @@ func PatchKubeEnvForInstanceType(metadata *compute.Metadata, instanceType *cloud
 
 	arch, family := kubeEnvPatchTargets(instanceType)
 	for _, item := range metadata.Items {
-		if item.Key != "kube-env" {
-			continue
-		}
-		kubeEnv := lo.FromPtr(item.Value)
-		if kubeEnv == "" {
-			return fmt.Errorf("kube-env metadata is empty")
-		}
+		switch item.Key {
+		case "kube-labels":
+			if family != "" {
+				item.Value = lo.ToPtr(upsertLabelString(lo.FromPtr(item.Value), "cloud.google.com/machine-family", family))
+			}
+		case "kube-env":
+			kubeEnv := lo.FromPtr(item.Value)
+			if kubeEnv == "" {
+				return fmt.Errorf("kube-env metadata is empty")
+			}
 
-		// Note: SERVER_BINARY_TAR_URL and SERVER_BINARY_TAR_HASH are left untouched.
-		// They are set correctly per-architecture by GKE in the node pool template.
-		// Patching the URL without the corresponding hash causes bootstrap failures.
-		updated := patchKubeEnvKeyValue(kubeEnv, kubeEnvArchRegex, "arch="+arch)
-		if family != "" {
-			updated = patchKubeEnvKeyValue(updated, kubeEnvFamilyRegex, "cloud.google.com/machine-family="+family)
-		}
+			// Note: SERVER_BINARY_TAR_URL and SERVER_BINARY_TAR_HASH are left untouched.
+			// They are set correctly per-architecture by GKE in the node pool template.
+			// Patching the URL without the corresponding hash causes bootstrap failures.
+			updated := patchKubeEnvKeyValue(kubeEnv, kubeEnvArchRegex, "arch="+arch)
+			if family != "" {
+				updated = patchKubeEnvKeyValue(updated, kubeEnvFamilyRegex, "cloud.google.com/machine-family="+family)
+				updated = upsertNodeLabelInKubeEnv(updated, "cloud.google.com/machine-family", family)
+			}
 
-		if updated != kubeEnv {
-			item.Value = lo.ToPtr(updated)
+			if updated != kubeEnv {
+				item.Value = lo.ToPtr(updated)
+			}
 		}
 	}
 

--- a/pkg/providers/metadata/utils_test.go
+++ b/pkg/providers/metadata/utils_test.go
@@ -181,6 +181,45 @@ func TestAppendGPUTaint_ErrorWhenNoKubeletArgs(t *testing.T) {
 	require.Error(t, AppendGPUTaint(meta))
 }
 
+func TestSetRegisterWithTaints_ReplacesSourceTaints(t *testing.T) {
+	meta := &compute.Metadata{Items: []*compute.MetadataItems{{
+		Key:   "kube-env",
+		Value: lo.ToPtr("KUBELET_ARGS: --v=2 --register-with-taints=dedicated=karpenter:NoSchedule,old=true:NoExecute\n"),
+	}}}
+
+	require.NoError(t, SetRegisterWithTaints(meta, []string{"karpenter.sh/unregistered=true:NoExecute"}))
+
+	got := kubeEnvValue(meta)
+	require.NotContains(t, got, "dedicated=karpenter:NoSchedule")
+	require.NotContains(t, got, "old=true:NoExecute")
+	require.Contains(t, got, "--register-with-taints=karpenter.sh/unregistered=true:NoExecute")
+	require.Equal(t, 1, strings.Count(got, "--register-with-taints="))
+}
+
+func TestSetRegisterWithTaints_AddsFlagWhenMissing(t *testing.T) {
+	meta := &compute.Metadata{Items: []*compute.MetadataItems{{
+		Key:   "kube-env",
+		Value: lo.ToPtr("KUBELET_ARGS: --v=2\n"),
+	}}}
+
+	require.NoError(t, SetRegisterWithTaints(meta, []string{"karpenter.sh/unregistered=true:NoExecute"}))
+
+	require.Contains(t, kubeEnvValue(meta), "--register-with-taints=karpenter.sh/unregistered=true:NoExecute")
+}
+
+func TestSetRegisterWithTaints_RemovesFlagWhenEmpty(t *testing.T) {
+	meta := &compute.Metadata{Items: []*compute.MetadataItems{{
+		Key:   "kube-env",
+		Value: lo.ToPtr("KUBELET_ARGS: --v=2 --register-with-taints=dedicated=karpenter:NoSchedule\n"),
+	}}}
+
+	require.NoError(t, SetRegisterWithTaints(meta, nil))
+
+	got := kubeEnvValue(meta)
+	require.NotContains(t, got, "--register-with-taints=")
+	require.Contains(t, got, "KUBELET_ARGS: --v=2")
+}
+
 // gpuTestMeta returns a compute.Metadata that mirrors a real GKE template:
 // kube-labels holds comma-separated node labels, and kube-env's KUBELET_ARGS carries
 // those same labels in a --node-labels= flag (the canonical kubelet label source).
@@ -212,6 +251,49 @@ func kubeEnvValue(meta *compute.Metadata) string {
 		}
 	}
 	return ""
+}
+
+func TestSetNodeLabels_ReplacesSourceLabelsInKubeLabelsAndKubeEnv(t *testing.T) {
+	meta := gpuTestMeta(
+		"cloud.google.com/gke-nodepool=bootstrap,workload=karpenter,max-pods-per-node=110",
+		"cloud.google.com/gke-nodepool=bootstrap,workload=karpenter,max-pods-per-node=110",
+	)
+	kubeLabels := map[string]string{
+		"max-pods-per-node":              "32",
+		"karpenter.sh/nodepool":          "default",
+		"karpenter.k8s.gcp/gcenodeclass": "default",
+		"karpenter.sh/registered":        "true",
+	}
+	kubeEnvLabels := map[string]string{
+		"max-pods-per-node":              "32",
+		"karpenter.sh/nodepool":          "default",
+		"karpenter.k8s.gcp/gcenodeclass": "default",
+	}
+
+	require.NoError(t, SetNodeLabels(meta, kubeLabels, kubeEnvLabels))
+
+	for _, got := range []string{kubeLabelsValue(meta), kubeEnvValue(meta)} {
+		require.NotContains(t, got, "cloud.google.com/gke-nodepool=bootstrap")
+		require.NotContains(t, got, "workload=karpenter")
+		require.Contains(t, got, "max-pods-per-node=32")
+		require.Contains(t, got, "karpenter.sh/nodepool=default")
+		require.Contains(t, got, "karpenter.k8s.gcp/gcenodeclass=default")
+	}
+	require.Contains(t, kubeLabelsValue(meta), "karpenter.sh/registered=true")
+	require.NotContains(t, kubeEnvValue(meta), "karpenter.sh/registered=true")
+	require.Equal(t, 1, strings.Count(kubeEnvValue(meta), "--node-labels="))
+}
+
+func TestSetNodeLabels_HandlesMissingNodeLabelsFlag(t *testing.T) {
+	meta := &compute.Metadata{Items: []*compute.MetadataItems{
+		{Key: "kube-labels", Value: lo.ToPtr("workload=karpenter")},
+		{Key: "kube-env", Value: lo.ToPtr("KUBELET_ARGS: --v=2\n")},
+	}}
+
+	require.NoError(t, SetNodeLabels(meta, map[string]string{"karpenter.sh/nodepool": "default"}, map[string]string{"karpenter.sh/nodepool": "default"}))
+
+	require.Equal(t, "karpenter.sh/nodepool=default", kubeLabelsValue(meta))
+	require.Contains(t, kubeEnvValue(meta), "--node-labels=karpenter.sh/nodepool=default")
 }
 
 func TestSetDiskTypeLabelsReplacesInheritedLabels(t *testing.T) {
@@ -429,4 +511,54 @@ func TestApplyCustomMetadata_SkipsEmptyValue(t *testing.T) {
 	require.Len(t, meta.Items, 1, "empty value must not remove the existing key")
 	require.Equal(t, "true", metadataValue(meta, "serial-port-logging-enable"),
 		"empty value is ignored: it cannot clear a value inherited from the base template")
+}
+
+func TestSetProvisioningModel_AddsSpotAfterLabelRebuild(t *testing.T) {
+	meta := &compute.Metadata{Items: []*compute.MetadataItems{
+		{Key: "kube-labels", Value: lo.ToPtr("workload=karpenter")},
+		{Key: "kube-env", Value: lo.ToPtr("AUTOSCALER_ENV_VARS: gke-provisioning=standard\nKUBELET_ARGS: --v=2 --node-labels=workload=karpenter\n")},
+	}}
+
+	require.NoError(t, SetNodeLabels(meta, map[string]string{"karpenter.sh/nodepool": "default"}, map[string]string{"karpenter.sh/nodepool": "default"}))
+	require.NoError(t, SetProvisioningModel(meta, "spot"))
+
+	require.Contains(t, kubeLabelsValue(meta), "gke-provisioning=spot")
+	require.Contains(t, kubeEnvValue(meta), "gke-provisioning=spot")
+	require.NotContains(t, kubeEnvValue(meta), "gke-provisioning=standard")
+	require.Contains(t, kubeEnvValue(meta), "--node-labels=karpenter.sh/nodepool=default,gke-provisioning=spot")
+	require.NotContains(t, kubeLabelsValue(meta), "workload=karpenter")
+	require.NotContains(t, kubeEnvValue(meta), "workload=karpenter")
+}
+
+func TestSetNodeLabels_ComposesWithGPUAndDiskLabelHelpers(t *testing.T) {
+	meta := gpuTestMeta("workload=karpenter", "workload=karpenter")
+
+	require.NoError(t, SetNodeLabels(meta, map[string]string{"karpenter.sh/nodepool": "default"}, map[string]string{"karpenter.sh/nodepool": "default"}))
+	require.NoError(t, SetGPUAcceleratorLabel(meta, "nvidia-l4"))
+	require.NoError(t, SetGPUDriverVersionLabel(meta, "latest"))
+	require.NoError(t, SetDiskTypeLabels(meta, map[string]string{"disk-type.gke.io/pd-balanced": "true"}))
+
+	for _, got := range []string{kubeLabelsValue(meta), kubeEnvValue(meta)} {
+		require.NotContains(t, got, "workload=karpenter")
+		require.Contains(t, got, "karpenter.sh/nodepool=default")
+		require.Contains(t, got, "cloud.google.com/gke-accelerator=nvidia-l4")
+		require.Contains(t, got, "cloud.google.com/gke-gpu-driver-version=latest")
+		require.Contains(t, got, "disk-type.gke.io/pd-balanced=true")
+	}
+}
+
+func TestSetRegisterWithTaints_ComposesWithAppendGPUTaint(t *testing.T) {
+	meta := &compute.Metadata{Items: []*compute.MetadataItems{{
+		Key:   "kube-env",
+		Value: lo.ToPtr("KUBELET_ARGS: --v=2 --register-with-taints=dedicated=karpenter:NoSchedule\n"),
+	}}}
+
+	require.NoError(t, SetRegisterWithTaints(meta, []string{"karpenter.sh/unregistered=true:NoExecute"}))
+	require.NoError(t, AppendGPUTaint(meta))
+
+	got := kubeEnvValue(meta)
+	require.NotContains(t, got, "dedicated=karpenter:NoSchedule")
+	require.Contains(t, got, "karpenter.sh/unregistered=true:NoExecute")
+	require.Contains(t, got, GPUTaintArg)
+	require.Equal(t, 1, strings.Count(got, "--register-with-taints="))
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Rebuilds bootstrap Kubernetes node labels and register-with-taints from target-derived Karpenter/provider values instead of inheriting them from the selected GKE source pool template.

This prevents labels and taints from an arbitrary bootstrap pool, such as `workload=karpenter` or `dedicated=karpenter:NoSchedule`, from propagating to Karpenter-provisioned nodes.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

Fixes #435

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

- Added unit coverage for source label/taint removal across `kube-labels`, `--node-labels`, and `--register-with-taints`.
- `make presubmit` passed.
- This PR depends on PR #439 for zonal clusters. It makes kube-env `ZONE:` match the selected target VM zone, which is correct, but current `origin/main` can select an unconfigured zone for zonal clusters. E2E is validated on a temporary stack of PR 439 + this PR; this PR branch remains based on `origin/main` so the final diff contains only the label/taint changes.
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes label and taint inheritance from the GKE bootstrap source pool. Previously, labels such as `workload=karpenter` or taints like `dedicated=karpenter:NoSchedule` were copied from the bootstrap pool template into the provisioned node's kubelet bootstrap metadata; now they are fully discarded and rebuilt from Karpenter/provider-owned state.

- **`SetNodeLabels`** (new) replaces `RemoveGKEBuiltinLabels` — instead of surgically removing one pool label it wholesale replaces `kube-labels` and `--node-labels=` in `kube-env` with a clean, deterministic baseline derived from `BaselineKubeLabels`/`BaselineKubeEnvLabels`.
- **`SetRegisterWithTaints`** (new) replaces `PatchUnregisteredTaints` — it sets `--register-with-taints=` from the Karpenter-owned taint list instead of appending to whatever the bootstrap pool had.
- **`setProvisioningModel`** now explicitly sets `gke-provisioning=standard` for on-demand nodes (not just spot), addressing a previous concern that on-demand nodes lost this label after the baseline wipe. GCE instance labels are also narrowed: Kubernetes scheduling labels no longer leak into GCE labels, and new GKE-internal labels (`goog-gke-cluster-id-base32`, `goog-gke-node`, `goog-gke-cost-management`, `goog-gke-node-pool-provisioning-model`) are correctly set from the provider.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the refactoring is well-scoped, all changed call sites are updated, and the new baseline-rebuild approach is thoroughly covered by unit tests.

The logic replacing bootstrap-pool label/taint inheritance with a deterministic Karpenter-owned baseline is sound and correctly handles on-demand provisioning model. The only issues found are two minor style nits in SetKubeEnvZone: an inline regex compilation that should be a package-level variable, and a redundant newline that can produce a cosmetic blank line in kube-env when ZONE is first added. Neither affects runtime correctness.

No files require special attention; pkg/providers/metadata/utils.go has the two minor style points in SetKubeEnvZone but is otherwise correct.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pkg/providers/metadata/utils.go | Core logic rewritten: adds SetNodeLabels, SetRegisterWithTaints, SetKubeEnvZone, BaselineKubeLabels/BaselineKubeEnvLabels, upsertLabelString, formatLabels, appendKubeletArg; removes RemoveGKEBuiltinLabels, PatchUnregisteredTaints, AppendNodeClaimLabel, AppendRegisteredLabel. Inline regex compilation in SetKubeEnvZone is a minor style nit. |
| pkg/providers/instance/instance.go | setupInstanceMetadata refactored to use SetNodeLabels/SetRegisterWithTaints; sourcePoolName parameter removed; new patchTargetKubeEnv helper adds zone and provisioning-model steps; setupInstanceLabels narrowed to controller-owned GCE labels only; clusterIDBase32 helper added. |
| pkg/providers/instance/instance_test.go | New tests cover baseline label/taint rebuild, GCE label identity isolation, no K8s label leakage to GCE labels, and provisioning model composition; existing tests updated to drop sourcePoolName parameter. |
| pkg/providers/metadata/utils_test.go | New tests for SetRegisterWithTaints (replace, add, remove), SetNodeLabels (replace, missing flag, composition with GPU/disk helpers), and SetProvisioningModel composition after label rebuild. |
| pkg/providers/metadata/metadata.go | Removed RegisteredLabel var and unused import; constants unchanged. |
| docs/bootstrap-pool.md | Added Metadata sources table documenting which fields come from bootstrap pool vs Karpenter/provider; updated troubleshooting section to reflect narrowed scope of what bootstrap pool contributes. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as buildInstance
    participant SM as setupInstanceMetadata
    participant M as metadata pkg

    C->>SM: zone, capacityType (no sourcePoolName)
    SM->>M: SetNodeLabels(baseline kube-labels, baseline kube-env labels)
    Note over M: Completely replaces kube-labels<br/>and --node-labels= in kube-env<br/>discarding bootstrap pool labels
    SM->>M: "SetMaxPodsPerNode (updates --max-pods= in KUBELET_ARGS)"
    SM->>M: RenderKubeletConfigMetadata
    SM->>M: SetRegisterWithTaints([unregistered taint])
    Note over M: Replaces --register-with-taints=<br/>discarding bootstrap pool taints
    SM->>M: patchTargetKubeEnv(zone, capacityType)
    M->>M: PatchKubeEnvForInstanceType (arch/family)
    M->>M: PatchKubeEnvForOSType
    M->>M: SetKubeEnvZone (ZONE: target-zone)
    M->>M: SetProvisioningModel (standard or spot)
    SM->>M: AppendSecondaryBootDisks
    SM->>M: ApplyCustomMetadata
    SM->>M: PatchKubeEnvForInstanceType (re-apply after custom metadata)
    SM->>M: setupGPUMetadata
    SM->>M: SetDiskTypeLabels
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pkg/providers/instance/instance.go`, line 834-836 ([link](https://github.com/cloudpilot-ai/karpenter-provider-gcp/blob/8607bc22ed3b99e65cc51080131e559dad10cadc/pkg/providers/instance/instance.go#L834-L836)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`RemoveGKEBuiltinLabels` is now a no-op before `SetNodeLabels`**

   `RemoveGKEBuiltinLabels` removes `cloud.google.com/gke-nodepool=<pool>` from `kube-labels` and `kube-env`, but `SetNodeLabels` (line 854) unconditionally replaces the entire `kube-labels` value and the entire `--node-labels=` flag in `kube-env` with a clean baseline. Any changes made by `RemoveGKEBuiltinLabels` are immediately discarded. The call is harmless but is now dead work; it can be removed.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fproviders%2Finstance%2Finstance.go%0ALine%3A%20834-836%0A%0AComment%3A%0A**%60RemoveGKEBuiltinLabels%60%20is%20now%20a%20no-op%20before%20%60SetNodeLabels%60**%0A%0A%60RemoveGKEBuiltinLabels%60%20removes%20%60cloud.google.com%2Fgke-nodepool%3D%3Cpool%3E%60%20from%20%60kube-labels%60%20and%20%60kube-env%60%2C%20but%20%60SetNodeLabels%60%20%28line%20854%29%20unconditionally%20replaces%20the%20entire%20%60kube-labels%60%20value%20and%20the%20entire%20%60--node-labels%3D%60%20flag%20in%20%60kube-env%60%20with%20a%20clean%20baseline.%20Any%20changes%20made%20by%20%60RemoveGKEBuiltinLabels%60%20are%20immediately%20discarded.%20The%20call%20is%20harmless%20but%20is%20now%20dead%20work%3B%20it%20can%20be%20removed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=436&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fproviders%2Finstance%2Finstance.go%0ALine%3A%20834-836%0A%0AComment%3A%0A**%60RemoveGKEBuiltinLabels%60%20is%20now%20a%20no-op%20before%20%60SetNodeLabels%60**%0A%0A%60RemoveGKEBuiltinLabels%60%20removes%20%60cloud.google.com%2Fgke-nodepool%3D%3Cpool%3E%60%20from%20%60kube-labels%60%20and%20%60kube-env%60%2C%20but%20%60SetNodeLabels%60%20%28line%20854%29%20unconditionally%20replaces%20the%20entire%20%60kube-labels%60%20value%20and%20the%20entire%20%60--node-labels%3D%60%20flag%20in%20%60kube-env%60%20with%20a%20clean%20baseline.%20Any%20changes%20made%20by%20%60RemoveGKEBuiltinLabels%60%20are%20immediately%20discarded.%20The%20call%20is%20harmless%20but%20is%20now%20dead%20work%3B%20it%20can%20be%20removed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=436&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22fix-bootstrap-labels-taints%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-bootstrap-labels-taints%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fproviders%2Finstance%2Finstance.go%0ALine%3A%20834-836%0A%0AComment%3A%0A**%60RemoveGKEBuiltinLabels%60%20is%20now%20a%20no-op%20before%20%60SetNodeLabels%60**%0A%0A%60RemoveGKEBuiltinLabels%60%20removes%20%60cloud.google.com%2Fgke-nodepool%3D%3Cpool%3E%60%20from%20%60kube-labels%60%20and%20%60kube-env%60%2C%20but%20%60SetNodeLabels%60%20%28line%20854%29%20unconditionally%20replaces%20the%20entire%20%60kube-labels%60%20value%20and%20the%20entire%20%60--node-labels%3D%60%20flag%20in%20%60kube-env%60%20with%20a%20clean%20baseline.%20Any%20changes%20made%20by%20%60RemoveGKEBuiltinLabels%60%20are%20immediately%20discarded.%20The%20call%20is%20harmless%20but%20is%20now%20dead%20work%3B%20it%20can%20be%20removed.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=436&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `pkg/providers/instance/instance.go`, line 838-840 ([link](https://github.com/cloudpilot-ai/karpenter-provider-gcp/blob/8607bc22ed3b99e65cc51080131e559dad10cadc/pkg/providers/instance/instance.go#L838-L840)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`SetMaxPodsPerNode` kube-labels update is immediately overwritten**

   `SetMaxPodsPerNode` writes `max-pods-per-node=<N>` into `kube-labels` and replaces `max-pods=<N>` in KUBELET_ARGS. The KUBELET_ARGS `--max-pods=` update is still necessary and preserved. However, the `kube-labels` change is unconditionally discarded a few lines later when `SetNodeLabels` (line 854) replaces the entire `kube-labels` value with a fresh map built from `BaselineKubeLabels` (which already includes `max-pods-per-node` from `nodeClass.GetMaxPods()`). The result is correct, but the kube-labels half of `SetMaxPodsPerNode` is wasted work here.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fproviders%2Finstance%2Finstance.go%0ALine%3A%20838-840%0A%0AComment%3A%0A**%60SetMaxPodsPerNode%60%20kube-labels%20update%20is%20immediately%20overwritten**%0A%0A%60SetMaxPodsPerNode%60%20writes%20%60max-pods-per-node%3D%3CN%3E%60%20into%20%60kube-labels%60%20and%20replaces%20%60max-pods%3D%3CN%3E%60%20in%20KUBELET_ARGS.%20The%20KUBELET_ARGS%20%60--max-pods%3D%60%20update%20is%20still%20necessary%20and%20preserved.%20However%2C%20the%20%60kube-labels%60%20change%20is%20unconditionally%20discarded%20a%20few%20lines%20later%20when%20%60SetNodeLabels%60%20%28line%20854%29%20replaces%20the%20entire%20%60kube-labels%60%20value%20with%20a%20fresh%20map%20built%20from%20%60BaselineKubeLabels%60%20%28which%20already%20includes%20%60max-pods-per-node%60%20from%20%60nodeClass.GetMaxPods%28%29%60%29.%20The%20result%20is%20correct%2C%20but%20the%20kube-labels%20half%20of%20%60SetMaxPodsPerNode%60%20is%20wasted%20work%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=436&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fproviders%2Finstance%2Finstance.go%0ALine%3A%20838-840%0A%0AComment%3A%0A**%60SetMaxPodsPerNode%60%20kube-labels%20update%20is%20immediately%20overwritten**%0A%0A%60SetMaxPodsPerNode%60%20writes%20%60max-pods-per-node%3D%3CN%3E%60%20into%20%60kube-labels%60%20and%20replaces%20%60max-pods%3D%3CN%3E%60%20in%20KUBELET_ARGS.%20The%20KUBELET_ARGS%20%60--max-pods%3D%60%20update%20is%20still%20necessary%20and%20preserved.%20However%2C%20the%20%60kube-labels%60%20change%20is%20unconditionally%20discarded%20a%20few%20lines%20later%20when%20%60SetNodeLabels%60%20%28line%20854%29%20replaces%20the%20entire%20%60kube-labels%60%20value%20with%20a%20fresh%20map%20built%20from%20%60BaselineKubeLabels%60%20%28which%20already%20includes%20%60max-pods-per-node%60%20from%20%60nodeClass.GetMaxPods%28%29%60%29.%20The%20result%20is%20correct%2C%20but%20the%20kube-labels%20half%20of%20%60SetMaxPodsPerNode%60%20is%20wasted%20work%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=436&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22fix-bootstrap-labels-taints%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-bootstrap-labels-taints%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fproviders%2Finstance%2Finstance.go%0ALine%3A%20838-840%0A%0AComment%3A%0A**%60SetMaxPodsPerNode%60%20kube-labels%20update%20is%20immediately%20overwritten**%0A%0A%60SetMaxPodsPerNode%60%20writes%20%60max-pods-per-node%3D%3CN%3E%60%20into%20%60kube-labels%60%20and%20replaces%20%60max-pods%3D%3CN%3E%60%20in%20KUBELET_ARGS.%20The%20KUBELET_ARGS%20%60--max-pods%3D%60%20update%20is%20still%20necessary%20and%20preserved.%20However%2C%20the%20%60kube-labels%60%20change%20is%20unconditionally%20discarded%20a%20few%20lines%20later%20when%20%60SetNodeLabels%60%20%28line%20854%29%20replaces%20the%20entire%20%60kube-labels%60%20value%20with%20a%20fresh%20map%20built%20from%20%60BaselineKubeLabels%60%20%28which%20already%20includes%20%60max-pods-per-node%60%20from%20%60nodeClass.GetMaxPods%28%29%60%29.%20The%20result%20is%20correct%2C%20but%20the%20kube-labels%20half%20of%20%60SetMaxPodsPerNode%60%20is%20wasted%20work%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=436&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apkg%2Fproviders%2Fmetadata%2Futils.go%3A459-460%0A**Regex%20compiled%20twice%20per%20call%20in%20%60SetKubeEnvZone%60**%0A%0AThe%20pattern%20%60%28%3Fm%29%5EZONE%3A%20%5B%5E%5Cn%5D%2B%60%20is%20passed%20to%20%60regexp.MustCompile%60%20twice%20on%20every%20invocation%20%E2%80%94%20once%20for%20the%20%60.MatchString%60%20check%20and%20once%20for%20the%20replacement.%20Every%20other%20pattern%20used%20in%20this%20file%20is%20compiled%20once%20into%20a%20package-level%20%60var%60.%20Extracting%20%60kubeEnvZoneRegex%60%20to%20the%20%60var%60%20block%20at%20the%20top%20of%20the%20file%20would%20match%20the%20established%20convention%20and%20avoid%20redundant%20compilation.%0A%0A%23%23%23%20Issue%202%20of%202%0Apkg%2Fproviders%2Fmetadata%2Futils.go%3A462%0A**Extra%20blank%20line%20when%20appending%20ZONE%20to%20kube-env%20that%20ends%20with%20%60%5Cn%60**%0A%0AWhen%20ZONE%20is%20absent%20and%20%60kubeEnv%60%20already%20ends%20with%20%60%5Cn%60%20%28the%20common%20case%20for%20GKE%20templates%29%2C%20this%20produces%20%60%22%E2%80%A6content%5Cn%5CnZONE%3A%20zone%5Cn%22%60%20%E2%80%94%20an%20extra%20blank%20line%20before%20the%20entry.%20The%20existing%20helpers%20in%20this%20file%20%28%60appendKubeletArg%60%2C%20%60ensureKubeEnvLine%60%29%20guard%20against%20this%20by%20checking%20%60strings.HasSuffix%28kubeEnv%2C%20%22%5Cn%22%29%60%20before%20deciding%20whether%20to%20prepend%20%60%22%5Cn%22%60.%20Applying%20the%20same%20guard%20here%20would%20keep%20the%20output%20consistent.%0A%0A&pr=436&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apkg%2Fproviders%2Fmetadata%2Futils.go%3A459-460%0A**Regex%20compiled%20twice%20per%20call%20in%20%60SetKubeEnvZone%60**%0A%0AThe%20pattern%20%60%28%3Fm%29%5EZONE%3A%20%5B%5E%5Cn%5D%2B%60%20is%20passed%20to%20%60regexp.MustCompile%60%20twice%20on%20every%20invocation%20%E2%80%94%20once%20for%20the%20%60.MatchString%60%20check%20and%20once%20for%20the%20replacement.%20Every%20other%20pattern%20used%20in%20this%20file%20is%20compiled%20once%20into%20a%20package-level%20%60var%60.%20Extracting%20%60kubeEnvZoneRegex%60%20to%20the%20%60var%60%20block%20at%20the%20top%20of%20the%20file%20would%20match%20the%20established%20convention%20and%20avoid%20redundant%20compilation.%0A%0A%23%23%23%20Issue%202%20of%202%0Apkg%2Fproviders%2Fmetadata%2Futils.go%3A462%0A**Extra%20blank%20line%20when%20appending%20ZONE%20to%20kube-env%20that%20ends%20with%20%60%5Cn%60**%0A%0AWhen%20ZONE%20is%20absent%20and%20%60kubeEnv%60%20already%20ends%20with%20%60%5Cn%60%20%28the%20common%20case%20for%20GKE%20templates%29%2C%20this%20produces%20%60%22%E2%80%A6content%5Cn%5CnZONE%3A%20zone%5Cn%22%60%20%E2%80%94%20an%20extra%20blank%20line%20before%20the%20entry.%20The%20existing%20helpers%20in%20this%20file%20%28%60appendKubeletArg%60%2C%20%60ensureKubeEnvLine%60%29%20guard%20against%20this%20by%20checking%20%60strings.HasSuffix%28kubeEnv%2C%20%22%5Cn%22%29%60%20before%20deciding%20whether%20to%20prepend%20%60%22%5Cn%22%60.%20Applying%20the%20same%20guard%20here%20would%20keep%20the%20output%20consistent.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=436&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22fix-bootstrap-labels-taints%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-bootstrap-labels-taints%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apkg%2Fproviders%2Fmetadata%2Futils.go%3A459-460%0A**Regex%20compiled%20twice%20per%20call%20in%20%60SetKubeEnvZone%60**%0A%0AThe%20pattern%20%60%28%3Fm%29%5EZONE%3A%20%5B%5E%5Cn%5D%2B%60%20is%20passed%20to%20%60regexp.MustCompile%60%20twice%20on%20every%20invocation%20%E2%80%94%20once%20for%20the%20%60.MatchString%60%20check%20and%20once%20for%20the%20replacement.%20Every%20other%20pattern%20used%20in%20this%20file%20is%20compiled%20once%20into%20a%20package-level%20%60var%60.%20Extracting%20%60kubeEnvZoneRegex%60%20to%20the%20%60var%60%20block%20at%20the%20top%20of%20the%20file%20would%20match%20the%20established%20convention%20and%20avoid%20redundant%20compilation.%0A%0A%23%23%23%20Issue%202%20of%202%0Apkg%2Fproviders%2Fmetadata%2Futils.go%3A462%0A**Extra%20blank%20line%20when%20appending%20ZONE%20to%20kube-env%20that%20ends%20with%20%60%5Cn%60**%0A%0AWhen%20ZONE%20is%20absent%20and%20%60kubeEnv%60%20already%20ends%20with%20%60%5Cn%60%20%28the%20common%20case%20for%20GKE%20templates%29%2C%20this%20produces%20%60%22%E2%80%A6content%5Cn%5CnZONE%3A%20zone%5Cn%22%60%20%E2%80%94%20an%20extra%20blank%20line%20before%20the%20entry.%20The%20existing%20helpers%20in%20this%20file%20%28%60appendKubeletArg%60%2C%20%60ensureKubeEnvLine%60%29%20guard%20against%20this%20by%20checking%20%60strings.HasSuffix%28kubeEnv%2C%20%22%5Cn%22%29%60%20before%20deciding%20whether%20to%20prepend%20%60%22%5Cn%22%60.%20Applying%20the%20same%20guard%20here%20would%20keep%20the%20output%20consistent.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=436&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (7): Last reviewed commit: ["fix: preserve machine family bootstrap l..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/cdb765a8305a7f3ab3a59d85f80744124dded6b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36234328)</sub>

<!-- /greptile_comment -->