### PR TITLE
Document reserved GCENodeClass metadata keys

### DIFF
--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -8,6 +8,34 @@ See [`examples/nodeclass/gcenodeclass-metadata.yaml`](https://github.com/cloudpi
 
 For example, if the base GKE node-pool template sets `serial-port-logging-enable=true`, specifying `serial-port-logging-enable: "false"` in `spec.metadata` results in the provisioned instance having `serial-port-logging-enable=false`.
 
+### Reserved metadata keys
+
+The following GKE bootstrap metadata keys are reserved and cannot be set in `spec.metadata`:
+
+- `cluster-location`
+- `cluster-name`
+- `cluster-uid`
+- `common-psm1`
+- `configure-sh`
+- `containerd-configure-sh`
+- `disable-address-manager`
+- `enable-os-login`
+- `gci-ensure-gke-docker`
+- `gci-metrics-enabled`
+- `gci-update-strategy`
+- `instance-template`
+- `install-ssh-psm1`
+- `k8s-node-setup-psm1`
+- `kube-env`
+- `kubeconfig`
+- `kubelet-config`
+- `startup-script`
+- `user-data`
+- `user-profile-psm1`
+- `windows-startup-script-ps1`
+
+Using any of these keys causes a CRD validation error at admission time. Custom metadata keys not in this list work normally.
+
 > **Note:** For GPU driver version control, use `spec.gpuDriverVersion` instead of setting `cloud.google.com/gke-gpu-driver-version` via metadata. See [GPU Nodes](../gpu-nodes.md) for details.
 
 ## Secondary boot disk (container image pre-loading)


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/96b87f18-3d1d-46f8-8619-7dc9c5615acd)

Add documentation for the new CRD validation that rejects GKE-reserved bootstrap metadata keys in GCENodeClass.spec.metadata. Lists all 21 reserved keys and explains that using them causes a validation error at admission time.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #446: feat: reject reserved nodeclass metadata keys](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/446)

---

_Tip: Sort by Shortest Review in the [Dashboard](https://app.gopromptless.ai) to find quick wins ⚡_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a \"Reserved metadata keys\" subsection to `docs/examples/advanced.md` that lists 21 GKE bootstrap metadata keys blocked from `spec.metadata` and states they trigger a CRD validation error at admission time.

- The implementation that would enforce this validation (kubebuilder XValidation markers on the `Metadata` field) is tracked in a separate, not-yet-merged PR (#446); the current `GCENodeClassSpec.Metadata` field has no reserved-key guards at HEAD.
- The 21-key list and prose description are accurate to what PR #446 intends, but they should either land after #446 is merged or carry a version caveat so users aren't misled by non-existent validation.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The documentation change is accurate in content but describes validation behaviour not yet present in the codebase; merging this before the implementation PR (#446) would mislead users.

The 21-key list matches what PR #446 intends to implement, but the Metadata field in GCENodeClassSpec currently carries no XValidation markers at HEAD. A user reading these docs today would try a reserved key, get no error, and either file a bug or silently misconfigure a node.

docs/examples/advanced.md — the new section should be held until the matching implementation in PR #446 is merged, or annotated with a minimum provider version.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/examples/advanced.md | Adds a "Reserved metadata keys" subsection listing 21 GKE bootstrap keys. The corresponding CRD validation (XValidation markers on the Metadata field) is not yet present in the repository — the implementation lives in the unreleased PR #446, so the documented behavior does not match the current code. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User sets spec.metadata key] --> B{Key in reserved list?}
    B -- No --> C[Key accepted and applied to GCE instance]
    B -- Yes --> D[CRD admission validation rejects request]
    D --> E[Validation error returned to user]
    style D fill:#f88,stroke:#c00
    style E fill:#f88,stroke:#c00
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fexamples%2Fadvanced.md%3A11-37%0A**Documentation%20describes%20unimplemented%20validation**%0A%0AThe%20%60Metadata%60%20field%20in%20%60GCENodeClassSpec%60%20%28%60pkg%2Fapis%2Fv1alpha1%2Fgcenodeclass.go%60%2C%20line%2079%E2%80%9381%29%20currently%20has%20no%20%60%2Bkubebuilder%3Avalidation%3AXValidation%60%20markers%20for%20any%20reserved%20keys%20%E2%80%94%20there%20are%20no%20admission-time%20guards%20in%20the%20CRD%20at%20the%20current%20HEAD.%20The%20referenced%20implementation%20PR%20%23446%20has%20not%20been%20merged%20into%20%60main%60%20yet%2C%20so%20users%20who%20read%20this%20page%20and%20expect%20a%20validation%20error%20when%20setting%20e.g.%20%60kube-env%60%20will%20instead%20see%20the%20value%20silently%20accepted.%20This%20doc%20should%20either%20be%20merged%20after%20%23446%20lands%2C%20or%20gated%20%28e.g.%20a%20note%20saying%20%22requires%20provider%20version%20X%22%29%20so%20readers%20aren't%20misled%20by%20behavior%20that%20doesn't%20exist%20yet.%0A%0A&pr=447&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fexamples%2Fadvanced.md%3A11-37%0A**Documentation%20describes%20unimplemented%20validation**%0A%0AThe%20%60Metadata%60%20field%20in%20%60GCENodeClassSpec%60%20%28%60pkg%2Fapis%2Fv1alpha1%2Fgcenodeclass.go%60%2C%20line%2079%E2%80%9381%29%20currently%20has%20no%20%60%2Bkubebuilder%3Avalidation%3AXValidation%60%20markers%20for%20any%20reserved%20keys%20%E2%80%94%20there%20are%20no%20admission-time%20guards%20in%20the%20CRD%20at%20the%20current%20HEAD.%20The%20referenced%20implementation%20PR%20%23446%20has%20not%20been%20merged%20into%20%60main%60%20yet%2C%20so%20users%20who%20read%20this%20page%20and%20expect%20a%20validation%20error%20when%20setting%20e.g.%20%60kube-env%60%20will%20instead%20see%20the%20value%20silently%20accepted.%20This%20doc%20should%20either%20be%20merged%20after%20%23446%20lands%2C%20or%20gated%20%28e.g.%20a%20note%20saying%20%22requires%20provider%20version%20X%22%29%20so%20readers%20aren't%20misled%20by%20behavior%20that%20doesn't%20exist%20yet.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=447&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22promptless%2Fdocument-reserved-metadata-keys%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22promptless%2Fdocument-reserved-metadata-keys%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fexamples%2Fadvanced.md%3A11-37%0A**Documentation%20describes%20unimplemented%20validation**%0A%0AThe%20%60Metadata%60%20field%20in%20%60GCENodeClassSpec%60%20%28%60pkg%2Fapis%2Fv1alpha1%2Fgcenodeclass.go%60%2C%20line%2079%E2%80%9381%29%20currently%20has%20no%20%60%2Bkubebuilder%3Avalidation%3AXValidation%60%20markers%20for%20any%20reserved%20keys%20%E2%80%94%20there%20are%20no%20admission-time%20guards%20in%20the%20CRD%20at%20the%20current%20HEAD.%20The%20referenced%20implementation%20PR%20%23446%20has%20not%20been%20merged%20into%20%60main%60%20yet%2C%20so%20users%20who%20read%20this%20page%20and%20expect%20a%20validation%20error%20when%20setting%20e.g.%20%60kube-env%60%20will%20instead%20see%20the%20value%20silently%20accepted.%20This%20doc%20should%20either%20be%20merged%20after%20%23446%20lands%2C%20or%20gated%20%28e.g.%20a%20note%20saying%20%22requires%20provider%20version%20X%22%29%20so%20readers%20aren't%20misled%20by%20behavior%20that%20doesn't%20exist%20yet.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=447&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: document reserved GCENodeClass met..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/41ea5749a7ad9188f704f7097d0ec5c1ff41725b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36488590)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->