### PR TITLE
feat(chart): support PDB maxUnavailable

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -137,7 +137,8 @@ serviceMonitor:
 | logOutputPaths | list | `["stdout"]` | Log outputPaths - defaults to stdout only |
 | nameOverride | string | `""` |  |
 | podAnnotations | object | `{}` |  |
-| podDisruptionBudget.minAvailable | int | `1` |  |
+| podDisruptionBudget.maxUnavailable | integer or string | `nil` | Maximum number of unavailable pods. When set, takes precedence over minAvailable. |
+| podDisruptionBudget.minAvailable | int | `1` | Minimum number of available pods. Used when maxUnavailable is not set. |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context applied at the pod level. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context applied to the karpenter container. |

--- a/charts/karpenter/templates/poddisruptionbudget.yaml
+++ b/charts/karpenter/templates/poddisruptionbudget.yaml
@@ -10,7 +10,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if ne .Values.podDisruptionBudget.maxUnavailable nil }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
   selector:
     matchLabels:
     {{- include "karpenter.selectorLabels" . | nindent 6 }}

--- a/charts/karpenter/values.schema.json
+++ b/charts/karpenter/values.schema.json
@@ -83,6 +83,15 @@
           ],
           "description": "Minimum number of available pods (integer or percentage string).",
           "default": 1
+        },
+        "maxUnavailable": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ],
+          "description": "Maximum number of unavailable pods (integer or percentage string). When set, takes precedence over minAvailable.",
+          "default": null
         }
       }
     },

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -48,7 +48,10 @@ imagePullSecrets: []
 #  - name: my-registry-secret
 
 podDisruptionBudget:
+  # -- Minimum number of available pods. Used when maxUnavailable is not set.
   minAvailable: 1
+  # -- (integer or string) Maximum number of unavailable pods. When set, takes precedence over minAvailable.
+  maxUnavailable: null
 
 serviceMonitor:
   # -- Specifies whether a ServiceMonitor should be created.


### PR DESCRIPTION
## Summary
- add optional `podDisruptionBudget.maxUnavailable` support to the karpenter Helm chart
- keep the existing `minAvailable` default path for backwards compatibility
- update values schema and generated chart README

## Verification
- `helm template karpenter charts/karpenter --show-only templates/poddisruptionbudget.yaml`
- `helm template karpenter charts/karpenter --show-only templates/poddisruptionbudget.yaml --set podDisruptionBudget.maxUnavailable=1`
- `make chart-lint`

## Release note
Support configuring PodDisruptionBudget maxUnavailable in the Karpenter Helm chart.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds optional `maxUnavailable` support to the Karpenter Helm chart's `PodDisruptionBudget`, keeping `minAvailable: 1` as the backwards-compatible default. The previous review comments about the empty-string schema gap and the README type column have both been addressed: `"minLength": 1` is present on the string branch and the README correctly reflects `integer or string`.

- **`poddisruptionbudget.yaml`**: Uses `ne .Values.podDisruptionBudget.maxUnavailable nil` which correctly handles `maxUnavailable: 0` (an explicitly-zero integer that would be falsy with a plain `if`) and falls through to `minAvailable` when the value is `null`.
- **`values.schema.json`**: The `oneOf` for `maxUnavailable` covers `integer ≥ 0`, `string` with `minLength: 1`, and `null`, fully constraining valid inputs.
- **`values.yaml` / `README.md`**: Both updated to document the new field and its precedence over `minAvailable`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a purely additive, backwards-compatible Helm chart feature with no impact on existing deployments.

The nil-check correctly handles integer zero, the schema constrains inputs tightly (non-empty string, non-negative integer, or null), and the if/else ensures Kubernetes never receives both fields simultaneously. Previous review concerns about empty-string validation and the README type label have been resolved.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| charts/karpenter/templates/poddisruptionbudget.yaml | Adds if/else branch to render maxUnavailable when non-nil, falling back to minAvailable; nil comparison correctly handles the integer-zero edge case |
| charts/karpenter/values.schema.json | New maxUnavailable oneOf schema covers integer >= 0, non-empty string, and null; minLength: 1 closes the empty-string gap from prior review |
| charts/karpenter/values.yaml | Adds maxUnavailable: null default with helm-docs type annotation; minAvailable kept with updated description for clarity |
| charts/karpenter/README.md | Auto-generated table updated to reflect new maxUnavailable field with correct integer-or-string type and updated minAvailable description |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Helm template: poddisruptionbudget.yaml] --> B{ne maxUnavailable nil?}
    B -- true\nmaxUnavailable is set --> C[render: maxUnavailable: value]
    B -- false\nmaxUnavailable is null --> D[render: minAvailable: value]
    C --> E[PodDisruptionBudget spec]
    D --> E

    style C fill:#d4edda
    style D fill:#d4edda
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Helm template: poddisruptionbudget.yaml] --> B{ne maxUnavailable nil?}
    B -- true\nmaxUnavailable is set --> C[render: maxUnavailable: value]
    B -- false\nmaxUnavailable is null --> D[render: minAvailable: value]
    C --> E[PodDisruptionBudget spec]
    D --> E

    style C fill:#d4edda
    style D fill:#d4edda
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into codex/pdb-max-u..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/47f8f89b0638a41efacb3fd51a791476d74bce0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39145076)</sub>

<!-- /greptile_comment -->