### PR TITLE
Clarify that node labels and taints are not inherited from bootstrap pool

### DIFF
--- a/docs/bootstrap-pool.md
+++ b/docs/bootstrap-pool.md
@@ -52,6 +52,20 @@ Karpenter patches the source pool's kube-env metadata when provisioning nodes wi
 
 This allows a single source pool to bootstrap nodes of any OS and architecture combination.
 
+## What metadata is inherited
+
+Karpenter reads the bootstrap pool's instance template for network configuration, service account, and kubelet settings. Node labels and taints are rebuilt from NodePool and GCENodeClass definitions, not inherited from the bootstrap pool.
+
+| Metadata | Source |
+|----------|--------|
+| Subnetwork, private-node setting | Inherited from bootstrap pool |
+| Service account, scopes | Inherited from bootstrap pool |
+| Kubelet configuration (max-pods, etc.) | Inherited, then patched by GCENodeClass settings |
+| Node labels | Rebuilt from NodePool and GCENodeClass (not inherited) |
+| Node taints | Rebuilt from NodePool and GCENodeClass (not inherited) |
+
+Labels and taints configured on the bootstrap pool (such as `workload=karpenter` or `dedicated=karpenter:NoSchedule`) are intentionally discarded. Karpenter-provisioned nodes receive only labels and taints that Karpenter explicitly controls.
+
 ## Upgrading from template pools
 
 Previous Karpenter versions created up to four template pools (`karpenter-default`, `karpenter-ubuntu`, `karpenter-cos-arm64`, `karpenter-ubuntu-arm64`) at startup. These are no longer needed.
@@ -96,7 +110,7 @@ If fallback creation fails due to org policy violations, the error message ident
 
 **Nodes fail to join the cluster after switching bootstrap pools**
 
-If the new source pool has materially different metadata (service account, scopes, labels), existing Karpenter nodes may have stale configuration. Trigger a rolling replacement:
+If the new source pool has a different service account or scopes, existing Karpenter nodes may have stale configuration. Trigger a rolling replacement:
 
 ```bash
 kubectl annotate nodepool NODEPOOL_NAME "karpenter.k8s.gcp/force-rollout=$(date +%s)" --overwrite


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/75c8c887-febd-4c9a-a15e-7d1f4ddbc1b8)

Adds a new "What metadata is inherited" section to the bootstrap pool documentation explaining that Karpenter rebuilds node labels and taints from NodePool and GCENodeClass definitions rather than inheriting them from the bootstrap pool. Also updates the troubleshooting section to remove the misleading reference to labels as inherited metadata. This documents the behavior fixed in PR #436.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #436: Fix bootstrap label and taint inheritance](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/436)

---

_Tip: Worried about broken links? Ask Promptless to find and fix them automatically 🔗_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR adds a "What metadata is inherited" section to `docs/bootstrap-pool.md` and tightens the troubleshooting entry for switching bootstrap pools, both reflecting the behavior fixed in PR #436.

- The new section includes a table distinguishing truly inherited metadata (subnetwork, service account, scopes, kubelet config) from metadata that Karpenter rebuilds from `NodePool`/`GCENodeClass` (labels and taints), with a prose note that bootstrap-pool labels/taints are intentionally discarded.
- The troubleshooting entry removes the now-incorrect mention of "labels" as a reason existing nodes might have stale configuration after switching pools.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change; no code is modified.

The new section accurately categorises inherited vs. rebuilt metadata and the troubleshooting correction aligns with that table. The only observation is that the troubleshooting entry omits subnetwork changes from the list of inherited metadata that could trigger stale-node issues, but that is a minor inconsistency within the doc itself.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/bootstrap-pool.md | Adds "What metadata is inherited" section with a clear table and removes the misleading "labels" reference from the troubleshooting entry about switching bootstrap pools. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Bootstrap Pool] --> B{Metadata type}
    B -- "Subnetwork / private-node" --> C[Inherited directly]
    B -- "Service account / scopes" --> C
    B -- "Kubelet config (max-pods, etc.)" --> D[Inherited, then patched by GCENodeClass]
    B -- "Node labels" --> E[Rebuilt from NodePool + GCENodeClass]
    B -- "Node taints" --> E
    C --> F[New node]
    D --> F
    E --> F
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fbootstrap-pool.md%3A113%0AThe%20troubleshooting%20entry%20now%20only%20calls%20out%20service%20account%20and%20scopes%2C%20but%20the%20new%20%22What%20metadata%20is%20inherited%22%20table%20lists%20subnetwork%20and%20private-node%20setting%20as%20also%20inherited%20from%20the%20bootstrap%20pool.%20If%20someone%20switches%20to%20a%20pool%20that%20uses%20a%20different%20subnetwork%20%28e.g.%20a%20different%20VPC%20or%20subnet%20range%29%2C%20newly%20provisioned%20nodes%20would%20land%20on%20that%20subnetwork%20while%20existing%20nodes%20remain%20on%20the%20old%20one%20%E2%80%94%20the%20same%20stale-configuration%20scenario%20the%20rolling-replacement%20step%20is%20meant%20to%20address.%20Worth%20extending%20the%20condition%20so%20the%20entry%20matches%20the%20table.%0A%0A%60%60%60suggestion%0AIf%20the%20new%20source%20pool%20has%20a%20different%20service%20account%2C%20scopes%2C%20or%20subnetwork%20configuration%2C%20existing%20Karpenter%20nodes%20may%20have%20stale%20configuration.%20Trigger%20a%20rolling%20replacement%3A%0A%60%60%60%0A%0A&pr=437&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fbootstrap-pool.md%3A113%0AThe%20troubleshooting%20entry%20now%20only%20calls%20out%20service%20account%20and%20scopes%2C%20but%20the%20new%20%22What%20metadata%20is%20inherited%22%20table%20lists%20subnetwork%20and%20private-node%20setting%20as%20also%20inherited%20from%20the%20bootstrap%20pool.%20If%20someone%20switches%20to%20a%20pool%20that%20uses%20a%20different%20subnetwork%20%28e.g.%20a%20different%20VPC%20or%20subnet%20range%29%2C%20newly%20provisioned%20nodes%20would%20land%20on%20that%20subnetwork%20while%20existing%20nodes%20remain%20on%20the%20old%20one%20%E2%80%94%20the%20same%20stale-configuration%20scenario%20the%20rolling-replacement%20step%20is%20meant%20to%20address.%20Worth%20extending%20the%20condition%20so%20the%20entry%20matches%20the%20table.%0A%0A%60%60%60suggestion%0AIf%20the%20new%20source%20pool%20has%20a%20different%20service%20account%2C%20scopes%2C%20or%20subnetwork%20configuration%2C%20existing%20Karpenter%20nodes%20may%20have%20stale%20configuration.%20Trigger%20a%20rolling%20replacement%3A%0A%60%60%60%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=437&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22promptless%2Fclarify-bootstrap-label-taint-handling%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22promptless%2Fclarify-bootstrap-label-taint-handling%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fbootstrap-pool.md%3A113%0AThe%20troubleshooting%20entry%20now%20only%20calls%20out%20service%20account%20and%20scopes%2C%20but%20the%20new%20%22What%20metadata%20is%20inherited%22%20table%20lists%20subnetwork%20and%20private-node%20setting%20as%20also%20inherited%20from%20the%20bootstrap%20pool.%20If%20someone%20switches%20to%20a%20pool%20that%20uses%20a%20different%20subnetwork%20%28e.g.%20a%20different%20VPC%20or%20subnet%20range%29%2C%20newly%20provisioned%20nodes%20would%20land%20on%20that%20subnetwork%20while%20existing%20nodes%20remain%20on%20the%20old%20one%20%E2%80%94%20the%20same%20stale-configuration%20scenario%20the%20rolling-replacement%20step%20is%20meant%20to%20address.%20Worth%20extending%20the%20condition%20so%20the%20entry%20matches%20the%20table.%0A%0A%60%60%60suggestion%0AIf%20the%20new%20source%20pool%20has%20a%20different%20service%20account%2C%20scopes%2C%20or%20subnetwork%20configuration%2C%20existing%20Karpenter%20nodes%20may%20have%20stale%20configuration.%20Trigger%20a%20rolling%20replacement%3A%0A%60%60%60%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=437&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Clarify that node labels and taints are ..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/6cc7b9cbcb4535146ff7103e771e947ac419dc00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36235116)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->