### PR TITLE
Document gke-cpu-scaling-level label for GPU nodes

### DIFF
--- a/docs/gpu-nodes.md
+++ b/docs/gpu-nodes.md
@@ -10,12 +10,13 @@ Karpenter can provision GPU-equipped GKE nodes for workloads that request `nvidi
 
 ## GKE GPU software stack labels
 
-GKE's GPU software stack requires two labels for GPU nodes to function:
+GKE's GPU software stack requires several labels for GPU nodes to function:
 
 - `cloud.google.com/gke-accelerator=<type>` — used by the NVIDIA device plugin DaemonSet to target GPU nodes via node affinity.
 - `cloud.google.com/gke-gpu-driver-version=<value>` — used by the GKE GPU driver installer to select the NVIDIA driver version.
+- `cloud.google.com/gke-cpu-scaling-level=<cpu>` — used by GKE's NVIDIA device plugin DaemonSets to select the appropriate plugin variant (small/medium/large) for GPU nodes.
 
-Karpenter automatically applies both labels at node boot time. The accelerator type is derived from the instance type. The driver version is controlled by `spec.gpuDriverVersion`.
+Karpenter applies these labels automatically at node boot time. The accelerator type and CPU scaling level are derived from the instance type; the driver version is controlled by `spec.gpuDriverVersion`.
 
 ## GPU driver version
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/354b94af-d224-48d2-bbfb-87de793fc910)

Updates the GPU nodes documentation to include the cloud.google.com/gke-cpu-scaling-level label, which GKE's NVIDIA device plugin DaemonSets use to select the appropriate plugin variant for GPU nodes. This label was restored in PR #448.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #448: fix: restore GKE readiness labels](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/448)

---

_Tip: Whenever you leave a comment tagged `@Promptless` on a Promptless PR, Promptless will remember it for future suggestions 🧠_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `cloud.google.com/gke-cpu-scaling-level` to the GPU nodes documentation, claiming it is automatically applied by Karpenter at node boot time alongside the accelerator and driver-version labels.

- The label is not present in any Go source file (`labels.go`, `instance.go`, `metadata/utils.go`, etc.) — a full-codebase search returns only this documentation file as a match.
- The referenced implementation PR (#448) does not appear in the git history, indicating it has not yet been merged; this documentation would go live ahead of the actual feature.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The documentation describes automatic label application for gke-cpu-scaling-level, but the feature does not exist in the current codebase and the implementation PR it references has not been merged.

The updated prose makes a factual promise that is not backed by any code in this repository. Users who rely on this label being present will find that GPU nodes are missing it and the NVIDIA device plugin variant selection will fail silently.

docs/gpu-nodes.md — the claim that gke-cpu-scaling-level is applied automatically is inaccurate given the current state of the codebase.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/gpu-nodes.md | Adds documentation for the gke-cpu-scaling-level label, but the label is not yet applied by any code in the repository — the referenced PR #448 is not merged. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Node Provisioning] --> B[instance.go: setupGPULabels]
    B --> C[SetGPUAcceleratorLabel\ngke-accelerator=TYPE]
    B --> D[SetGPUDriverVersionLabel\ngke-gpu-driver-version=VERSION]
    B -.->|NOT YET IMPLEMENTED| E[gke-cpu-scaling-level=CPU\n❌ missing from code]
    C --> F[Node registered in GKE]
    D --> F
    F --> G[NVIDIA device plugin DaemonSet\nselects node via gke-accelerator]
    F -.->|depends on missing label| H[NVIDIA plugin variant selection\nsmall/medium/large]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fgpu-nodes.md%3A17-19%0A**Documentation%20ahead%20of%20implementation**%0A%0AThe%20doc%20states%20%22Karpenter%20applies%20these%20labels%20automatically%20at%20node%20boot%20time.%20The%20accelerator%20type%20and%20CPU%20scaling%20level%20are%20derived%20from%20the%20instance%20type%22%20%E2%80%94%20but%20there%20is%20no%20code%20in%20this%20repository%20that%20actually%20sets%20%60cloud.google.com%2Fgke-cpu-scaling-level%60.%20Searching%20the%20entire%20codebase%20returns%20only%20this%20doc%20file%20as%20a%20match%3B%20%60pkg%2Fproviders%2Finstance%2Finstance.go%60%20applies%20only%20%60gke-accelerator%60%20and%20%60gke-gpu-driver-version%60.%20The%20referenced%20PR%20%23448%20%28%22fix%3A%20restore%20GKE%20readiness%20labels%22%29%20does%20not%20appear%20in%20the%20git%20history%2C%20which%20means%20it%20has%20not%20yet%20been%20merged.%20Merging%20this%20documentation%20now%20means%20users%20will%20read%20that%20the%20label%20is%20applied%20automatically%20when%20it%20isn't%2C%20potentially%20causing%20them%20to%20rely%20on%20it%20and%20discover%20the%20NVIDIA%20device%20plugin%20DaemonSet%20can't%20select%20the%20correct%20plugin%20variant%20for%20their%20GPU%20nodes.%0A%0A&pr=449&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fgpu-nodes.md%3A17-19%0A**Documentation%20ahead%20of%20implementation**%0A%0AThe%20doc%20states%20%22Karpenter%20applies%20these%20labels%20automatically%20at%20node%20boot%20time.%20The%20accelerator%20type%20and%20CPU%20scaling%20level%20are%20derived%20from%20the%20instance%20type%22%20%E2%80%94%20but%20there%20is%20no%20code%20in%20this%20repository%20that%20actually%20sets%20%60cloud.google.com%2Fgke-cpu-scaling-level%60.%20Searching%20the%20entire%20codebase%20returns%20only%20this%20doc%20file%20as%20a%20match%3B%20%60pkg%2Fproviders%2Finstance%2Finstance.go%60%20applies%20only%20%60gke-accelerator%60%20and%20%60gke-gpu-driver-version%60.%20The%20referenced%20PR%20%23448%20%28%22fix%3A%20restore%20GKE%20readiness%20labels%22%29%20does%20not%20appear%20in%20the%20git%20history%2C%20which%20means%20it%20has%20not%20yet%20been%20merged.%20Merging%20this%20documentation%20now%20means%20users%20will%20read%20that%20the%20label%20is%20applied%20automatically%20when%20it%20isn't%2C%20potentially%20causing%20them%20to%20rely%20on%20it%20and%20discover%20the%20NVIDIA%20device%20plugin%20DaemonSet%20can't%20select%20the%20correct%20plugin%20variant%20for%20their%20GPU%20nodes.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=449&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22promptless%2Fdocument-gpu-cpu-scaling-label%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22promptless%2Fdocument-gpu-cpu-scaling-label%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fgpu-nodes.md%3A17-19%0A**Documentation%20ahead%20of%20implementation**%0A%0AThe%20doc%20states%20%22Karpenter%20applies%20these%20labels%20automatically%20at%20node%20boot%20time.%20The%20accelerator%20type%20and%20CPU%20scaling%20level%20are%20derived%20from%20the%20instance%20type%22%20%E2%80%94%20but%20there%20is%20no%20code%20in%20this%20repository%20that%20actually%20sets%20%60cloud.google.com%2Fgke-cpu-scaling-level%60.%20Searching%20the%20entire%20codebase%20returns%20only%20this%20doc%20file%20as%20a%20match%3B%20%60pkg%2Fproviders%2Finstance%2Finstance.go%60%20applies%20only%20%60gke-accelerator%60%20and%20%60gke-gpu-driver-version%60.%20The%20referenced%20PR%20%23448%20%28%22fix%3A%20restore%20GKE%20readiness%20labels%22%29%20does%20not%20appear%20in%20the%20git%20history%2C%20which%20means%20it%20has%20not%20yet%20been%20merged.%20Merging%20this%20documentation%20now%20means%20users%20will%20read%20that%20the%20label%20is%20applied%20automatically%20when%20it%20isn't%2C%20potentially%20causing%20them%20to%20rely%20on%20it%20and%20discover%20the%20NVIDIA%20device%20plugin%20DaemonSet%20can't%20select%20the%20correct%20plugin%20variant%20for%20their%20GPU%20nodes.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=449&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: document gke-cpu-scaling-level lab..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/aca99ad78d9cd8396e361060de11399f8b0413e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36565561)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->