### PR TITLE
fix: honor configured GKE cluster locations

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -210,10 +210,9 @@ Karpenter provisions nodes only in zones configured for your GKE cluster. If a N
 no zones match topology requirement "topology.kubernetes.io/zone"; requested zones europe-west4-b, configured GKE cluster locations europe-west4-a,europe-west4-c
 ```
 
-Common causes:
+Common cause:
 
-- The NodePool requirement lists zones not in the cluster's node locations
-- The cluster is zonal (single zone) but the NodePool requests multiple zones
+- The NodePool requirement lists zones not in the cluster's node locations. Zonal clusters can use multiple node locations, but the requested zones must be configured on the cluster.
 
 To resolve:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -199,3 +199,30 @@ To increase provisioning success:
   ```
 
 - Allow both spot and on-demand to let Karpenter fall back automatically.
+
+---
+
+## Zone mismatch errors
+
+Karpenter provisions nodes only in zones configured for your GKE cluster. If a NodePool's `topology.kubernetes.io/zone` requirement specifies zones outside the cluster's configured locations, provisioning fails with an error like:
+
+```
+no zones match topology requirement "topology.kubernetes.io/zone"; requested zones europe-west4-b, configured GKE cluster locations europe-west4-a,europe-west4-c
+```
+
+Common causes:
+
+- The NodePool requirement lists zones not in the cluster's node locations
+- The cluster is zonal (single zone) but the NodePool requests multiple zones
+
+To resolve:
+
+1. Check your cluster's configured node locations:
+
+   ```sh
+   gcloud container clusters describe CLUSTER_NAME \
+     --location=CLUSTER_LOCATION \
+     --format="value(locations)"
+   ```
+
+2. Update the NodePool `topology.kubernetes.io/zone` requirement to match available zones, or remove the requirement to let Karpenter use any configured cluster zone.

--- a/pkg/providers/gke/gke.go
+++ b/pkg/providers/gke/gke.go
@@ -19,6 +19,7 @@ package gke
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -33,8 +34,9 @@ import (
 const (
 	zoneCacheExpiration      = 5 * time.Minute
 	zoneCacheCleanupInterval = 1 * time.Minute
-	clusterCacheTTL          = 30 * time.Minute
-	serverConfigCacheTTL     = 30 * time.Minute
+	// Cluster location changes are visible after the cached cluster config expires.
+	clusterCacheTTL      = 30 * time.Minute
+	serverConfigCacheTTL = 30 * time.Minute
 
 	zoneCacheKey         = "zone-cache"
 	clusterCacheKey      = "cluster"
@@ -79,6 +81,17 @@ func (p *DefaultProvider) ResolveClusterZones(ctx context.Context) ([]string, er
 		return zone.([]string), nil
 	}
 
+	cluster, err := p.GetClusterConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(cluster.Locations) != 0 {
+		zones := append([]string(nil), cluster.Locations...)
+		sort.Strings(zones)
+		p.zoneCache.Set(zoneCacheKey, zones, cache.DefaultExpiration)
+		return zones, nil
+	}
+
 	projectID := options.FromContext(ctx).ProjectID
 	clusterLocation := options.FromContext(ctx).ClusterLocation
 
@@ -90,7 +103,7 @@ func (p *DefaultProvider) ResolveClusterZones(ctx context.Context) ([]string, er
 
 	var zones []string
 	prefix := region + "-"
-	err := p.computeService.Zones.List(projectID).Pages(ctx, func(page *compute.ZoneList) error {
+	err = p.computeService.Zones.List(projectID).Pages(ctx, func(page *compute.ZoneList) error {
 		for _, z := range page.Items {
 			if strings.HasPrefix(z.Name, prefix) {
 				zones = append(zones, z.Name)
@@ -107,6 +120,7 @@ func (p *DefaultProvider) ResolveClusterZones(ctx context.Context) ([]string, er
 		return nil, fmt.Errorf("no zones found for region: %s", region)
 	}
 
+	sort.Strings(zones)
 	p.zoneCache.Set(zoneCacheKey, zones, cache.DefaultExpiration)
 	return zones, nil
 }

--- a/pkg/providers/gke/gke_test.go
+++ b/pkg/providers/gke/gke_test.go
@@ -26,8 +26,11 @@ import (
 
 	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/require"
+	computev1 "google.golang.org/api/compute/v1"
 	containerv1 "google.golang.org/api/container/v1"
-	"google.golang.org/api/option"
+	googleapioption "google.golang.org/api/option"
+
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/operator/options"
 )
 
 func TestGetServerConfig_CacheHit(t *testing.T) {
@@ -46,8 +49,8 @@ func TestGetServerConfig_CacheHit(t *testing.T) {
 	defer srv.Close()
 
 	svc, err := containerv1.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithEndpoint(srv.URL+"/"),
+		googleapioption.WithoutAuthentication(),
+		googleapioption.WithEndpoint(srv.URL+"/"),
 	)
 	require.NoError(t, err)
 
@@ -69,6 +72,85 @@ func TestGetServerConfig_CacheHit(t *testing.T) {
 	require.Equal(t, int32(1), calls.Load(), "second call must hit cache")
 }
 
+func TestResolveClusterZones_UsesClusterLocations(t *testing.T) {
+	var calls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		resp := &containerv1.Cluster{
+			Name:      "test-cluster",
+			Location:  "europe-west4-a",
+			Locations: []string{"europe-west4-c", "europe-west4-a"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv.URL, "europe-west4-a")
+
+	zones, err := p.ResolveClusterZones(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"europe-west4-a", "europe-west4-c"}, zones)
+	require.Equal(t, int32(1), calls.Load())
+
+	zones, err = p.ResolveClusterZones(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"europe-west4-a", "europe-west4-c"}, zones)
+	require.Equal(t, int32(1), calls.Load(), "second call must hit cache")
+}
+
+func TestResolveClusterZones_FallsBackToRegionZonesWhenClusterLocationsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/projects/p/locations/europe-west4-a/clusters/test-cluster":
+			_ = json.NewEncoder(w).Encode(&containerv1.Cluster{Name: "test-cluster", Location: "europe-west4-a"})
+		case "/projects/p/zones":
+			_ = json.NewEncoder(w).Encode(&computev1.ZoneList{Items: []*computev1.Zone{
+				{Name: "europe-west4-c"},
+				{Name: "europe-west4-a"},
+				{Name: "us-central1-a"},
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	p := newTestProvider(t, srv.URL, "europe-west4-a")
+	ctx := options.ToContext(context.Background(), &options.Options{ProjectID: "p", ClusterLocation: "europe-west4-a"})
+
+	zones, err := p.ResolveClusterZones(ctx)
+	require.NoError(t, err)
+	require.Equal(t, []string{"europe-west4-a", "europe-west4-c"}, zones)
+}
+
+func newTestProvider(t *testing.T, endpoint, nodeLocation string) *DefaultProvider {
+	t.Helper()
+	containerService, err := containerv1.NewService(context.Background(),
+		googleapioption.WithoutAuthentication(),
+		googleapioption.WithEndpoint(endpoint+"/"),
+	)
+	require.NoError(t, err)
+
+	computeService, err := computev1.NewService(context.Background(),
+		googleapioption.WithoutAuthentication(),
+		googleapioption.WithEndpoint(endpoint+"/"),
+	)
+	require.NoError(t, err)
+
+	return &DefaultProvider{
+		computeService:   computeService,
+		containerService: containerService,
+		projectID:        "p",
+		nodeLocation:     nodeLocation,
+		clusterName:      "test-cluster",
+		clusterCache:     cache.New(clusterCacheTTL, clusterCacheTTL),
+		zoneCache:        cache.New(zoneCacheExpiration, zoneCacheCleanupInterval),
+	}
+}
+
 func TestGetClusterConfig_CacheHit(t *testing.T) {
 	var calls atomic.Int32
 
@@ -88,8 +170,8 @@ func TestGetClusterConfig_CacheHit(t *testing.T) {
 	defer srv.Close()
 
 	svc, err := containerv1.NewService(context.Background(),
-		option.WithoutAuthentication(),
-		option.WithEndpoint(srv.URL+"/"),
+		googleapioption.WithoutAuthentication(),
+		googleapioption.WithEndpoint(srv.URL+"/"),
 	)
 	require.NoError(t, err)
 

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -497,17 +497,27 @@ func orderInstanceTypesByPrice(instanceTypes []*cloudprovider.InstanceType, requ
 }
 
 func filterZonesByRequirement(zones []string, reqs scheduling.Requirements) []string {
-	zoneReq := reqs.Get(corev1.LabelTopologyZone)
-	if zoneReq == nil || len(zoneReq.Values()) == 0 {
+	requested := requestedZones(reqs)
+	if len(requested) == 0 {
 		return zones
 	}
 	allowed := sets.NewString()
 	for _, z := range zones {
-		if lo.Contains(zoneReq.Values(), z) {
+		if lo.Contains(requested, z) {
 			allowed.Insert(z)
 		}
 	}
 	return allowed.List()
+}
+
+func requestedZones(reqs scheduling.Requirements) []string {
+	zoneReq := reqs.Get(corev1.LabelTopologyZone)
+	if zoneReq == nil || len(zoneReq.Values()) == 0 {
+		return nil
+	}
+	zones := append([]string(nil), zoneReq.Values()...)
+	sort.Strings(zones)
+	return zones
 }
 
 func randomZone(zones []string) string {
@@ -543,12 +553,14 @@ func (p *DefaultProvider) selectZone(ctx context.Context, nodeClaim *karpv1.Node
 		return "", err
 	}
 
+	configuredZones := append([]string(nil), zones...)
 	reqs := scheduling.NewNodeSelectorRequirementsWithMinValues(nodeClaim.Spec.Requirements...)
 	zones = filterZonesByRequirement(zones, reqs)
 
 	// If no zones remain after applying requirements, fail fast.
 	if len(zones) == 0 {
-		return "", fmt.Errorf("no zones match topology requirement %q", corev1.LabelTopologyZone)
+		return "", fmt.Errorf("no zones match topology requirement %q; requested zones %s, configured GKE cluster locations %s",
+			corev1.LabelTopologyZone, strings.Join(requestedZones(reqs), ","), strings.Join(configuredZones, ","))
 	}
 
 	// Skip zones with known ICE for this instance type and capacity type.

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -371,6 +371,9 @@ func TestSelectZone_FailsWhenNoZonesMatchRequirement(t *testing.T) {
 
 	_, err := p.selectZone(ctx, nodeClaim, instanceType, karpv1.CapacityTypeOnDemand)
 	require.Error(t, err)
+	require.Contains(t, err.Error(), `no zones match topology requirement "topology.kubernetes.io/zone"`)
+	require.Contains(t, err.Error(), "requested zones europe-west4-b")
+	require.Contains(t, err.Error(), "configured GKE cluster locations europe-west4-a,europe-west4-c")
 }
 
 func TestAdoptExistingInstance_PopulatesFieldsFromGCEInstance(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Uses GKE `Cluster.locations` as the preferred provisioning zone set.

Previously, Karpenter expanded a zonal cluster location like `europe-west4-a` to every zone in `europe-west4`. That can create VMs outside the cluster's configured node locations.

If `Cluster.locations` is empty, Karpenter falls back to the existing region expansion path.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

Fixes #438

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

- Added regression coverage for populated `Cluster.locations` and the empty-locations fallback.
- Improved unsupported topology-zone errors to show requested zones and configured GKE locations.
- Zonal clusters can still use multiple node locations when those locations are configured on the cluster.
- Release note: Fixes an issue where Karpenter could provision nodes in zones outside the GKE cluster's configured locations.
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where Karpenter could provision nodes outside a GKE cluster's configured node locations by honoring `Cluster.locations` when non-empty, falling back to region-wide Compute API zone expansion only when `Cluster.locations` is empty.

- **`gke.go`**: `ResolveClusterZones` now calls `GetClusterConfig` first and uses `cluster.Locations` as the authoritative zone set when present; the fallback path now also sorts zones for deterministic output.
- **`instance.go`**: Extracts a `requestedZones` helper and enriches the "no zones match" error message with both the requested zones and the configured cluster locations.
- **Tests & docs**: Regression coverage added for both the `Locations`-populated path and the empty-fallback path; a troubleshooting guide entry documents the new error message.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is scoped to zone resolution and instance zone selection, both of which are well-covered by the new tests.

The logic is straightforward: cluster.Locations is used as a non-empty authoritative override, with the existing compute-API fallback preserved intact. GetClusterConfig was already a required dependency in the provisioning flow (called in instance.go and imagefamily/image.go), so no new IAM permission is introduced. Both paths are exercised by regression tests that use real HTTP mock servers. The error message improvement is additive and cannot regress existing behaviour.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/providers/gke/gke.go | Core fix: ResolveClusterZones now uses cluster.Locations when non-empty; zones are sorted on both code paths; TTL caveat documented with a comment. |
| pkg/providers/instance/instance.go | filterZonesByRequirement refactored to extract requestedZones helper; error message now includes requested and configured zones for better diagnostics. |
| pkg/providers/gke/gke_test.go | New test helper newTestProvider reduces boilerplate; tests cover both the cluster.Locations happy path and the empty-Locations region-expansion fallback with correct URL routing to mock servers. |
| pkg/providers/instance/instance_test.go | Existing failure test extended with three targeted assertions on the improved error message content. |
| docs/troubleshooting.md | New "Zone mismatch errors" section documents the new error format and provides a gcloud command to inspect configured cluster locations. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ResolveClusterZones called] --> B{Zone cache hit?}
    B -- Yes --> C[Return cached zones]
    B -- No --> D[GetClusterConfig]
    D --> E{cluster.Locations non-empty?}
    E -- Yes --> F[Copy & sort cluster.Locations]
    F --> G[Set zone cache 5min TTL]
    G --> H[Return zones]
    E -- No --> I[Read ProjectID & ClusterLocation from context]
    I --> J[Extract region from ClusterLocation]
    J --> K[Compute API: Zones.List with region prefix filter]
    K --> L{zones found?}
    L -- No --> M[Error: no zones for region]
    L -- Yes --> N[Sort zones]
    N --> O[Set zone cache 5min TTL]
    O --> P[Return zones]
```
</details>

<sub>Reviews (10): Last reviewed commit: ["docs: clarify zone mismatch troubleshoot..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/1b20e9668f480a61622c943a9a05de6462fb27c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36267429)</sub>

<!-- /greptile_comment -->