### PR TITLE
feat(helm): add pod and container security contexts with secure defaults

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -138,6 +138,8 @@ serviceMonitor:
 | podAnnotations | object | `{}` |  |
 | podDisruptionBudget.minAvailable | int | `1` |  |
 | podLabels | object | `{}` |  |
+| podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context applied at the pod level. |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context applied to the karpenter container. |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.automount | bool | `true` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "karpenter.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -46,6 +50,10 @@ spec:
         - name: karpenter
           image: "{{ .Values.controller.image.repository }}:{{ default .Chart.AppVersion .Values.controller.image.tag }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: HEALTH_PROBE_PORT
               value: "{{ .Values.controller.healthProbe.port }}"

--- a/charts/karpenter/values.schema.json
+++ b/charts/karpenter/values.schema.json
@@ -62,6 +62,16 @@
       "additionalProperties": { "type": "string" },
       "description": "Labels added to the controller pod."
     },
+    "podSecurityContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Security context applied at the pod level."
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Security context applied to the karpenter container."
+    },
     "podDisruptionBudget": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/karpenter/values.schema.json
+++ b/charts/karpenter/values.schema.json
@@ -63,12 +63,12 @@
       "description": "Labels added to the controller pod."
     },
     "podSecurityContext": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": true,
       "description": "Security context applied at the pod level."
     },
     "securityContext": {
-      "type": "object",
+      "type": ["object", "null"],
       "additionalProperties": true,
       "description": "Security context applied to the karpenter container."
     },

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -27,6 +27,23 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
+# -- Security context applied at the pod level.
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Security context applied to the karpenter container.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
 imagePullSecrets: []
 #  - name: my-registry-secret
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Add `podSecurityContext` and `securityContext` fields to the Helm chart with secure defaults enforcing least-privilege for the controller pod
- Set both contexts into `deployment.yaml` via `{{- with }}` blocks so they can be overridden or disabled by setting the value to `{}`
- Adds both new keys in `values.schema.json` so `helm lint` continues to pass

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `podSecurityContext` and `securityContext` fields to the Helm chart with secure defaults, enforcing least-privilege for the Karpenter controller pod. Both contexts are wired into `deployment.yaml` via `{{- with }}` blocks so they can be fully overridden or disabled, and the JSON schema is updated to allow `null` to support clearing the contexts via `--set`.

- **Pod-level context** (`podSecurityContext`): sets `runAsNonRoot: true` and `seccompProfile.type: RuntimeDefault`.
- **Container-level context** (`securityContext`): adds `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`, plus the same `runAsNonRoot` and `seccompProfile` as the pod level (redundant for this single-container deployment but harmless).
- **Schema**: correctly typed as `[\"object\", \"null\"]` with `additionalProperties: true`, keeping `helm lint` green while allowing users to pass null to opt out.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is additive Helm chart configuration with no logic changes to the controller binary; the secure defaults can be fully overridden by users who need different settings.

All four changed files are chart metadata (YAML, JSON schema, README). The template additions use the standard {{- with }} pattern correctly, the schema accepts null to let users opt out, and the default values follow established Kubernetes security hardening practices. No controller logic is touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| charts/karpenter/templates/deployment.yaml | Added podSecurityContext and securityContext via {{- with }} blocks; placement and indentation are correct. |
| charts/karpenter/values.yaml | Introduces secure default security contexts; runAsNonRoot/seccompProfile appear in both podSecurityContext and securityContext (redundant but harmless for a single-container pod). |
| charts/karpenter/values.schema.json | Both new keys declared with type ["object","null"] and additionalProperties: true; allows null to clear contexts and satisfies helm lint. |
| charts/karpenter/README.md | Documentation updated to reflect new podSecurityContext and securityContext values with correct defaults. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[helm install / upgrade] --> B{podSecurityContext\ndefined and non-empty?}
    B -- yes --> C[Render pod securityContext\nrunAsNonRoot: true\nseccompProfile: RuntimeDefault]
    B -- no / null / empty --> D[No pod securityContext rendered]
    C --> E[Pod Spec]
    D --> E

    E --> F{securityContext\ndefined and non-empty?}
    F -- yes --> G[Render container securityContext\nallowPrivilegeEscalation: false\nreadOnlyRootFilesystem: true\nrunAsNonRoot: true\ncapabilities.drop: ALL\nseccompProfile: RuntimeDefault]
    F -- no / null / empty --> H[No container securityContext rendered]
    G --> I[karpenter container]
    H --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[helm install / upgrade] --> B{podSecurityContext\ndefined and non-empty?}
    B -- yes --> C[Render pod securityContext\nrunAsNonRoot: true\nseccompProfile: RuntimeDefault]
    B -- no / null / empty --> D[No pod securityContext rendered]
    C --> E[Pod Spec]
    D --> E

    E --> F{securityContext\ndefined and non-empty?}
    F -- yes --> G[Render container securityContext\nallowPrivilegeEscalation: false\nreadOnlyRootFilesystem: true\nrunAsNonRoot: true\ncapabilities.drop: ALL\nseccompProfile: RuntimeDefault]
    F -- no / null / empty --> H[No container securityContext rendered]
    G --> I[karpenter container]
    H --> I
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["chore(helm): updated readme"](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/6708db77476d6ae46bf8ac050bfe71cab931a6c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38112000)</sub>

<!-- /greptile_comment -->