### PR TITLE
chore: fix presubmit formatter drift

### DIFF
--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -35,11 +35,11 @@ import (
 )
 
 var (
-	maxPodsPerNodeRegex     = regexp.MustCompile(`max-pods-per-node=\d+`)
-	maxPodsRegex            = regexp.MustCompile(`max-pods=\d+`)
-	gkeProvisioningRegex    = regexp.MustCompile(`gke-provisioning=\w+`)
-	kubeEnvArchRegex        = regexp.MustCompile(`\barch=(amd64|arm64)\b`)
-	kubeEnvFamilyRegex      = regexp.MustCompile(`cloud\.google\.com/machine-family=[^,;\s]+`)
+	maxPodsPerNodeRegex           = regexp.MustCompile(`max-pods-per-node=\d+`)
+	maxPodsRegex                  = regexp.MustCompile(`max-pods=\d+`)
+	gkeProvisioningRegex          = regexp.MustCompile(`gke-provisioning=\w+`)
+	kubeEnvArchRegex              = regexp.MustCompile(`\barch=(amd64|arm64)\b`)
+	kubeEnvFamilyRegex            = regexp.MustCompile(`cloud\.google\.com/machine-family=[^,;\s]+`)
 	diskTypeLabelRegex            = regexp.MustCompile(`^disk-type\.gke\.io/`)
 	diskTypeLabelEntryRegex       = regexp.MustCompile(`,?disk-type\.gke\.io/[^=,\s]+=[^,\s]*`)
 	kubeEnvNodeLabelsEmptyOKRegex = regexp.MustCompile(`--node-labels=\S*`)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fixes `make presubmit` on `origin/main` by committing the formatter output for `pkg/providers/metadata/utils.go`.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

N/A

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

#### Test Plan

- `make presubmit`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR commits the output of `gofmt` on `pkg/providers/metadata/utils.go` to fix a presubmit formatter drift failure. No logic was altered.

- Adjusts whitespace alignment of the top-level `var` block so the first five regex declarations line up with the rest of the block, matching what `gofmt` expects.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a pure whitespace realignment with no functional impact.

Only the column alignment of five variable declarations in a var block was changed. No expressions, function bodies, control flow, or types were touched, so there is no runtime risk.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/providers/metadata/utils.go | Whitespace-only alignment fix in the var block; no functional or logic changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[gofmt formatter run] --> B{var block alignment already correct?}
    B -- No --> C[Realign first 5 regex declarations to match the rest of the block]
    C --> D[make presubmit passes]
    B -- Yes --> D
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix metadata formatter drift"](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/d3fdc88d2172917a3c60c377a4f47163a61471f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36335574)</sub>

<!-- /greptile_comment -->