### PR TITLE
Document Helm pod and container security contexts

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -70,9 +70,9 @@ controller:
 
 By default, the Helm chart applies least-privilege security contexts to the controller pod and the `karpenter` container. These follow the Kubernetes Pod Security Standards and let the controller run under the `restricted` profile. Each context is rendered only when its value is non-empty, so you can override individual fields or disable a context entirely by setting it to `{}`.
 
-| Helm value          | Scope     | Default                                                                                                                            | Description                                          |
-|---------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
-| `podSecurityContext` | Pod       | `runAsNonRoot: true`, `seccompProfile.type: RuntimeDefault`                                                                          | Security context applied at the pod level.           |
+| Helm value           | Scope     | Default                                                                                                                                                    | Description                                            |
+|----------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+| `podSecurityContext` | Pod       | `runAsNonRoot: true`, `seccompProfile.type: RuntimeDefault`                                                                                                | Security context applied at the pod level.             |
 | `securityContext`    | Container | `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `runAsNonRoot: true`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault` | Security context applied to the `karpenter` container. |
 
 These are the chart defaults:

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -66,6 +66,51 @@ controller:
       value: "my-node-sa@my-project.iam.gserviceaccount.com"
 ```
 
+## Security Contexts
+
+By default, the Helm chart applies least-privilege security contexts to the controller pod and the `karpenter` container. These follow the Kubernetes Pod Security Standards and let the controller run under the `restricted` profile. Each context is rendered only when its value is non-empty, so you can override individual fields or disable a context entirely by setting it to `{}`.
+
+| Helm value          | Scope     | Default                                                                                                                            | Description                                          |
+|---------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| `podSecurityContext` | Pod       | `runAsNonRoot: true`, `seccompProfile.type: RuntimeDefault`                                                                          | Security context applied at the pod level.           |
+| `securityContext`    | Container | `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `runAsNonRoot: true`, `capabilities.drop: [ALL]`, `seccompProfile.type: RuntimeDefault` | Security context applied to the `karpenter` container. |
+
+These are the chart defaults:
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+To override a field, set it under the corresponding key. For example, to pin the user the controller runs as:
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  seccompProfile:
+    type: RuntimeDefault
+```
+
+To disable a context, set it to an empty object so no `securityContext` block is rendered:
+
+```yaml
+podSecurityContext: {}
+securityContext: {}
+```
+
 ## NodePool Features
 
 These fields are set on `NodePool` objects, not on the controller. They are part of the karpenter-core API and are available in this provider.


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/0c6a9df9-cf61-4459-97d9-658e52437aaf)

Document the new podSecurityContext and securityContext Helm chart values (with their secure defaults) introduced in PR #464, in the Settings Reference. Adds a Security Contexts section covering the default least-privilege settings and how to override or disable them.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #464: feat(helm): add pod and container security contexts with secure defaults](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/464)

---

_Tip: Assign suggestions to team members in the [Promptless dashboard](https://app.gopromptless.ai) to claim work 👥_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Security Contexts" section to `docs/settings.md` documenting the `podSecurityContext` and `securityContext` Helm values introduced in PR #464, which has already landed in `main`. The documented defaults match `charts/karpenter/values.yaml` exactly, and the deployment template correctly uses `{{- with }}` guards to make both contexts opt-out.

- Documents least-privilege defaults (`runAsNonRoot`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`, etc.) and how to override individual fields.
- The \"disable a context\" example uses `{}` (empty object), but Helm's deep-merge fills an empty user-supplied map with chart defaults before the template runs — setting to `null` (or `~`) is the correct way to remove the key and suppress the `securityContext` block.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after fixing the disable-context advice; the documented defaults are accurate and the underlying chart implementation is correct.

The documented defaults match the chart exactly and the override instructions are correct. The one concrete defect is the disable-by-empty-map advice: Helm deep-merge populates the user-supplied empty object with chart defaults before the template evaluates, so the security context is never actually suppressed when following the current instructions.

docs/settings.md — the To disable a context code block needs null instead of {}
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/settings.md | Adds Security Contexts section documenting podSecurityContext and securityContext Helm values; defaults match values.yaml correctly but the disable-by-setting-to-empty-object advice is wrong — Helm deep-merge fills the empty map with chart defaults, so null is needed instead. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User values file] --> B{podSecurityContext value}
    B -->|non-empty map| C[Helm deep-merge with chart defaults]
    B -->|empty map| D[Helm deep-merge fills in chart defaults]
    B -->|null or tilde| E[Key removed before template evaluation]
    C --> F[with .Values.podSecurityContext]
    D --> F
    E --> G[with block skipped - no securityContext rendered]
    F --> H[securityContext block rendered in Deployment]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User values file] --> B{podSecurityContext value}
    B -->|non-empty map| C[Helm deep-merge with chart defaults]
    B -->|empty map| D[Helm deep-merge fills in chart defaults]
    B -->|null or tilde| E[Key removed before template evaluation]
    C --> F[with .Values.podSecurityContext]
    D --> F
    E --> G[with block skipped - no securityContext rendered]
    F --> H[securityContext block rendered in Deployment]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["docs(settings): fix mdox table formattin..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/585ff27163544fd10eb4c30201d3dcbef440cc93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38112705)</sub>

<!-- /greptile_comment -->