### PR TITLE
Add troubleshooting section for zone mismatch errors

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -199,3 +199,30 @@ To increase provisioning success:
   ```
 
 - Allow both spot and on-demand to let Karpenter fall back automatically.
+
+---
+
+## Zone mismatch errors
+
+Karpenter provisions nodes only in zones configured for your GKE cluster. If a NodePool's `topology.kubernetes.io/zone` requirement specifies zones outside the cluster's configured locations, provisioning fails with an error like:
+
+```
+no zones match topology requirement "topology.kubernetes.io/zone"; requested zones europe-west4-b, configured GKE cluster locations europe-west4-a,europe-west4-c
+```
+
+Common causes:
+
+- The NodePool requirement lists zones not in the cluster's node locations
+- The cluster is zonal (single zone) but the NodePool requests multiple zones
+
+To resolve:
+
+1. Check your cluster's configured node locations:
+
+   ```sh
+   gcloud container clusters describe CLUSTER_NAME \
+     --location=CLUSTER_LOCATION \
+     --format="value(locations)"
+   ```
+
+2. Update the NodePool `topology.kubernetes.io/zone` requirement to match available zones, or remove the requirement to let Karpenter use any configured cluster zone.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/00b7673a-6ee3-40ab-afea-50a2eae7b3bb)

Documents the improved error message from PR #439 that shows requested zones vs configured GKE cluster locations when a NodePool's topology.kubernetes.io/zone requirement doesn't match available zones.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #439: fix: honor configured GKE cluster locations](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/439)

---

_Tip: Assign suggestions to team members in the [Promptless dashboard](https://app.gopromptless.ai) to claim work 👥_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new "Zone mismatch errors" section to `docs/troubleshooting.md`, documenting the improved error message from PR #439 that surfaces requested zones vs. cluster-configured locations when a NodePool's zone requirement doesn't intersect the GKE cluster's available zones.

- Describes the error message format, lists common causes (wrong zones in requirement, zonal cluster with multi-zone requirement), and provides a `gcloud` command to inspect configured cluster locations.
- Closes the documentation gap for the behavioral change in PR #439 so users know how to diagnose and resolve zone-mismatch provisioning failures.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — documentation-only change with no code impact.

The new section is accurate and consistent with the rest of the file. The one minor point worth noting is that the gcloud --format="value(locations)" output uses semicolons as a list separator, which would mismatch the comma-separated zone list shown in the error message example — a potential source of reader confusion, but nothing that blocks the docs from being useful.

No files require special attention beyond the single gcloud format string.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/troubleshooting.md | Adds a new "Zone mismatch errors" troubleshooting section documenting the error message introduced in PR #439, with a gcloud diagnostic command and resolution steps. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[NodePool with topology.kubernetes.io/zone requirement] --> B{Zones in requirement\nintersect GKE cluster\nconfigured locations?}
    B -- Yes --> C[Provisioning proceeds\nin matching zones]
    B -- No --> D[Error: no zones match\ntopology requirement]
    D --> E[User runs gcloud describe\nto check cluster locations]
    E --> F{Fix approach}
    F -- Update requirement --> G[Set topology.kubernetes.io/zone\nto a configured cluster zone]
    F -- Remove requirement --> H[Karpenter uses any\nconfigured cluster zone]
    G --> C
    H --> C
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Ftroubleshooting.md%3A223-225%0AThe%20%60gcloud%60%20%60value%28%29%60%20format%20uses%20**semicolons**%20as%20the%20list%20separator%20for%20repeated%20fields%2C%20so%20the%20output%20of%20this%20command%20will%20look%20like%20%60europe-west4-a%3Beurope-west4-c%60%20rather%20than%20the%20comma-separated%20form%20shown%20in%20the%20error%20message%20example%20above.%20A%20reader%20who%20runs%20this%20command%20and%20then%20tries%20to%20reconcile%20the%20output%20with%20the%20error%20message%20format%20may%20be%20confused.%20Using%20%60--format%3D%22get%28locations%29%22%60%20produces%20comma-separated%20output%20that%20matches%20the%20error%20message.%0A%0A%60%60%60suggestion%0A%20%20%20gcloud%20container%20clusters%20describe%20CLUSTER_NAME%20%5C%0A%20%20%20%20%20--location%3DCLUSTER_LOCATION%20%5C%0A%20%20%20%20%20--format%3D%22get%28locations%29%22%0A%60%60%60%0A%0A&pr=440&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Ftroubleshooting.md%3A223-225%0AThe%20%60gcloud%60%20%60value%28%29%60%20format%20uses%20**semicolons**%20as%20the%20list%20separator%20for%20repeated%20fields%2C%20so%20the%20output%20of%20this%20command%20will%20look%20like%20%60europe-west4-a%3Beurope-west4-c%60%20rather%20than%20the%20comma-separated%20form%20shown%20in%20the%20error%20message%20example%20above.%20A%20reader%20who%20runs%20this%20command%20and%20then%20tries%20to%20reconcile%20the%20output%20with%20the%20error%20message%20format%20may%20be%20confused.%20Using%20%60--format%3D%22get%28locations%29%22%60%20produces%20comma-separated%20output%20that%20matches%20the%20error%20message.%0A%0A%60%60%60suggestion%0A%20%20%20gcloud%20container%20clusters%20describe%20CLUSTER_NAME%20%5C%0A%20%20%20%20%20--location%3DCLUSTER_LOCATION%20%5C%0A%20%20%20%20%20--format%3D%22get%28locations%29%22%0A%60%60%60%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=440&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22promptless%2Fdocument-zone-mismatch-error%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22promptless%2Fdocument-zone-mismatch-error%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Ftroubleshooting.md%3A223-225%0AThe%20%60gcloud%60%20%60value%28%29%60%20format%20uses%20**semicolons**%20as%20the%20list%20separator%20for%20repeated%20fields%2C%20so%20the%20output%20of%20this%20command%20will%20look%20like%20%60europe-west4-a%3Beurope-west4-c%60%20rather%20than%20the%20comma-separated%20form%20shown%20in%20the%20error%20message%20example%20above.%20A%20reader%20who%20runs%20this%20command%20and%20then%20tries%20to%20reconcile%20the%20output%20with%20the%20error%20message%20format%20may%20be%20confused.%20Using%20%60--format%3D%22get%28locations%29%22%60%20produces%20comma-separated%20output%20that%20matches%20the%20error%20message.%0A%0A%60%60%60suggestion%0A%20%20%20gcloud%20container%20clusters%20describe%20CLUSTER_NAME%20%5C%0A%20%20%20%20%20--location%3DCLUSTER_LOCATION%20%5C%0A%20%20%20%20%20--format%3D%22get%28locations%29%22%0A%60%60%60%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=440&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: add troubleshooting section for zo..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/3df6a3a2e12f4118c1cb1afc8a7ad71c56edeea3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36335322)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->