### PR TITLE
Expand Dynamic Resource Allocation (DRA) settings guidance

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -34,6 +34,22 @@ These options configure the controller's runtime behavior.
 | `--batch-idle-duration`       | `BATCH_IDLE_DURATION`       | `controller.settings.batchIdleDuration` | `1s`    | Idle time after the last pod event before Karpenter triggers provisioning.                                                                        |
 | `--ignore-dra-requests`       | `IGNORE_DRA_REQUESTS`       | `controller.settings.ignoreDRARequests` | `true`  | When `true`, Karpenter ignores pods' Dynamic Resource Allocation requests during scheduling simulations.                                          |
 
+### Dynamic Resource Allocation (DRA)
+
+Dynamic Resource Allocation (DRA) is a Kubernetes API for requesting and sharing hardware devices — typically GPUs and other accelerators — through `ResourceClaim` objects rather than plain resource requests. Pods reference a claim, and a DRA driver allocates matching devices on nodes that can satisfy it.
+
+Karpenter ignores DRA requests during scheduling simulations by default (`controller.settings.ignoreDRARequests: true`). This preserves scheduling behavior for clusters without DRA drivers, the common case on GKE.
+
+Set `ignoreDRARequests` to `false` only when the cluster has DRA drivers installed and runs workloads that schedule against `ResourceClaim`s. When disabled, Karpenter registers the upstream device-allocation controller and accounts for DRA device availability when provisioning.
+
+```yaml
+controller:
+  settings:
+    ignoreDRARequests: false
+```
+
+DRA is a Kubernetes-level feature. Review the [Kubernetes DRA documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) and your DRA driver's requirements before enabling it.
+
 ## GCP-specific Settings
 
 | Setting             | Env var                            | Helm value                                        | Required | Description                                                                                                                                                                                                                                                                                |
@@ -118,7 +134,7 @@ These fields are set on `NodePool` objects, not on the controller. They are part
 
 ### Karpenter core v1.13
 
-Karpenter core v1.13 adds Dynamic Resource Allocation device allocation tracking and treats Kubernetes Node Readiness Controller taints (`readiness.k8s.io/*`) as ephemeral during scheduling. DRA scheduling remains disabled by default through `controller.settings.ignoreDRARequests: true`.
+Karpenter core v1.13 adds Dynamic Resource Allocation device allocation tracking and treats Kubernetes Node Readiness Controller taints (`readiness.k8s.io/*`) as ephemeral during scheduling. DRA scheduling remains disabled by default through `controller.settings.ignoreDRARequests: true` — see [Dynamic Resource Allocation (DRA)](#dynamic-resource-allocation-dra).
 
 ### Node count limit (v1.11)
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/345bd277-6209-43ed-b83c-91a28cc4a0c0)

Adds a conceptual "Dynamic Resource Allocation (DRA)" subsection to docs/settings.md explaining what DRA is, the default ignoreDRARequests=true behavior, and when/how to set it to false. Follows the karpenter core v1.13 bump (PR #455) that exposed the IGNORE_DRA_REQUESTS controller setting.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #455: chore(deps): bump karpenter core to v1.13.0](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/455)

---

_Tip: Add more repositories in your [Configuration](https://app.gopromptless.ai/configuration) to keep multiple doc sites in sync 📚_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a new "Dynamic Resource Allocation (DRA)" subsection under Controller Options in `docs/settings.md`, explaining what DRA is, the default `ignoreDRARequests: true` behavior, when to flip it to `false`, and linking to Kubernetes DRA docs. It also updates the v1.13 changelog entry with a cross-reference to the new subsection.

- All technical claims are verified against the karpenter core vendor source: setting `ignoreDRARequests: false` does register the `deviceallocation` controller and makes the scheduler process DRA pod requirements, exactly as the docs describe.
- The flag's upstream source includes a comment that it is intentionally temporary (`NOTE: This flag will be removed once formal DRA support is GA in Karpenter`), which the new docs section doesn't surface.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation-only change; no runtime code is modified and the new text accurately describes the underlying controller behavior confirmed in vendor source.

The added DRA section is technically accurate — controller registration and scheduler behavior both match — but the docs omit that the flag is explicitly marked as transitional in the karpenter core source, which could mislead operators who set `ignoreDRARequests: false` into treating it as a stable, long-lived knob.

docs/settings.md — the new DRA subsection should note the transitional/removable nature of the flag.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/settings.md | Adds a DRA conceptual subsection and a cross-reference link in the v1.13 changelog entry; technical claims are accurate against karpenter core source, but omits the upstream note that the ignoreDRARequests flag is transitional and will be removed when DRA support reaches GA |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Controller startup] --> B{ignoreDRARequests?}
    B -- true default --> C[Skip deviceallocation controller\nScheduler returns error for DRA pods]
    B -- false --> D[Register deviceallocation controller\nScheduler processes DRA ResourceClaims]
    D --> E[Track allocated devices per node\nAccount for DRA availability in provisioning]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Controller startup] --> B{ignoreDRARequests?}
    B -- true default --> C[Skip deviceallocation controller\nScheduler returns error for DRA pods]
    B -- false --> D[Register deviceallocation controller\nScheduler processes DRA ResourceClaims]
    D --> E[Track allocated devices per node\nAccount for DRA availability in provisioning]
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fsettings.md%3A43-51%0A**Missing%20note%20on%20temporary%20flag%20lifetime**%0A%0AThe%20upstream%20source%20defines%20%60IgnoreDRARequests%60%20with%20an%20explicit%20code%20comment%3A%20%60%2F%2F%20NOTE%3A%20This%20flag%20will%20be%20removed%20once%20formal%20DRA%20support%20is%20GA%20in%20Karpenter.%60%20The%20documentation%20doesn't%20surface%20this%2C%20so%20operators%20who%20set%20%60ignoreDRARequests%3A%20false%60%20today%20won't%20know%20the%20setting%20is%20transitional%20and%20may%20break%20silently%20when%20it's%20removed%20in%20a%20future%20core%20version.%0A%0A&pr=469&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fsettings.md%3A43-51%0A**Missing%20note%20on%20temporary%20flag%20lifetime**%0A%0AThe%20upstream%20source%20defines%20%60IgnoreDRARequests%60%20with%20an%20explicit%20code%20comment%3A%20%60%2F%2F%20NOTE%3A%20This%20flag%20will%20be%20removed%20once%20formal%20DRA%20support%20is%20GA%20in%20Karpenter.%60%20The%20documentation%20doesn't%20surface%20this%2C%20so%20operators%20who%20set%20%60ignoreDRARequests%3A%20false%60%20today%20won't%20know%20the%20setting%20is%20transitional%20and%20may%20break%20silently%20when%20it's%20removed%20in%20a%20future%20core%20version.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=469&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22promptless%2Fdocument-dra-ignore-dra-requests%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22promptless%2Fdocument-dra-ignore-dra-requests%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fsettings.md%3A43-51%0A**Missing%20note%20on%20temporary%20flag%20lifetime**%0A%0AThe%20upstream%20source%20defines%20%60IgnoreDRARequests%60%20with%20an%20explicit%20code%20comment%3A%20%60%2F%2F%20NOTE%3A%20This%20flag%20will%20be%20removed%20once%20formal%20DRA%20support%20is%20GA%20in%20Karpenter.%60%20The%20documentation%20doesn't%20surface%20this%2C%20so%20operators%20who%20set%20%60ignoreDRARequests%3A%20false%60%20today%20won't%20know%20the%20setting%20is%20transitional%20and%20may%20break%20silently%20when%20it's%20removed%20in%20a%20future%20core%20version.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=469&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: expand Dynamic Resource Allocation..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/ea9d93dabc16f5951b4cf71f1d863f58f937eee1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38373010)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->