### PR TITLE
fix: avoid duplicate GKE kube-proxy on Karpenter nodes

### DIFF
--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -68,6 +68,8 @@ kubeletConfiguration:
 
 Both settings reduce node allocatable capacity. The scheduler accounts for these when bin-packing workloads.
 
+Karpenter also adds a provider-computed 100m CPU scheduling overhead for GKE's node-owned kube-proxy mirror pod on Karpenter nodes. User-provided `systemReserved` values add to this overhead in Karpenter's allocatable estimate, but the kube-proxy overhead is not written into the node's kubelet reservation configuration.
+
 When you set a partial `kubeReserved` (for example, only `cpu`), Karpenter preserves provider-computed defaults for unspecified keys like `ephemeral-storage` based on boot disk size.
 
 ### Eviction thresholds

--- a/pkg/apis/v1alpha1/gcenodeclass_test.go
+++ b/pkg/apis/v1alpha1/gcenodeclass_test.go
@@ -20,7 +20,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
+
+func TestKubeProxyReadinessLabelIsNotWellKnown(t *testing.T) {
+	require.False(t, karpv1.WellKnownLabels.Has(LabelGKEReadinessKubeProxyReady))
+}
 
 func TestImageFamily_FromSpecImageFamily(t *testing.T) {
 	cos := ImageFamilyContainerOptimizedOS

--- a/pkg/apis/v1alpha1/labels.go
+++ b/pkg/apis/v1alpha1/labels.go
@@ -47,7 +47,6 @@ func init() {
 		LabelTopologyZoneID,
 		corev1.LabelWindowsBuild,
 		LabelGKEReadinessCalicoReady,
-		LabelGKEReadinessKubeProxyReady,
 		LabelGKEReadinessMetadataServerEnabled,
 		LabelGKEReadinessMasqAgentReady,
 		LabelGKEReadinessNetdReady,
@@ -101,7 +100,11 @@ var (
 	// until the node is ready for each subsystem. Registering them as well-known
 	// allows Karpenter's DaemonSet overhead simulation (isDaemonPodCompatible) to
 	// include these DaemonSets when sizing instance types, preventing undersizing
-	// and node churn. See https://github.com/cloudpilot-ai/karpenter-provider-gcp/issues/202
+	// and node churn. kube-proxy is intentionally not registered or injected by
+	// the provider: GKE supplies a node-owned mirror pod on Karpenter nodes, and
+	// treating the DaemonSet selector as compatible would double-count or run a
+	// second kube-proxy pod.
+	// See https://github.com/cloudpilot-ai/karpenter-provider-gcp/issues/202
 	LabelGKEReadinessCalicoReady           = "projectcalico.org/ds-ready"
 	LabelGKEReadinessKubeProxyReady        = "node.kubernetes.io/kube-proxy-ds-ready"
 	LabelGKEReadinessMetadataServerEnabled = "iam.gke.io/gke-metadata-server-enabled"

--- a/pkg/providers/instancetype/overhead.go
+++ b/pkg/providers/instancetype/overhead.go
@@ -35,16 +35,25 @@ const (
 	signalNodeFSAvailable = "nodefs.available"
 )
 
-// kcSystemReserved returns Overhead.SystemReserved derived from the user's
-// systemReserved map. CRD pattern validation guarantees every value is a
-// parseable resource.Quantity, so MustParse is safe here.
-func kcSystemReserved(kc *v1alpha1.KubeletConfiguration) corev1.ResourceList {
-	out := corev1.ResourceList{}
+// kcSystemReserved returns Overhead.SystemReserved derived from computed and
+// user-provided reservations. CRD pattern validation guarantees every user
+// value is a parseable resource.Quantity, so MustParse is safe here. User
+// values are additive because computed reservations model provider overhead
+// that exists independently of explicit kubelet systemReserved settings.
+func kcSystemReserved(computed corev1.ResourceList, kc *v1alpha1.KubeletConfiguration) corev1.ResourceList {
+	out := computed.DeepCopy()
 	if kc == nil {
 		return out
 	}
 	for k, v := range kc.SystemReserved {
-		out[corev1.ResourceName(k)] = resource.MustParse(string(v))
+		name := corev1.ResourceName(k)
+		q := resource.MustParse(string(v))
+		if existing, ok := out[name]; ok {
+			existing.Add(q)
+			out[name] = existing
+			continue
+		}
+		out[name] = q
 	}
 	return out
 }

--- a/pkg/providers/instancetype/overhead_test.go
+++ b/pkg/providers/instancetype/overhead_test.go
@@ -35,27 +35,29 @@ import (
 )
 
 func TestKCSystemReserved(t *testing.T) {
+	computed := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}
 	tests := []struct {
 		name string
 		kc   *v1alpha1.KubeletConfiguration
 		want corev1.ResourceList
 	}{
-		{name: "nil → empty", kc: nil, want: corev1.ResourceList{}},
+		{name: "nil → computed", kc: nil, want: computed},
 		{
-			name: "cpu and memory parsed",
+			name: "user values add to computed",
 			kc: &v1alpha1.KubeletConfiguration{
 				SystemReserved: map[string]v1alpha1.KubeletQuantity{"cpu": "1", "memory": "1Gi"},
 			},
 			want: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceCPU:    resource.MustParse("1100m"),
 				corev1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := kcSystemReserved(tt.kc)
+			got := kcSystemReserved(computed, tt.kc)
 			assert.True(t, quantityListsEqual(tt.want, got), "want %v, got %v", tt.want, got)
+			assert.Equal(t, "100m", computed.Cpu().String())
 		})
 	}
 }
@@ -212,6 +214,20 @@ func TestKCMaxPods(t *testing.T) {
 // It covers the #398 fix (SystemReserved verbatim, KubeReserved merged with
 // the #220 ephemeral-storage survival, PodsPerCore caps Capacity[pods]) and
 // the nil-kc baseline in a single table.
+func TestNewInstanceType_IncludesStaticKubeProxyOverhead(t *testing.T) {
+	ctx := options.ToContext(context.Background(), &options.Options{VMMemoryOverheadPercent: 0.07})
+	mt := &computepb.MachineType{
+		Name:      lo.ToPtr("n2-standard-1"),
+		GuestCpus: lo.ToPtr[int32](1),
+		MemoryMb:  lo.ToPtr[int32](4096),
+	}
+
+	it := NewInstanceType(ctx, mt, &v1alpha1.GCENodeClass{}, "us-central1", testOfferings())
+
+	assert.Equal(t, int64(60), it.Overhead.KubeReserved.Cpu().MilliValue())
+	assert.Equal(t, int64(staticKubeProxyCPUMilliCore), it.Overhead.SystemReserved.Cpu().MilliValue())
+}
+
 func TestNewInstanceType_RespectsKubeletConfiguration(t *testing.T) {
 	ctx := options.ToContext(context.Background(), &options.Options{VMMemoryOverheadPercent: 0.07})
 	mt := &computepb.MachineType{
@@ -225,11 +241,11 @@ func TestNewInstanceType_RespectsKubeletConfiguration(t *testing.T) {
 		assert func(t *testing.T, it *cloudprovider.InstanceType)
 	}{
 		{
-			name: "nil kc → SystemReserved empty, KubeReserved computed, default max pods",
+			name: "nil kc → static kube-proxy SystemReserved, KubeReserved computed, default max pods",
 			kc:   nil,
 			assert: func(t *testing.T, it *cloudprovider.InstanceType) {
-				assert.Empty(t, it.Overhead.SystemReserved)
-				assert.Greater(t, it.Overhead.KubeReserved.Cpu().MilliValue(), int64(0))
+				assert.Equal(t, int64(staticKubeProxyCPUMilliCore), it.Overhead.SystemReserved.Cpu().MilliValue())
+				assert.Equal(t, int64(80), it.Overhead.KubeReserved.Cpu().MilliValue())
 				assert.Greater(t, it.Overhead.KubeReserved.Memory().Value(), int64(0))
 				pods := it.Capacity[corev1.ResourcePods]
 				assert.Equal(t, int64(v1alpha1.KubeletMaxPods), pods.Value())
@@ -245,7 +261,7 @@ func TestNewInstanceType_RespectsKubeletConfiguration(t *testing.T) {
 				KubeReserved:   map[string]v1alpha1.KubeletQuantity{"cpu": "500m"},
 			},
 			assert: func(t *testing.T, it *cloudprovider.InstanceType) {
-				assert.Equal(t, "1", it.Overhead.SystemReserved.Cpu().String())
+				assert.Equal(t, "1100m", it.Overhead.SystemReserved.Cpu().String())
 				assert.Equal(t, "1Gi", it.Overhead.SystemReserved.Memory().String())
 				assert.Equal(t, "500m", it.Overhead.KubeReserved.Cpu().String())
 				assert.Greater(t, it.Overhead.KubeReserved.Memory().Value(), int64(0))

--- a/pkg/providers/instancetype/types.go
+++ b/pkg/providers/instancetype/types.go
@@ -37,6 +37,11 @@ import (
 	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/utils/localssd"
 )
 
+// staticKubeProxyCPUMilliCore matches the CPU request on GKE's node-owned
+// kube-proxy mirror pod observed on GKE 1.35.5 COS ARM64 Karpenter nodes.
+// Re-check this constant when GKE changes kube-proxy resource requests.
+const staticKubeProxyCPUMilliCore = 100
+
 func NewInstanceType(ctx context.Context, mt *computepb.MachineType, nodeClass *v1alpha1.GCENodeClass,
 	region string, offerings cloudprovider.Offerings) *cloudprovider.InstanceType {
 	if offerings == nil {
@@ -85,6 +90,16 @@ func NewStaticInstanceType(ctx context.Context, mt *computepb.MachineType, nodeC
 		corev1.ResourceMemory:           *resource.NewQuantity(reservedMemory*1024*1024, resource.BinarySI),
 		corev1.ResourceEphemeralStorage: *resource.NewQuantity(ephemeralSystem*1024*1024*1024, resource.BinarySI),
 	}
+	// GKE creates a node-owned kube-proxy mirror pod on Karpenter nodes. The provider
+	// no longer injects the kube-proxy DaemonSet readiness label, so only the mirror
+	// pod runs. Mirror pods are not part of Karpenter's daemon overhead simulation,
+	// so account for the mirror pod's CPU request here as provider overhead. Using
+	// SystemReserved (rather than KubeReserved) keeps this value out of kubelet
+	// kubeReserved metadata, avoiding a double reduction of allocatable on top of the
+	// mirror pod's own scheduling request.
+	computedSystemReserved := corev1.ResourceList{
+		corev1.ResourceCPU: *resource.NewMilliQuantity(staticKubeProxyCPUMilliCore, resource.DecimalSI),
+	}
 	computedEviction := corev1.ResourceList{
 		corev1.ResourceMemory:           *resource.NewQuantity(evictionMemory*1024*1024, resource.BinarySI),
 		corev1.ResourceEphemeralStorage: *resource.NewQuantity(ephemeralEviction*1024*1024*1024, resource.BinarySI),
@@ -94,7 +109,7 @@ func NewStaticInstanceType(ctx context.Context, mt *computepb.MachineType, nodeC
 
 	overhead := cloudprovider.InstanceTypeOverhead{
 		KubeReserved:      mergeKubeReserved(computedKubeReserved, kc),
-		SystemReserved:    kcSystemReserved(kc),
+		SystemReserved:    kcSystemReserved(computedSystemReserved, kc),
 		EvictionThreshold: evictionThreshold(memoryQuantity, storageQuantity, computedEviction, kc),
 	}
 

--- a/test/pkg/environment/helpers.go
+++ b/test/pkg/environment/helpers.go
@@ -873,21 +873,82 @@ func (e *Environment) WaitForNodeClaimInitialized(ctx context.Context, nodePoolN
 	}).WithTimeout(GPUProvisioningTimeout).WithPolling(DefaultPollInterval).Should(Succeed())
 }
 
-// WaitForKubeProxyRunning polls until the kube-proxy DaemonSet pod on the given
-// node is Running and Ready. GKE uses "component=kube-proxy" (not the upstream
-// "k8s-app=kube-proxy" label), so we query by that selector.
+// WaitForKubeProxyRunning polls until exactly one kube-proxy pod exists on the
+// given node, is Running/Ready, and resolves to an image matching the node arch.
+// GKE can expose kube-proxy as either a node-owned static/mirror pod
+// (component=kube-proxy) or an addonmanager-managed DaemonSet pod
+// (k8s-app=kube-proxy); a Karpenter node must not run both.
 func (e *Environment) WaitForKubeProxyRunning(ctx context.Context, nodeName string) {
 	Eventually(func(g Gomega) {
-		pods, err := e.KubeClient.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
+		node, err := e.KubeClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred(), "getting node %s", nodeName)
+		arch := node.Labels[corev1.LabelArchStable]
+		g.Expect(arch).NotTo(BeEmpty(), "node %s has no %s label", nodeName, corev1.LabelArchStable)
+
+		fieldSelector := fmt.Sprintf("spec.nodeName=%s", nodeName)
+		staticPods, err := e.KubeClient.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
 			LabelSelector: "component=kube-proxy",
-			FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+			FieldSelector: fieldSelector,
 		})
-		g.Expect(err).NotTo(HaveOccurred(), "listing kube-proxy pods on node %s", nodeName)
-		g.Expect(pods.Items).NotTo(BeEmpty(), "no kube-proxy pod on node %s", nodeName)
-		g.Expect(isRunningAndReady(&pods.Items[0])).To(BeTrue(),
-			"kube-proxy pod on %s is not Running/Ready (phase=%s)",
-			nodeName, pods.Items[0].Status.Phase)
+		g.Expect(err).NotTo(HaveOccurred(), "listing static kube-proxy pods on node %s", nodeName)
+		daemonSetPods, err := e.KubeClient.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
+			LabelSelector: "k8s-app=kube-proxy",
+			FieldSelector: fieldSelector,
+		})
+		g.Expect(err).NotTo(HaveOccurred(), "listing DaemonSet kube-proxy pods on node %s", nodeName)
+
+		kubeProxyPods := make([]corev1.Pod, 0, len(staticPods.Items)+len(daemonSetPods.Items))
+		kubeProxyPods = append(kubeProxyPods, staticPods.Items...)
+		kubeProxyPods = append(kubeProxyPods, daemonSetPods.Items...)
+		g.Expect(kubeProxyPods).To(HaveLen(1), "expected exactly one kube-proxy pod on node %s, got %v", nodeName, podNames(kubeProxyPods))
+
+		pod := kubeProxyPods[0]
+		g.Expect(isRunningAndReady(&pod)).To(BeTrue(),
+			"kube-proxy pod %s on %s is not Running/Ready (phase=%s)",
+			pod.Name, nodeName, pod.Status.Phase)
+		g.Expect(kubeProxyImageMatchesArch(&pod, arch)).To(BeTrue(),
+			"kube-proxy pod %s on %s has images %s that do not match arch %s",
+			pod.Name, nodeName, kubeProxyImages(&pod), arch)
 	}).WithTimeout(ProvisioningTimeout).WithPolling(DefaultPollInterval).Should(Succeed())
+}
+
+func kubeProxyImageMatchesArch(pod *corev1.Pod, arch string) bool {
+	oppositeArch := karpv1.ArchitectureArm64
+	if arch == karpv1.ArchitectureArm64 {
+		oppositeArch = karpv1.ArchitectureAmd64
+	}
+	for _, image := range kubeProxyImages(pod) {
+		if strings.Contains(image, "kube-proxy-"+oppositeArch+":") || strings.Contains(image, "kube-proxy-"+oppositeArch+"@") {
+			return false
+		}
+	}
+	return true
+}
+
+func kubeProxyImages(pod *corev1.Pod) []string {
+	images := make([]string, 0, len(pod.Spec.Containers)+len(pod.Status.ContainerStatuses)*2)
+	for _, container := range pod.Spec.Containers {
+		if strings.Contains(container.Image, "kube-proxy") {
+			images = append(images, container.Image)
+		}
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if strings.Contains(status.Image, "kube-proxy") {
+			images = append(images, status.Image)
+		}
+		if strings.Contains(status.ImageID, "kube-proxy") {
+			images = append(images, status.ImageID)
+		}
+	}
+	return images
+}
+
+func podNames(pods []corev1.Pod) []string {
+	names := make([]string, 0, len(pods))
+	for _, pod := range pods {
+		names = append(names, pod.Name)
+	}
+	return names
 }
 
 // WaitForNodeClassReady polls until the named GCENodeClass reports Ready=True.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes duplicate GKE kube-proxy handling for Karpenter nodes:

- stops adding `node.kubernetes.io/kube-proxy-ds-ready`, so GKE's kube-proxy DaemonSet does not run alongside the node-owned static/mirror kube-proxy pod
- accounts for the static kube-proxy pod's 100m CPU request in provider overhead modeling
- strengthens provisioning e2e checks to require exactly one Running/Ready kube-proxy pod per node and no opposite-arch kube-proxy image

Live cluster validation showed the node-owned static kube-proxy manifest already uses the arch-independent `kube-proxy:<version>` image; the issue #487 symptom is addressed by preventing the extra DaemonSet kube-proxy path.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

Fixes #473
Fixes #487

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

Validation:

```console
go test ./test/pkg/environment
go test ./pkg/providers/...
```

E2E on `karpenter-e2e-cluster` with PR image `ttl.sh/karpenter-provider-gcp-pr481-8f5fe571-24h:e2e-8f5fe571`:

```console
ginkgo --procs=4 --timeout=2h -v ./test/suites/{channel-image-selection,confidential,consolidation,drift,expiration,gc,kubelet_config,networking,provisioning,repair,storage}
```

All non-GPU suites passed across the run; `networking` was rerun separately with `--procs=1` after a transient OAuth token EOF in `BeforeSuite` and passed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes duplicate kube-proxy pods on Karpenter-provisioned GKE nodes by removing `node.kubernetes.io/kube-proxy-ds-ready` from Karpenter's `WellKnownLabels` (preventing the DaemonSet from being scheduled via Karpenter's label injection) and accounting for the node-owned mirror pod's 100m CPU request as provider-level `SystemReserved` overhead so Karpenter's scheduling simulation reserves the right amount of capacity.

- **`pkg/apis/v1alpha1/labels.go`**: Drops `LabelGKEReadinessKubeProxyReady` from the `init()` well-known-label registration and updates the comment block to document the intentional exclusion; the constant and `GKEReadinessLabelKeys` entry are retained for source-template label propagation.
- **`pkg/providers/instancetype/overhead.go` + `types.go`**: Introduces `staticKubeProxyCPUMilliCore = 100` and threads a pre-computed `SystemReserved` baseline through `kcSystemReserved`, which merges user-supplied values additively on top of the provider baseline; `DeepCopy` ensures the input is not mutated.
- **`test/pkg/environment/helpers.go`**: Tightens `WaitForKubeProxyRunning` to assert exactly one kube-proxy pod (static or DaemonSet) per node and to verify it does not carry an opposite-arch image string.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the core overhead and label-injection changes are correct and well-tested, with live e2e validation across the provisioning suite.

The three main code paths — removing the well-known label registration, threading the 100m CPU baseline through SystemReserved, and tightening the e2e kube-proxy assertion — are all logically sound and covered by unit and integration tests. The two observations noted are non-blocking: the GKEReadinessLabelKeys gap is only relevant in a source-template scenario the e2e cluster confirmed does not occur on static-pod kube-proxy clusters, and the pod deduplication concern is an edge case in test diagnostic quality.

pkg/apis/v1alpha1/labels.go — worth a follow-up to decide whether LabelGKEReadinessKubeProxyReady should also be removed from GKEReadinessLabelKeys for consistency with the stated intent.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/apis/v1alpha1/labels.go | Removes LabelGKEReadinessKubeProxyReady from WellKnownLabels init registration and updates the comment; label constant is preserved and still appears in GKEReadinessLabelKeys, which means inheritReadinessLabels can still propagate it from source templates. |
| pkg/providers/instancetype/overhead.go | Refactors kcSystemReserved to accept a pre-computed baseline and merge user values additively; uses DeepCopy on the input so callers' ResourceList is not mutated — correct and well-tested. |
| pkg/providers/instancetype/types.go | Adds staticKubeProxyCPUMilliCore = 100 constant and wires it into computedSystemReserved; passes computed baseline to kcSystemReserved so the 100m CPU overhead for the mirror pod is included in every instance type's scheduling model. |
| pkg/providers/instancetype/overhead_test.go | Updates existing tests for the new kcSystemReserved signature, adds immutability assertion on the computed baseline, and adds TestNewInstanceType_IncludesStaticKubeProxyOverhead to pin the 100m CPU in SystemReserved. |
| test/pkg/environment/helpers.go | Strengthens WaitForKubeProxyRunning to assert exactly one kube-proxy pod (static or DaemonSet) and to check the pod image doesn't contain the opposite arch string; no deduplication by UID between the two label-selector queries. |
| pkg/apis/v1alpha1/gcenodeclass_test.go | Adds regression test asserting LabelGKEReadinessKubeProxyReady is not in WellKnownLabels, guarding against future accidental re-registration. |
| docs/examples/advanced.md | Adds a paragraph documenting the provider-computed 100m CPU scheduling overhead for the kube-proxy mirror pod and clarifying it is not written into kubelet's reservation config. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Before["Before this PR"]
        B1[Karpenter registers kube-proxy-ds-ready\nas WellKnownLabel] --> B2[DaemonSet overhead simulation\nincludes kube-proxy DaemonSet]
        B2 --> B3[Label injected onto Karpenter node]
        B3 --> B4[kube-proxy DaemonSet schedules on node]
        B4 --> B5[Static mirror pod also created by kubelet]
        B5 --> B6[2 kube-proxy pods on node]
    end

    subgraph After["After this PR"]
        A1[kube-proxy-ds-ready removed\nfrom WellKnownLabels] --> A2[DaemonSet NOT included\nin overhead simulation]
        A2 --> A3[Label NOT injected on\nKarpenter node]
        A3 --> A4[kube-proxy DaemonSet does\nNOT schedule on node]
        A4 --> A5[Only static mirror pod\ncreated by kubelet]
        A5 --> A6[1 kube-proxy pod on node]
        A7[100m CPU added to\nSystemReserved overhead] --> A8[Karpenter scheduler\naccounts for mirror pod CPU]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Before["Before this PR"]
        B1[Karpenter registers kube-proxy-ds-ready\nas WellKnownLabel] --> B2[DaemonSet overhead simulation\nincludes kube-proxy DaemonSet]
        B2 --> B3[Label injected onto Karpenter node]
        B3 --> B4[kube-proxy DaemonSet schedules on node]
        B4 --> B5[Static mirror pod also created by kubelet]
        B5 --> B6[2 kube-proxy pods on node]
    end

    subgraph After["After this PR"]
        A1[kube-proxy-ds-ready removed\nfrom WellKnownLabels] --> A2[DaemonSet NOT included\nin overhead simulation]
        A2 --> A3[Label NOT injected on\nKarpenter node]
        A3 --> A4[kube-proxy DaemonSet does\nNOT schedule on node]
        A4 --> A5[Only static mirror pod\ncreated by kubelet]
        A5 --> A6[1 kube-proxy pod on node]
        A7[100m CPU added to\nSystemReserved overhead] --> A8[Karpenter scheduler\naccounts for mirror pod CPU]
    end
```

</a>
</details>

<sub>Reviews (8): Last reviewed commit: ["test: assert single kube-proxy per e2e n..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/74343dd324da6f93fcf098352865792ce71f348d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39272906)</sub>

<!-- /greptile_comment -->