### PR TITLE
docs(readme): add Sponsors section crediting PlanetScale testing infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ We want your contributions and suggestions! One of the easiest ways to contribut
 
 * [Slack channel](https://kubernetes.slack.com/archives/C0B20K4KWP8)
 
+## Sponsors
+
+End-to-end testing infrastructure for this project is generously provided by [PlanetScale](https://planetscale.com), the fastest Postgres and MySQL.&nbsp;
+<a href="https://planetscale.com"><picture><source media="(prefers-color-scheme: dark)" srcset="https://planetscale.com/brand/planetscale-logo-mark-white.svg"><img src="https://planetscale.com/brand/planetscale-logo-mark-black.svg" height="20" alt="PlanetScale"></picture></a>
+
 ## Attribution Notice
 
 This project includes code derived from karpenter-provider-aws, used under the Apache License, Version 2.0 terms. We acknowledge the contributions of the original authors and thank them for making their work available. For more details, see the [karpenter-provider-aws](https://github.com/aws/karpenter-provider-aws).


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a "Sponsors" section to `README.md` acknowledging PlanetScale's contribution of end-to-end testing infrastructure. No code, logic, or configuration is changed.

- Inserts a new `## Sponsors` heading between the community and attribution sections, with a brief prose credit and the PlanetScale logo using a `<picture>` element that switches between light and dark variants.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change with no impact on code, tests, or configuration — safe to merge.

The change is purely additive prose and HTML in the README, touching no Go code, no provider packages, and no configuration. The new logo markup uses a `<picture>` element with proper `alt` text and separate dark/light SVG sources, which is correct. Nothing in the diff can affect runtime behavior.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Adds a Sponsors section crediting PlanetScale for e2e testing infrastructure, with a responsive logo image supporting dark/light mode. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md] --> B[Community Section]
    B --> C[**NEW: Sponsors Section**\nPlanetScale credit + logo]
    C --> D[Attribution Notice]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[README.md] --> B[Community Section]
    B --> C[**NEW: Sponsors Section**\nPlanetScale credit + logo]
    C --> D[Attribution Notice]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): add Sponsors section credi..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/7cfb14e38a1ef688cdde411cd76daa852ec8ca7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38509180)</sub>

<!-- /greptile_comment -->