### PR TITLE
Document baseline kube-proxy system CPU reservation in advanced kubelet examples

### DIFF
--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -68,6 +68,8 @@ kubeletConfiguration:
 
 Both settings reduce node allocatable capacity. The scheduler accounts for these when bin-packing workloads.
 
+On GKE, Karpenter always reserves a baseline 100m of CPU under `systemReserved` for the kube-proxy mirror pod that GKE runs on every Karpenter-provisioned node. Values you set in `systemReserved` add to this baseline rather than replace it, so `systemReserved.cpu: "1"` yields an effective reservation of 1100m CPU in Karpenter's allocatable estimate. The baseline applies only to Karpenter's scheduling view so its estimate matches the node's real allocatable capacity; it is not written into the node's kubelet reservation configuration.
+
 When you set a partial `kubeReserved` (for example, only `cpu`), Karpenter preserves provider-computed defaults for unspecified keys like `ephemeral-storage` based on boot disk size.
 
 ### Eviction thresholds


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/737a7a14-b173-4f3f-8495-8f7eb2c590eb)

Updates the "Resource reservations" section of docs/examples/advanced.md to document that Karpenter now reserves a baseline 100m CPU under systemReserved for GKE's node-owned kube-proxy mirror pod, and that user-provided systemReserved values are additive on top of this baseline. Reflects behavior introduced in PR #481.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #481: fix: reserve static kube-proxy overhead](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/481)

---

_Tip: Worried about broken links? Ask Promptless to find and fix them automatically 🔗_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a paragraph to the "Resource reservations" section of `docs/examples/advanced.md` documenting that Karpenter applies a baseline 100m CPU reservation under `systemReserved` for GKE's kube-proxy mirror pod, with user values being additive on top.

- The documented behavior does not exist in the current codebase — `kcSystemReserved` passes user values through unchanged and no baseline is injected anywhere in the overhead calculation path.
- The implementing change (PR #481) has not been merged, making this documentation inaccurate for the current release.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Merging this doc as-is publishes inaccurate information about CPU reservation behavior that does not exist in the current code.

The documented baseline 100m kube-proxy CPU reservation is absent from the codebase — `kcSystemReserved` returns only user-supplied values and there is no additive logic anywhere in the overhead path. A user who reads this paragraph and plans cluster capacity around the stated 1100m effective reservation for a `systemReserved.cpu: "1"` setting will get wrong numbers from the actual scheduler. The doc should either be held until PR #481 lands or clearly marked as describing upcoming behavior.

docs/examples/advanced.md — the newly added paragraph describes behavior that the current code does not implement.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/examples/advanced.md | Adds a paragraph documenting a baseline 100m CPU kube-proxy reservation in systemReserved, but the implementing PR (#481) has not been merged — the described behavior does not exist in the codebase today. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["NodeClass KubeletConfiguration\n(systemReserved.cpu: '1')"] --> B["kcSystemReserved(kc)\noverhead.go:41-50"]
    B --> C["ResourceList{cpu: 1000m}\n(user value only, no baseline)"]
    C --> D["InstanceTypeOverhead.SystemReserved\ntypes.go:97"]
    D --> E["Scheduler allocatable estimate\n(1000m reserved, NOT 1100m)"]

    F["Docs claim (this PR):\n+100m baseline for kube-proxy"] -.->|"not implemented\nPR #481 not merged"| D
    style F fill:#f66,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["NodeClass KubeletConfiguration\n(systemReserved.cpu: '1')"] --> B["kcSystemReserved(kc)\noverhead.go:41-50"]
    B --> C["ResourceList{cpu: 1000m}\n(user value only, no baseline)"]
    C --> D["InstanceTypeOverhead.SystemReserved\ntypes.go:97"]
    D --> E["Scheduler allocatable estimate\n(1000m reserved, NOT 1100m)"]

    F["Docs claim (this PR):\n+100m baseline for kube-proxy"] -.->|"not implemented\nPR #481 not merged"| D
    style F fill:#f66,color:#fff
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fexamples%2Fadvanced.md%3A71%0A**Documentation%20ahead%20of%20implementation**%0A%0AThe%20paragraph%20documents%20a%20baseline%20100m%20CPU%20reservation%20added%20to%20%60systemReserved%60%20for%20the%20kube-proxy%20mirror%20pod%2C%20but%20this%20behavior%20does%20not%20exist%20in%20the%20current%20codebase.%20%60kcSystemReserved%60%20in%20%60pkg%2Fproviders%2Finstancetype%2Foverhead.go%60%20%28lines%2041%E2%80%9350%29%20simply%20translates%20user-provided%20keys%20verbatim%20into%20a%20%60corev1.ResourceList%60%20with%20no%20baseline%20added%2C%20and%20%60types.go%60%20line%2097%20sets%20%60SystemReserved%3A%20kcSystemReserved%28kc%29%60%20directly.%20PR%20%23481%2C%20which%20is%20cited%20as%20implementing%20this%20change%2C%20is%20not%20yet%20merged.%20Users%20who%20rely%20on%20this%20document%20to%20calculate%20allocatable%20CPU%20will%20get%20wrong%20estimates%20%E2%80%94%20they%20will%20subtract%20an%20extra%20100m%20that%20the%20scheduler%20is%20not%20actually%20reserving.%0A%0A&pr=482&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fexamples%2Fadvanced.md%3A71%0A**Documentation%20ahead%20of%20implementation**%0A%0AThe%20paragraph%20documents%20a%20baseline%20100m%20CPU%20reservation%20added%20to%20%60systemReserved%60%20for%20the%20kube-proxy%20mirror%20pod%2C%20but%20this%20behavior%20does%20not%20exist%20in%20the%20current%20codebase.%20%60kcSystemReserved%60%20in%20%60pkg%2Fproviders%2Finstancetype%2Foverhead.go%60%20%28lines%2041%E2%80%9350%29%20simply%20translates%20user-provided%20keys%20verbatim%20into%20a%20%60corev1.ResourceList%60%20with%20no%20baseline%20added%2C%20and%20%60types.go%60%20line%2097%20sets%20%60SystemReserved%3A%20kcSystemReserved%28kc%29%60%20directly.%20PR%20%23481%2C%20which%20is%20cited%20as%20implementing%20this%20change%2C%20is%20not%20yet%20merged.%20Users%20who%20rely%20on%20this%20document%20to%20calculate%20allocatable%20CPU%20will%20get%20wrong%20estimates%20%E2%80%94%20they%20will%20subtract%20an%20extra%20100m%20that%20the%20scheduler%20is%20not%20actually%20reserving.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=482&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22promptless%2Fdocument-kube-proxy-system-overhead%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22promptless%2Fdocument-kube-proxy-system-overhead%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fexamples%2Fadvanced.md%3A71%0A**Documentation%20ahead%20of%20implementation**%0A%0AThe%20paragraph%20documents%20a%20baseline%20100m%20CPU%20reservation%20added%20to%20%60systemReserved%60%20for%20the%20kube-proxy%20mirror%20pod%2C%20but%20this%20behavior%20does%20not%20exist%20in%20the%20current%20codebase.%20%60kcSystemReserved%60%20in%20%60pkg%2Fproviders%2Finstancetype%2Foverhead.go%60%20%28lines%2041%E2%80%9350%29%20simply%20translates%20user-provided%20keys%20verbatim%20into%20a%20%60corev1.ResourceList%60%20with%20no%20baseline%20added%2C%20and%20%60types.go%60%20line%2097%20sets%20%60SystemReserved%3A%20kcSystemReserved%28kc%29%60%20directly.%20PR%20%23481%2C%20which%20is%20cited%20as%20implementing%20this%20change%2C%20is%20not%20yet%20merged.%20Users%20who%20rely%20on%20this%20document%20to%20calculate%20allocatable%20CPU%20will%20get%20wrong%20estimates%20%E2%80%94%20they%20will%20subtract%20an%20extra%20100m%20that%20the%20scheduler%20is%20not%20actually%20reserving.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=482&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: document baseline kube-proxy syste..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/64513f92fd47268803fd4664131bd3a34b148b78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39273994)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->