### PR TITLE
[codex] Bound instance type cache growth

### DIFF
--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -85,7 +85,9 @@ type DefaultProvider struct {
 
 	unavailableOfferings *pkgcache.UnavailableOfferings
 	// FIXME: use cache to speed up query.
-	instanceTypesCache *cache.Cache
+	instanceTypesCache         *cache.Cache
+	muInstanceTypesCache       sync.Mutex
+	instanceTypesCacheRevision string
 }
 
 func NewDefaultProvider(ctx context.Context, authOptions *auth.Credential, pricingProvider pricing.Provider,
@@ -120,6 +122,7 @@ func (p *DefaultProvider) validateState() error {
 	return nil
 }
 
+//nolint:gocyclo // List keeps cache invalidation and instance type construction together to avoid stale cache writes.
 func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1alpha1.GCENodeClass) ([]*cloudprovider.InstanceType, error) {
 	p.muInstanceTypesInfo.RLock()
 	defer p.muInstanceTypesInfo.RUnlock()
@@ -136,9 +139,19 @@ func (p *DefaultProvider) List(ctx context.Context, nodeClass *v1alpha1.GCENodeC
 	zonesHash, _ := hashstructure.Hash(zones, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	kcHash, _ := hashstructure.Hash(nodeClass.Spec.KubeletConfiguration, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	disksHash, _ := hashstructure.Hash(nodeClass.Spec.Disks, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
-	listKey := fmt.Sprintf("%d-%d-%d-%d-%d", p.instanceTypesSeqNum, p.unavailableOfferings.SeqNum, zonesHash, kcHash, disksHash)
-	item, ok := p.instanceTypesCache.Get(listKey)
-	if ok && len(item.([]*cloudprovider.InstanceType)) > 0 {
+
+	instanceTypesSeqNum := atomic.LoadUint64(&p.instanceTypesSeqNum)
+	unavailableOfferingsSeqNum := atomic.LoadUint64(&p.unavailableOfferings.SeqNum)
+	cacheRevision := fmt.Sprintf("%d-%d", instanceTypesSeqNum, unavailableOfferingsSeqNum)
+	listKey := fmt.Sprintf("%s-%d-%d-%d", cacheRevision, zonesHash, kcHash, disksHash)
+
+	p.muInstanceTypesCache.Lock()
+	defer p.muInstanceTypesCache.Unlock()
+	if p.instanceTypesCacheRevision != cacheRevision {
+		p.instanceTypesCache.Flush()
+		p.instanceTypesCacheRevision = cacheRevision
+	}
+	if item, ok := p.instanceTypesCache.Get(listKey); ok && len(item.([]*cloudprovider.InstanceType)) > 0 {
 		return item.([]*cloudprovider.InstanceType), nil
 	}
 

--- a/pkg/providers/instancetype/types_test.go
+++ b/pkg/providers/instancetype/types_test.go
@@ -78,6 +78,34 @@ func TestListEphemeralStorageCacheIsolation(t *testing.T) {
 		"each distinct disk config must produce a separate cache entry")
 }
 
+func TestListUnavailableOfferingsCacheRevisionEvictsStaleEntries(t *testing.T) {
+	ctx := options.ToContext(context.Background(), &options.Options{VMMemoryOverheadPercent: 0.07})
+	p := newTestProvider()
+
+	nodeClass := &v1alpha1.GCENodeClass{}
+	first, err := p.List(ctx, nodeClass)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, first)
+	assert.True(t, spotOfferingAvailable(first[0].Offerings))
+
+	p.unavailableOfferings.MarkUnavailable(ctx, "ICE", "n2-standard-4", "us-central1-a", karpv1.CapacityTypeSpot)
+	second, err := p.List(ctx, nodeClass)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, second)
+	assert.False(t, spotOfferingAvailable(second[0].Offerings))
+	assert.Equal(t, 1, p.instanceTypesCache.ItemCount(),
+		"unavailable offering changes must evict stale instance type cache entries")
+}
+
+func spotOfferingAvailable(offerings cloudprovider.Offerings) bool {
+	for _, offering := range offerings {
+		if offering.Requirements.Get(karpv1.CapacityTypeLabelKey).Any() == karpv1.CapacityTypeSpot {
+			return offering.Available
+		}
+	}
+	return false
+}
+
 func TestCalculateDiskConfiguration(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
## Summary

Bounds the instance type list cache so stale dynamic revisions are evicted instead of retaining full `[]*InstanceType` snapshots for the 30 hour TTL.

## Root cause

`DefaultProvider.List()` keys its cache by instance type sequence, unavailable offering sequence, zone hash, kubelet config hash, and disk hash. When `UnavailableOfferings.SeqNum` changes, the next `List()` call creates a new full instance type list entry, while the old entries remain resident until the long TTL expires. Frequent ICE/preemption updates can therefore retain many large list snapshots.

## Changes

- Track the current dynamic cache revision from instance type and unavailable offering sequence numbers.
- Flush stale instance type cache entries when that revision changes.
- Preserve separate cache entries for static NodeClass-dependent inputs within the current revision.
- Use atomic loads for sequence numbers that are incremented atomically.
- Add regression coverage for unavailable offering changes evicting stale instance type cache entries.

## Validation

- `go test ./pkg/providers/instancetype ./pkg/cache`
- `git diff --check`
- `make presubmit`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bounds the `instanceTypesCache` memory footprint by introducing a `cacheRevision` string (combining `instanceTypesSeqNum` and `unavailableOfferings.SeqNum`) and flushing all stale entries whenever that revision changes, rather than letting them accumulate for the full 30-hour TTL.

- **`instancetype.go`**: Adds `muInstanceTypesCache sync.Mutex` and `instanceTypesCacheRevision string` to `DefaultProvider`; `List()` now atomically reads both sequence numbers, checks for a revision change, flushes if needed, and serialises the cache-miss rebuild behind the new mutex.
- **`types_test.go`**: Adds `TestListUnavailableOfferingsCacheRevisionEvictsStaleEntries` to regression-test that a `MarkUnavailable` call evicts the prior cache entry and returns a freshly computed result with the correct offering availability, plus the `spotOfferingAvailable` helper that inspects an offering slice by capacity-type label.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the cache-flush logic is correct and the new mutex prevents concurrent stale writes, with two non-blocking observations about mutex hold duration and zone-change coverage.

The revision-based flush correctly evicts stale entries when either sequence number changes, and the new test provides direct regression coverage. Two observations remain: the cache mutex is held for the full rebuild loop (potential latency spike when many goroutines hit a revision change simultaneously) and zone changes are excluded from the revision (old zone-keyed entries accumulate until TTL, partially preserving memory growth for the zone-change case). Neither affects correctness in the common path.

pkg/providers/instancetype/instancetype.go — the mutex hold duration during cache rebuild and the missing zone-based revision component are worth a second look.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pkg/providers/instancetype/instancetype.go | Adds cache revision tracking (instanceTypesSeqNum + unavailableOfferingsSeqNum) with a flush-on-revision-change strategy to bound cache growth; two P2 observations: the cache mutex is held during the full instance-type rebuild (potential latency spike) and zone changes are not included in the revision (stale zone-keyed entries can accumulate until TTL). |
| pkg/providers/instancetype/types_test.go | Adds TestListUnavailableOfferingsCacheRevisionEvictsStaleEntries and spotOfferingAvailable helper; test correctly uses the single-instance-type test provider to verify spot is marked unavailable after MarkUnavailable fires and that ItemCount is 1 post-flush. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as List() caller
    participant Prov as DefaultProvider
    participant UO as UnavailableOfferings
    participant Cache as instanceTypesCache

    Caller->>Prov: List(ctx, nodeClass)
    Prov->>Prov: muInstanceTypesInfo.RLock()
    Prov->>Prov: atomic.LoadUint64(instanceTypesSeqNum)
    Prov->>UO: atomic.LoadUint64(SeqNum)
    UO-->>Prov: unavailableOfferingsSeqNum
    Prov->>Prov: "cacheRevision = seqA-seqB"
    Prov->>Prov: "listKey = cacheRevision-zonesHash-kcHash-disksHash"
    Prov->>Prov: muInstanceTypesCache.Lock()
    alt revision changed
        Prov->>Cache: Flush()
        Prov->>Prov: "instanceTypesCacheRevision = cacheRevision"
    end
    alt cache hit
        Prov->>Cache: Get(listKey)
        Cache-->>Prov: "[]*InstanceType"
        Prov-->>Caller: return cached list
    else cache miss
        Prov->>Prov: build instanceTypes loop
        Prov->>UO: IsUnavailable(instanceType, zone, capacityType)
        UO-->>Prov: bool
        Prov->>Cache: SetDefault(listKey, instanceTypes)
        Prov-->>Caller: return built list
    end
    Prov->>Prov: muInstanceTypesCache.Unlock()
    Prov->>Prov: muInstanceTypesInfo.RUnlock()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as List() caller
    participant Prov as DefaultProvider
    participant UO as UnavailableOfferings
    participant Cache as instanceTypesCache

    Caller->>Prov: List(ctx, nodeClass)
    Prov->>Prov: muInstanceTypesInfo.RLock()
    Prov->>Prov: atomic.LoadUint64(instanceTypesSeqNum)
    Prov->>UO: atomic.LoadUint64(SeqNum)
    UO-->>Prov: unavailableOfferingsSeqNum
    Prov->>Prov: "cacheRevision = seqA-seqB"
    Prov->>Prov: "listKey = cacheRevision-zonesHash-kcHash-disksHash"
    Prov->>Prov: muInstanceTypesCache.Lock()
    alt revision changed
        Prov->>Cache: Flush()
        Prov->>Prov: "instanceTypesCacheRevision = cacheRevision"
    end
    alt cache hit
        Prov->>Cache: Get(listKey)
        Cache-->>Prov: "[]*InstanceType"
        Prov-->>Caller: return cached list
    else cache miss
        Prov->>Prov: build instanceTypes loop
        Prov->>UO: IsUnavailable(instanceType, zone, capacityType)
        UO-->>Prov: bool
        Prov->>Cache: SetDefault(listKey, instanceTypes)
        Prov-->>Caller: return built list
    end
    Prov->>Prov: muInstanceTypesCache.Unlock()
    Prov->>Prov: muInstanceTypesInfo.RUnlock()
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pkg/providers/instancetype/instancetype.go`, line 148-174 ([link](https://github.com/cloudpilot-ai/karpenter-provider-gcp/blob/61e349ce3dce65c52492a8c4ffa2c7cf0b00ed20/pkg/providers/instancetype/instancetype.go#L148-L174)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Cache mutex held during full instance-type rebuild**

   `muInstanceTypesCache.Lock()` is acquired before the cache miss check and held — via `defer` — through the entire `for _, mt := range p.instanceTypesInfo` loop. On a revision change (e.g., a burst of ICE events), every concurrent `List()` caller serialises here while the rebuilding goroutine iterates potentially hundreds of machine types, all while also holding `muInstanceTypesInfo.RLock()`. This blocks `UpdateInstanceTypes` and `UpdateInstanceTypeOfferings` from acquiring their write lock for the duration of the rebuild, and causes scheduling latency spikes if several goroutines call `List()` simultaneously.

   A `singleflight.Group` keyed by `listKey` would let concurrent callers wait for one rebuild rather than each queuing behind the mutex, without requiring the full mutex hold.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fproviders%2Finstancetype%2Finstancetype.go%0ALine%3A%20148-174%0A%0AComment%3A%0A**Cache%20mutex%20held%20during%20full%20instance-type%20rebuild**%0A%0A%60muInstanceTypesCache.Lock%28%29%60%20is%20acquired%20before%20the%20cache%20miss%20check%20and%20held%20%E2%80%94%20via%20%60defer%60%20%E2%80%94%20through%20the%20entire%20%60for%20_%2C%20mt%20%3A%3D%20range%20p.instanceTypesInfo%60%20loop.%20On%20a%20revision%20change%20%28e.g.%2C%20a%20burst%20of%20ICE%20events%29%2C%20every%20concurrent%20%60List%28%29%60%20caller%20serialises%20here%20while%20the%20rebuilding%20goroutine%20iterates%20potentially%20hundreds%20of%20machine%20types%2C%20all%20while%20also%20holding%20%60muInstanceTypesInfo.RLock%28%29%60.%20This%20blocks%20%60UpdateInstanceTypes%60%20and%20%60UpdateInstanceTypeOfferings%60%20from%20acquiring%20their%20write%20lock%20for%20the%20duration%20of%20the%20rebuild%2C%20and%20causes%20scheduling%20latency%20spikes%20if%20several%20goroutines%20call%20%60List%28%29%60%20simultaneously.%0A%0AA%20%60singleflight.Group%60%20keyed%20by%20%60listKey%60%20would%20let%20concurrent%20callers%20wait%20for%20one%20rebuild%20rather%20than%20each%20queuing%20behind%20the%20mutex%2C%20without%20requiring%20the%20full%20mutex%20hold.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=461&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fproviders%2Finstancetype%2Finstancetype.go%0ALine%3A%20148-174%0A%0AComment%3A%0A**Cache%20mutex%20held%20during%20full%20instance-type%20rebuild**%0A%0A%60muInstanceTypesCache.Lock%28%29%60%20is%20acquired%20before%20the%20cache%20miss%20check%20and%20held%20%E2%80%94%20via%20%60defer%60%20%E2%80%94%20through%20the%20entire%20%60for%20_%2C%20mt%20%3A%3D%20range%20p.instanceTypesInfo%60%20loop.%20On%20a%20revision%20change%20%28e.g.%2C%20a%20burst%20of%20ICE%20events%29%2C%20every%20concurrent%20%60List%28%29%60%20caller%20serialises%20here%20while%20the%20rebuilding%20goroutine%20iterates%20potentially%20hundreds%20of%20machine%20types%2C%20all%20while%20also%20holding%20%60muInstanceTypesInfo.RLock%28%29%60.%20This%20blocks%20%60UpdateInstanceTypes%60%20and%20%60UpdateInstanceTypeOfferings%60%20from%20acquiring%20their%20write%20lock%20for%20the%20duration%20of%20the%20rebuild%2C%20and%20causes%20scheduling%20latency%20spikes%20if%20several%20goroutines%20call%20%60List%28%29%60%20simultaneously.%0A%0AA%20%60singleflight.Group%60%20keyed%20by%20%60listKey%60%20would%20let%20concurrent%20callers%20wait%20for%20one%20rebuild%20rather%20than%20each%20queuing%20behind%20the%20mutex%2C%20without%20requiring%20the%20full%20mutex%20hold.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=461&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22codex%2Fbound-instance-type-cache-growth%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fbound-instance-type-cache-growth%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fproviders%2Finstancetype%2Finstancetype.go%0ALine%3A%20148-174%0A%0AComment%3A%0A**Cache%20mutex%20held%20during%20full%20instance-type%20rebuild**%0A%0A%60muInstanceTypesCache.Lock%28%29%60%20is%20acquired%20before%20the%20cache%20miss%20check%20and%20held%20%E2%80%94%20via%20%60defer%60%20%E2%80%94%20through%20the%20entire%20%60for%20_%2C%20mt%20%3A%3D%20range%20p.instanceTypesInfo%60%20loop.%20On%20a%20revision%20change%20%28e.g.%2C%20a%20burst%20of%20ICE%20events%29%2C%20every%20concurrent%20%60List%28%29%60%20caller%20serialises%20here%20while%20the%20rebuilding%20goroutine%20iterates%20potentially%20hundreds%20of%20machine%20types%2C%20all%20while%20also%20holding%20%60muInstanceTypesInfo.RLock%28%29%60.%20This%20blocks%20%60UpdateInstanceTypes%60%20and%20%60UpdateInstanceTypeOfferings%60%20from%20acquiring%20their%20write%20lock%20for%20the%20duration%20of%20the%20rebuild%2C%20and%20causes%20scheduling%20latency%20spikes%20if%20several%20goroutines%20call%20%60List%28%29%60%20simultaneously.%0A%0AA%20%60singleflight.Group%60%20keyed%20by%20%60listKey%60%20would%20let%20concurrent%20callers%20wait%20for%20one%20rebuild%20rather%20than%20each%20queuing%20behind%20the%20mutex%2C%20without%20requiring%20the%20full%20mutex%20hold.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=461&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apkg%2Fproviders%2Finstancetype%2Finstancetype.go%3A148-174%0A**Cache%20mutex%20held%20during%20full%20instance-type%20rebuild**%0A%0A%60muInstanceTypesCache.Lock%28%29%60%20is%20acquired%20before%20the%20cache%20miss%20check%20and%20held%20%E2%80%94%20via%20%60defer%60%20%E2%80%94%20through%20the%20entire%20%60for%20_%2C%20mt%20%3A%3D%20range%20p.instanceTypesInfo%60%20loop.%20On%20a%20revision%20change%20%28e.g.%2C%20a%20burst%20of%20ICE%20events%29%2C%20every%20concurrent%20%60List%28%29%60%20caller%20serialises%20here%20while%20the%20rebuilding%20goroutine%20iterates%20potentially%20hundreds%20of%20machine%20types%2C%20all%20while%20also%20holding%20%60muInstanceTypesInfo.RLock%28%29%60.%20This%20blocks%20%60UpdateInstanceTypes%60%20and%20%60UpdateInstanceTypeOfferings%60%20from%20acquiring%20their%20write%20lock%20for%20the%20duration%20of%20the%20rebuild%2C%20and%20causes%20scheduling%20latency%20spikes%20if%20several%20goroutines%20call%20%60List%28%29%60%20simultaneously.%0A%0AA%20%60singleflight.Group%60%20keyed%20by%20%60listKey%60%20would%20let%20concurrent%20callers%20wait%20for%20one%20rebuild%20rather%20than%20each%20queuing%20behind%20the%20mutex%2C%20without%20requiring%20the%20full%20mutex%20hold.%0A%0A%23%23%23%20Issue%202%20of%202%0Apkg%2Fproviders%2Finstancetype%2Finstancetype.go%3A143-146%0A**Zone%20changes%20don't%20trigger%20a%20cache%20flush**%0A%0A%60cacheRevision%60%20tracks%20only%20%60instanceTypesSeqNum%60%20and%20%60unavailableOfferingsSeqNum%60%3B%20it%20does%20not%20include%20%60zonesHash%60.%20If%20%60ResolveClusterZones%60%20returns%20a%20different%20set%20of%20zones%20%28e.g.%2C%20a%20zone%20is%20added%20or%20removed%29%2C%20the%20old%20per-zone%20cache%20entries%20accumulate%20until%20their%2030-hour%20TTL%20because%20the%20revision%20never%20changes.%20These%20entries%20are%20never%20served%20%28the%20%60listKey%60%20computed%20with%20the%20new%20%60zonesHash%60%20differs%29%2C%20but%20they%20still%20consume%20memory%20%E2%80%94%20partially%20undermining%20the%20stated%20goal%20of%20bounding%20cache%20growth.%0A%0A&pr=461&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apkg%2Fproviders%2Finstancetype%2Finstancetype.go%3A148-174%0A**Cache%20mutex%20held%20during%20full%20instance-type%20rebuild**%0A%0A%60muInstanceTypesCache.Lock%28%29%60%20is%20acquired%20before%20the%20cache%20miss%20check%20and%20held%20%E2%80%94%20via%20%60defer%60%20%E2%80%94%20through%20the%20entire%20%60for%20_%2C%20mt%20%3A%3D%20range%20p.instanceTypesInfo%60%20loop.%20On%20a%20revision%20change%20%28e.g.%2C%20a%20burst%20of%20ICE%20events%29%2C%20every%20concurrent%20%60List%28%29%60%20caller%20serialises%20here%20while%20the%20rebuilding%20goroutine%20iterates%20potentially%20hundreds%20of%20machine%20types%2C%20all%20while%20also%20holding%20%60muInstanceTypesInfo.RLock%28%29%60.%20This%20blocks%20%60UpdateInstanceTypes%60%20and%20%60UpdateInstanceTypeOfferings%60%20from%20acquiring%20their%20write%20lock%20for%20the%20duration%20of%20the%20rebuild%2C%20and%20causes%20scheduling%20latency%20spikes%20if%20several%20goroutines%20call%20%60List%28%29%60%20simultaneously.%0A%0AA%20%60singleflight.Group%60%20keyed%20by%20%60listKey%60%20would%20let%20concurrent%20callers%20wait%20for%20one%20rebuild%20rather%20than%20each%20queuing%20behind%20the%20mutex%2C%20without%20requiring%20the%20full%20mutex%20hold.%0A%0A%23%23%23%20Issue%202%20of%202%0Apkg%2Fproviders%2Finstancetype%2Finstancetype.go%3A143-146%0A**Zone%20changes%20don't%20trigger%20a%20cache%20flush**%0A%0A%60cacheRevision%60%20tracks%20only%20%60instanceTypesSeqNum%60%20and%20%60unavailableOfferingsSeqNum%60%3B%20it%20does%20not%20include%20%60zonesHash%60.%20If%20%60ResolveClusterZones%60%20returns%20a%20different%20set%20of%20zones%20%28e.g.%2C%20a%20zone%20is%20added%20or%20removed%29%2C%20the%20old%20per-zone%20cache%20entries%20accumulate%20until%20their%2030-hour%20TTL%20because%20the%20revision%20never%20changes.%20These%20entries%20are%20never%20served%20%28the%20%60listKey%60%20computed%20with%20the%20new%20%60zonesHash%60%20differs%29%2C%20but%20they%20still%20consume%20memory%20%E2%80%94%20partially%20undermining%20the%20stated%20goal%20of%20bounding%20cache%20growth.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=461&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22codex%2Fbound-instance-type-cache-growth%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fbound-instance-type-cache-growth%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apkg%2Fproviders%2Finstancetype%2Finstancetype.go%3A148-174%0A**Cache%20mutex%20held%20during%20full%20instance-type%20rebuild**%0A%0A%60muInstanceTypesCache.Lock%28%29%60%20is%20acquired%20before%20the%20cache%20miss%20check%20and%20held%20%E2%80%94%20via%20%60defer%60%20%E2%80%94%20through%20the%20entire%20%60for%20_%2C%20mt%20%3A%3D%20range%20p.instanceTypesInfo%60%20loop.%20On%20a%20revision%20change%20%28e.g.%2C%20a%20burst%20of%20ICE%20events%29%2C%20every%20concurrent%20%60List%28%29%60%20caller%20serialises%20here%20while%20the%20rebuilding%20goroutine%20iterates%20potentially%20hundreds%20of%20machine%20types%2C%20all%20while%20also%20holding%20%60muInstanceTypesInfo.RLock%28%29%60.%20This%20blocks%20%60UpdateInstanceTypes%60%20and%20%60UpdateInstanceTypeOfferings%60%20from%20acquiring%20their%20write%20lock%20for%20the%20duration%20of%20the%20rebuild%2C%20and%20causes%20scheduling%20latency%20spikes%20if%20several%20goroutines%20call%20%60List%28%29%60%20simultaneously.%0A%0AA%20%60singleflight.Group%60%20keyed%20by%20%60listKey%60%20would%20let%20concurrent%20callers%20wait%20for%20one%20rebuild%20rather%20than%20each%20queuing%20behind%20the%20mutex%2C%20without%20requiring%20the%20full%20mutex%20hold.%0A%0A%23%23%23%20Issue%202%20of%202%0Apkg%2Fproviders%2Finstancetype%2Finstancetype.go%3A143-146%0A**Zone%20changes%20don't%20trigger%20a%20cache%20flush**%0A%0A%60cacheRevision%60%20tracks%20only%20%60instanceTypesSeqNum%60%20and%20%60unavailableOfferingsSeqNum%60%3B%20it%20does%20not%20include%20%60zonesHash%60.%20If%20%60ResolveClusterZones%60%20returns%20a%20different%20set%20of%20zones%20%28e.g.%2C%20a%20zone%20is%20added%20or%20removed%29%2C%20the%20old%20per-zone%20cache%20entries%20accumulate%20until%20their%2030-hour%20TTL%20because%20the%20revision%20never%20changes.%20These%20entries%20are%20never%20served%20%28the%20%60listKey%60%20computed%20with%20the%20new%20%60zonesHash%60%20differs%29%2C%20but%20they%20still%20consume%20memory%20%E2%80%94%20partially%20undermining%20the%20stated%20goal%20of%20bounding%20cache%20growth.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=461&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Bound instance type cache growth"](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/61e349ce3dce65c52492a8c4ffa2c7cf0b00ed20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37852566)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->