### PR TITLE
chore(deps): bump gohugoio/hugo to v0.163.3 in hack/tools

### DIFF
--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/gocolly/colly/v2 v2.3.0 // indirect
 	github.com/gohugoio/hashstructure v0.6.0 // indirect
-	github.com/gohugoio/hugo v0.163.2 // indirect
+	github.com/gohugoio/hugo v0.163.3 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/hack/tools/go.sum
+++ b/hack/tools/go.sum
@@ -593,8 +593,8 @@ github.com/gohugoio/hashstructure v0.6.0/go.mod h1:lapVLk9XidheHG1IQ4ZSbyYrXcaIL
 github.com/gohugoio/httpcache v0.8.0 h1:hNdsmGSELztetYCsPVgjA960zSa4dfEqqF/SficorCU=
 github.com/gohugoio/httpcache v0.8.0/go.mod h1:fMlPrdY/vVJhAriLZnrF5QpN3BNAcoBClgAyQd+lGFI=
 github.com/gohugoio/hugo v0.74.3/go.mod h1:qTy3SQXdyeRLfUMMdGZeySMGMzvi3D31prjuIbAwImk=
-github.com/gohugoio/hugo v0.163.2 h1:+npWKPkhkBMPWwQ3A3MWlnDgFGDVE7Q82jsVP2fF0DM=
-github.com/gohugoio/hugo v0.163.2/go.mod h1:3FPGFgeqGYDTPRe1NJ10L1giY5ViUGeNlkVBDmVk46w=
+github.com/gohugoio/hugo v0.163.3 h1:fkiOvLv8hYZt96OhJE9RDWw4IkQVASCIIndBmAiLHgM=
+github.com/gohugoio/hugo v0.163.3/go.mod h1:3FPGFgeqGYDTPRe1NJ10L1giY5ViUGeNlkVBDmVk46w=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.7.0 h1:I/n6v7VImJ3aISLnn73JAHXyjcQsMVvbguQPTk9Ehus=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.7.0/go.mod h1:9LJNfKWFmhEJ7HW0in5znezMwH+FYMBIhNZ3VWtRcRs=
 github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.5.0 h1:p13Q0DBCrBRpJGtbtlgkYNCs4TnIlZJh8vHgnAiofrI=


### PR DESCRIPTION
## What

Bump `github.com/gohugoio/hugo` from v0.163.2 to **v0.163.3** in the `hack/tools` module (`go.mod` + `go.sum`).

## Why

Resolves the open GitHub Dependabot finding **GHSA-q76j-gcg9-vxc6** (Moderate) for `gohugoio/hugo`. The dependency is an indirect, tooling-only module under `hack/tools` and is not part of the shipped controller binary.

## Verification

- `go mod verify` → all modules verified.
- `go mod tidy` is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Bumps the indirect `gohugoio/hugo` tooling dependency from v0.163.2 to v0.163.3 inside `hack/tools`, addressing Dependabot advisory GHSA-q76j-gcg9-vxc6. The change is confined to the tooling module and has no effect on the shipped controller binary.

- `hack/tools/go.mod`: single-line version bump for the indirect `gohugoio/hugo` entry.
- `hack/tools/go.sum`: source digest updated for v0.163.3; the `go.mod` digest is unchanged between the two patch versions, which is expected when hugo's own `go.mod` was not modified in this release.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a one-line indirect version bump confined to the tooling module and never reaches the controller binary.

Both changed files are inside hack/tools, a build-time tooling module that is not included in the shipped controller image. The bump is a patch release of an indirect dependency, the go.sum checksums are updated correctly, and no provider package boundaries or runtime code paths are touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| hack/tools/go.mod | Bumps indirect dependency `github.com/gohugoio/hugo` from v0.163.2 to v0.163.3 in the tooling-only module; no logic change. |
| hack/tools/go.sum | Updates checksums for hugo v0.163.3; the go.mod hash for v0.163.3 is identical to v0.163.2 (expected when the module's own go.mod did not change), and the source hash is correctly updated. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[hack/tools module] -->|indirect dep| B[gohugoio/hugo]
    B -->|v0.163.2 → v0.163.3| C[Patch bump\nGHSA-q76j-gcg9-vxc6 fix]
    A -.->|not part of| D[Controller binary\nkarpenter-provider-gcp]
    style C fill:#d4edda,stroke:#28a745
    style D fill:#f8f9fa,stroke:#6c757d,stroke-dasharray: 5 5
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[hack/tools module] -->|indirect dep| B[gohugoio/hugo]
    B -->|v0.163.2 → v0.163.3| C[Patch bump\nGHSA-q76j-gcg9-vxc6 fix]
    A -.->|not part of| D[Controller binary\nkarpenter-provider-gcp]
    style C fill:#d4edda,stroke:#28a745
    style D fill:#f8f9fa,stroke:#6c757d,stroke-dasharray: 5 5
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump gohugoio/hugo to v0.16..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/588693577f771bacb520f0e8d6010d1eb646fda9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39259376)</sub>

<!-- /greptile_comment -->