### PR TITLE
fix: reuse kube-env zone regex

### DIFF
--- a/pkg/providers/metadata/utils.go
+++ b/pkg/providers/metadata/utils.go
@@ -39,6 +39,7 @@ var (
 	gkeProvisioningRegex          = regexp.MustCompile(`gke-provisioning=\w+`)
 	kubeEnvArchRegex              = regexp.MustCompile(`\barch=(amd64|arm64)\b`)
 	kubeEnvFamilyRegex            = regexp.MustCompile(`cloud\.google\.com/machine-family=[^,;\s]+`)
+	kubeEnvZoneRegex              = regexp.MustCompile(`(?m)^ZONE: [^\n]+`)
 	diskTypeLabelRegex            = regexp.MustCompile(`^disk-type\.gke\.io/`)
 	diskTypeLabelEntryRegex       = regexp.MustCompile(`,?disk-type\.gke\.io/[^=,\s]+=[^,\s]*`)
 	kubeEnvNodeLabelsEmptyOKRegex = regexp.MustCompile(`--node-labels=\S*`)
@@ -456,8 +457,8 @@ func SetKubeEnvZone(metadata *compute.Metadata, zone string) error {
 			return fmt.Errorf("kube-env metadata is empty")
 		}
 		zoneLine := "ZONE: " + zone
-		if regexp.MustCompile(`(?m)^ZONE: [^\n]+`).MatchString(kubeEnv) {
-			item.Value = lo.ToPtr(patchKubeEnvKeyValue(kubeEnv, regexp.MustCompile(`(?m)^ZONE: [^\n]+`), zoneLine))
+		if kubeEnvZoneRegex.MatchString(kubeEnv) {
+			item.Value = lo.ToPtr(patchKubeEnvKeyValue(kubeEnv, kubeEnvZoneRegex, zoneLine))
 		} else {
 			item.Value = lo.ToPtr(kubeEnv + "\n" + zoneLine + "\n")
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Reuses a package-level regex when patching the kube-env zone line instead of compiling the same pattern on every call.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

N/A

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

- Follow-up to Greptile feedback on #444; `origin/main` had the same issue.
- Validation: `go test ./pkg/providers/metadata/...`
- This PR was prepared with AI assistance (Claude Code). All changes have been reviewed and verified by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Promotes the `(?m)^ZONE: [^
]+` regex from two inline `regexp.MustCompile` calls inside `SetKubeEnvZone` to a single package-level `kubeEnvZoneRegex` variable, consistent with how every other regex in the file is declared.

- The compiled regex is now reused on every invocation of `SetKubeEnvZone` instead of being rebuilt twice per call.
- No logic, behaviour, or public API is changed.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a pure refactor with no logic difference and no public API impact.

The only change is hoisting a regex literal to a package-level variable. The pattern itself is identical to what was compiled inline before, and the call sites are unchanged. There is no way for this to alter runtime behavior.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/providers/metadata/utils.go | Moves the `kubeEnvZoneRegex` pattern from inline `regexp.MustCompile` calls inside `SetKubeEnvZone` to a package-level variable, matching the style of all other regexes in the file. No logic changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SetKubeEnvZone called] --> B{item.Key == kube-env?}
    B -- No --> A
    B -- Yes --> C{kubeEnv empty?}
    C -- Yes --> D[return error]
    C -- No --> E{kubeEnvZoneRegex.MatchString}
    E -- Match --> F[patchKubeEnvKeyValue replace existing ZONE line]
    E -- No match --> G[append new ZONE line]
    F --> H[return nil]
    G --> H
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reuse kube-env zone regex"](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/e814aad6bd41a238506416cc0f8311d68671f2b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36478144)</sub>

<!-- /greptile_comment -->