### PR TITLE
feat(disruption): Implement karpenter CRD disruption rules

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -66,6 +66,8 @@ func main() {
 			op.InstanceTypeProvider,
 			gcpCloudProvider,
 			op.PricingProvider,
+			op.Clock,
+			clusterState,
 		)...).
 		Start(ctx)
 }

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -23,7 +23,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
 	"sigs.k8s.io/karpenter/pkg/events"
 
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/cloudprovider"
@@ -58,6 +60,8 @@ func NewController(
 	instanceTypeProvider providerinstancetype.Provider,
 	cloudProvider *cloudprovider.CloudProvider,
 	pricingProvider pricing.Provider,
+	clk clock.Clock,
+	cluster *state.Cluster,
 ) []controller.Controller {
 	controllers := []controller.Controller{
 		nodeclassstatus.NewController(kubeClient, imageProvider),
@@ -67,7 +71,7 @@ func NewController(
 		instancetype.NewController(instanceTypeProvider),
 		csr.NewController(kubernetesInterface),
 		controllerspricing.NewController(pricingProvider),
-		node.NewController(kubeClient, cloudProvider),
+		node.NewController(kubeClient, cloudProvider, clk, cluster, recorder),
 		nodeclaimgc.NewController(kubeClient, cloudProvider),
 	}
 

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -84,8 +84,9 @@ func (c *Controller) Reconcile(ctx context.Context, node *corev1.Node) (reconcil
 	// window (it is never set when consolidation is disabled).
 	nodeClaim, err := nodeutils.NodeClaimForNode(ctx, c.kubeClient, node)
 	if err != nil {
-		// NodeClaim is not yet registered (or duplicated), retry later.
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		// NodeClaim is not yet registered (or duplicated), retry later. Genuine
+		// errors are surfaced so the request is requeued with backoff.
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nodeutils.IgnoreDuplicateNodeClaimError(nodeutils.IgnoreNodeClaimNotFoundError(err))
 	}
 	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeConsolidatable).IsTrue() {
 		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
@@ -95,7 +96,7 @@ func (c *Controller) Reconcile(ctx context.Context, node *corev1.Node) (reconcil
 	// same computation as the upstream disruption controller.
 	budgets, err := disruption.BuildDisruptionBudgetMapping(ctx, c.cluster, c.clock, c.kubeClient, c.cloudProvider, c.recorder, v1.DisruptionReasonEmpty)
 	if err != nil {
-		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+		return reconcile.Result{}, err
 	}
 	if budgets[node.Labels[v1.NodePoolLabelKey]] <= 0 {
 		// Empty disruption budget for this NodePool is exhausted; retry later.

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -22,12 +22,17 @@ import (
 
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/controllers/disruption"
+	"sigs.k8s.io/karpenter/pkg/controllers/state"
+	"sigs.k8s.io/karpenter/pkg/events"
 	nodeutils "sigs.k8s.io/karpenter/pkg/utils/node"
 	podutil "sigs.k8s.io/karpenter/pkg/utils/pod"
 )
@@ -35,12 +40,18 @@ import (
 type Controller struct {
 	kubeClient    client.Client
 	cloudProvider cloudprovider.CloudProvider
+	clock         clock.Clock
+	cluster       *state.Cluster
+	recorder      events.Recorder
 }
 
-func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider) *Controller {
+func NewController(kubeClient client.Client, cloudProvider cloudprovider.CloudProvider, clk clock.Clock, cluster *state.Cluster, recorder events.Recorder) *Controller {
 	return &Controller{
 		kubeClient:    kubeClient,
 		cloudProvider: cloudProvider,
+		clock:         clk,
+		cluster:       cluster,
+		recorder:      recorder,
 	}
 }
 
@@ -67,7 +78,30 @@ func (c *Controller) Reconcile(ctx context.Context, node *corev1.Node) (reconcil
 		return reconcile.Result{}, nil
 	}
 
-	// TODO: it should follow the emptiness disrupt rule of the target nodepool
+	// follow the emptiness disrupt rule of the target nodepool. The upstream
+	// nodeclaim disruption controller maintains the Consolidatable status condition,
+	// which already encodes the NodePool's consolidationPolicy and consolidateAfter
+	// window (it is never set when consolidation is disabled).
+	nodeClaim, err := nodeutils.NodeClaimForNode(ctx, c.kubeClient, node)
+	if err != nil {
+		// NodeClaim is not yet registered (or duplicated), retry later.
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+	if !nodeClaim.StatusConditions().Get(v1.ConditionTypeConsolidatable).IsTrue() {
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	// respect the NodePool's disruption budgets for the Empty reason, reusing the
+	// same computation as the upstream disruption controller.
+	budgets, err := disruption.BuildDisruptionBudgetMapping(ctx, c.cluster, c.clock, c.kubeClient, c.cloudProvider, c.recorder, v1.DisruptionReasonEmpty)
+	if err != nil {
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+	if budgets[node.Labels[v1.NodePoolLabelKey]] <= 0 {
+		// Empty disruption budget for this NodePool is exhausted; retry later.
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
 	log.FromContext(ctx).Info("deleting empty node", "node", node.Name)
 	// delete the node
 	if err := c.kubeClient.Delete(ctx, node); err != nil {

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -104,8 +104,17 @@ func (c *Controller) Reconcile(ctx context.Context, node *corev1.Node) (reconcil
 	}
 
 	log.FromContext(ctx).Info("deleting empty node", "node", node.Name)
+	// Synchronously mark the node for deletion in cluster state before deleting it.
+	// This controller deletes the Node object directly, so the NodeClaim's
+	// DeletionTimestamp is not set until the GC controller runs later. Marking the
+	// node here makes BuildDisruptionBudgetMapping count this deletion immediately,
+	// so concurrent reconciliations of other empty nodes in the same NodePool
+	// correctly observe the consumed budget.
+	c.cluster.MarkForDeletion(node.Spec.ProviderID)
 	// delete the node
 	if err := c.kubeClient.Delete(ctx, node); err != nil {
+		// Revert the marking so the budget is not permanently consumed by a failed delete.
+		c.cluster.UnmarkForDeletion(node.Spec.ProviderID)
 		return reconcile.Result{Requeue: true}, err
 	}
 


### PR DESCRIPTION
- node.emptiness controller: only delete empty nodes if they are eligible for consolidation. Fixes #474

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Additional labels (applied directly, not via /kind):
  dependencies  — dependency update PRs
  release-prep  — release preparation PRs (see RELEASE.md)
-->

#### What this PR does / why we need it:

This implements the dispruption/consolidation config in the karpenter nodepool CRD. As of right now, they are not respected when deleting empty nodes

#### Related proposal (if applicable):
<!--
Link the proposal this PR implements, e.g. proposals/0001-short-title.md
Leave blank if this PR does not correspond to a design proposal.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #474 

#### Docs and examples

- [ ] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [ ] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements disruption-policy enforcement in the GCP-specific `node.emptiness` controller by gating empty-node deletion on two upstream Karpenter signals: the `Consolidatable` NodeClaim status condition (which already encodes the NodePool's `consolidationPolicy` and `consolidateAfter` window) and the NodePool disruption-budget mapping from `disruption.BuildDisruptionBudgetMapping`.

- **Consolidatable guard (line 85–93):** Before deleting, the controller fetches the NodeClaim and checks `ConditionTypeConsolidatable`. If the condition is absent or false (consolidation disabled, or `consolidateAfter` window not yet elapsed), reconciliation is deferred 10 seconds with no action.
- **Budget enforcement (lines 95–113):** `BuildDisruptionBudgetMapping` is called with `DisruptionReasonEmpty`; if the NodePool's budget is exhausted the node is skipped. To prevent concurrent reconciles from each seeing a full budget, `cluster.MarkForDeletion` is called before the API delete, with `UnmarkForDeletion` on failure to revert the in-memory mark.
- **Wire-up (controllers.go, main.go):** `clock.Clock` and `*state.Cluster` are threaded into the node controller constructor; `main.go` passes the same `clusterState` instance already shared with the core controllers.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change correctly gates empty-node deletion on both the NodeClaim's Consolidatable condition and the NodePool disruption budget, with in-memory MarkForDeletion to prevent concurrent over-deletion.

The three changed files are well-scoped: the node controller correctly reuses upstream Karpenter's ConditionTypeConsolidatable (set by the nodeclaim disruption controller based on consolidateAfter elapsed time) and BuildDisruptionBudgetMapping. The MarkForDeletion/UnmarkForDeletion pattern soundly addresses the budget-atomicity window that existed before this PR. The clock and cluster state are wired from the same shared instance already used by the core controllers.

pkg/controllers/node/controller.go — the Register method watches only Node objects, so the ConditionTypeConsolidatable flip on a NodeClaim is detected by polling rather than events, but this does not affect correctness.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pkg/controllers/node/controller.go | Core change: adds Consolidatable condition check and disruption-budget enforcement before deleting empty nodes. MarkForDeletion/UnmarkForDeletion pair correctly addresses the in-process budget atomicity problem. Register() watches only Node objects, so NodeClaim condition changes are detected by 10-second polling rather than events. |
| pkg/controllers/controllers.go | Adds clock.Clock and *state.Cluster to NewController signature and threads them into node.NewController. Straightforward plumbing change with no logic issues. |
| cmd/controller/main.go | Passes op.Clock and clusterState to controllers.NewController — both were already created for the core controllers, so the same shared instance is reused correctly. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Node reconcile triggered] --> B{Node Ready\n>3 min?}
    B -- No --> Z[RequeueAfter 10s]
    B -- Yes --> C{IsManaged\nby Karpenter?}
    C -- No --> STOP[Return, no action]
    C -- Yes --> D{isEmpty?}
    D -- No --> STOP
    D -- Yes --> E[NodeClaimForNode]
    E -- Error/NotFound --> Z
    E -- Found --> F{ConditionTypeConsolidatable\n== True?}
    F -- No --> Z
    F -- Yes --> G[BuildDisruptionBudgetMapping\nreason=Empty]
    G -- Error --> ERR[Return error, requeue with backoff]
    G -- OK --> H{budget NodePool\n> 0?}
    H -- No --> Z
    H -- Yes --> I[cluster.MarkForDeletion\nproviderID]
    I --> J[kubeClient.Delete node]
    J -- Error --> K[cluster.UnmarkForDeletion\nproviderID]
    K --> ERR2[Return error, Requeue]
    J -- OK --> DONE[Return success]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Node reconcile triggered] --> B{Node Ready\n>3 min?}
    B -- No --> Z[RequeueAfter 10s]
    B -- Yes --> C{IsManaged\nby Karpenter?}
    C -- No --> STOP[Return, no action]
    C -- Yes --> D{isEmpty?}
    D -- No --> STOP
    D -- Yes --> E[NodeClaimForNode]
    E -- Error/NotFound --> Z
    E -- Found --> F{ConditionTypeConsolidatable\n== True?}
    F -- No --> Z
    F -- Yes --> G[BuildDisruptionBudgetMapping\nreason=Empty]
    G -- Error --> ERR[Return error, requeue with backoff]
    G -- OK --> H{budget NodePool\n> 0?}
    H -- No --> Z
    H -- Yes --> I[cluster.MarkForDeletion\nproviderID]
    I --> J[kubeClient.Delete node]
    J -- Error --> K[cluster.UnmarkForDeletion\nproviderID]
    K --> ERR2[Return error, Requeue]
    J -- OK --> DONE[Return success]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pkg/controllers/node/controller.go`, line 127 ([link](https://github.com/cloudpilot-ai/karpenter-provider-gcp/blob/65c65f41549297113b6e952a2cc1c2ccb651a36d/pkg/controllers/node/controller.go#L127)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`context.Background()` in `isEmpty` drops request context**

   `c.kubeClient.List` is called with `context.Background()` instead of the `ctx` passed to `Reconcile`. This loses the cancellation signal, tracing span, and any logger values injected by controller-runtime. The context from `Reconcile` should be threaded through here.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fcontrollers%2Fnode%2Fcontroller.go%0ALine%3A%20127%0A%0AComment%3A%0A**%60context.Background%28%29%60%20in%20%60isEmpty%60%20drops%20request%20context**%0A%0A%60c.kubeClient.List%60%20is%20called%20with%20%60context.Background%28%29%60%20instead%20of%20the%20%60ctx%60%20passed%20to%20%60Reconcile%60.%20This%20loses%20the%20cancellation%20signal%2C%20tracing%20span%2C%20and%20any%20logger%20values%20injected%20by%20controller-runtime.%20The%20context%20from%20%60Reconcile%60%20should%20be%20threaded%20through%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=475&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fcontrollers%2Fnode%2Fcontroller.go%0ALine%3A%20127%0A%0AComment%3A%0A**%60context.Background%28%29%60%20in%20%60isEmpty%60%20drops%20request%20context**%0A%0A%60c.kubeClient.List%60%20is%20called%20with%20%60context.Background%28%29%60%20instead%20of%20the%20%60ctx%60%20passed%20to%20%60Reconcile%60.%20This%20loses%20the%20cancellation%20signal%2C%20tracing%20span%2C%20and%20any%20logger%20values%20injected%20by%20controller-runtime.%20The%20context%20from%20%60Reconcile%60%20should%20be%20threaded%20through%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=475&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22empty_consolidate%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22empty_consolidate%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20pkg%2Fcontrollers%2Fnode%2Fcontroller.go%0ALine%3A%20127%0A%0AComment%3A%0A**%60context.Background%28%29%60%20in%20%60isEmpty%60%20drops%20request%20context**%0A%0A%60c.kubeClient.List%60%20is%20called%20with%20%60context.Background%28%29%60%20instead%20of%20the%20%60ctx%60%20passed%20to%20%60Reconcile%60.%20This%20loses%20the%20cancellation%20signal%2C%20tracing%20span%2C%20and%20any%20logger%20values%20injected%20by%20controller-runtime.%20The%20context%20from%20%60Reconcile%60%20should%20be%20threaded%20through%20here.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=475&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["empty\_consolidate: - address greptile re..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/a3f9e2a31f6316b4350f5ec045f423521b6e4a15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39129679)</sub>

<!-- /greptile_comment -->