### PR TITLE
Document inherited GKE readiness-gate labels in bootstrap pool selection

### DIFF
--- a/docs/bootstrap-pool.md
+++ b/docs/bootstrap-pool.md
@@ -63,10 +63,27 @@ Karpenter reads kubelet bootstrap metadata from the bootstrap pool's instance te
 | Private-node setting                   | GCENodeClass `spec.networkConfig.enablePrivateNodes`; defaults to cluster private-node setting from GKE cluster config |
 | Service account                        | GCENodeClass `spec.serviceAccount`, `DEFAULT_NODEPOOL_SERVICE_ACCOUNT`, or Compute Engine default service account      |
 | Service account scopes                 | Karpenter sets `cloud-platform`                                                                                        |
-| Node labels                            | Rebuilt from Karpenter/provider target state                                                                           |
+| Node labels                            | Rebuilt from Karpenter/provider target state, plus GKE readiness-gate labels inherited from the source pool template (see below) |
 | Node taints                            | Rebuilt from Karpenter/provider target state                                                                           |
 
-Labels and taints configured on the bootstrap pool (such as `workload=karpenter` or `dedicated=karpenter:NoSchedule`) are intentionally discarded. Karpenter-provisioned nodes receive only labels and taints that Karpenter explicitly controls.
+Labels and taints configured on the bootstrap pool (such as `workload=karpenter` or `dedicated=karpenter:NoSchedule`) are intentionally discarded. Karpenter-provisioned nodes receive only labels and taints that Karpenter explicitly controls, plus the GKE readiness-gate labels described below.
+
+### GKE readiness-gate labels
+
+GKE sets readiness-gate labels on each node to hold back system DaemonSets — such as `ip-masq-agent`, Calico, `netd`, `node-local-dns`, `kube-proxy`, and the metadata server — until the node is ready for each subsystem. The exact set is cluster-specific: it depends on the cluster's dataplane (for example, Dataplane V2) and which addons are enabled. GKE encodes the correct per-node set in the source pool's instance template.
+
+Karpenter inherits these readiness-gate labels from the source pool's template rather than rebuilding them from a fixed list, so provisioned nodes carry exactly the set their DaemonSets require. The inherited keys are:
+
+- `projectcalico.org/ds-ready`
+- `node.kubernetes.io/kube-proxy-ds-ready`
+- `iam.gke.io/gke-metadata-server-enabled`
+- `node.kubernetes.io/masq-agent-ds-ready`
+- `cloud.google.com/gke-netd-ready`
+- `addon.gke.io/node-local-dns-ds-ready`
+
+When Karpenter explicitly owns one of these keys, the Karpenter-owned value wins over the inherited one. All other source-pool labels are still discarded.
+
+Dropping a readiness-gate label prevents the DaemonSet it gates from scheduling on the node. For example, on clusters running `ip-masq-agent` (such as Dataplane V2 clusters), a missing `node.kubernetes.io/masq-agent-ds-ready` label keeps `ip-masq-agent` from scheduling, so pod traffic is not SNATed to the node IP and egress to internal endpoints times out.
 
 ## Upgrading from template pools
 


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/b9966725-07ff-44de-b649-e0a927519b55)

Updates docs/bootstrap-pool.md to reflect that Karpenter now inherits GKE readiness-gate labels (e.g. masq-agent-ds-ready, calico ds-ready) from the source pool's instance template instead of rebuilding node labels from a fixed list. Corrects the now-stale "Metadata sources" description and explains the user-visible impact (DaemonSet scheduling / pod egress) introduced by PR #485.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #485: fix(metadata): inherit GKE readiness labels from the source template](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/485)

---

_Tip: Use labels in the [Promptless dashboard](https://app.gopromptless.ai) to categorize suggestions by release or team 🏷️_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates `docs/bootstrap-pool.md` to document that Karpenter inherits GKE readiness-gate labels (calico, masq-agent, netd, etc.) from the source pool's instance template instead of using a hardcoded list, and explains the user-visible impact on DaemonSet scheduling and pod egress.

- The new \"GKE readiness-gate labels\" subsection lists 6 label keys and explains the inheritance mechanism and Karpenter's override priority.
- The \"Metadata sources\" table row for node labels is updated to reference the new subsection, and the paragraph below it is revised accordingly.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Documentation change only — no runtime code is modified, so there is no risk of introducing a bug or regression, but the added section describes label inheritance behavior that the current code does not implement.

The new readiness-gate labels section states Karpenter inherits labels from the source pool template, but BaselineKubeEnvLabels uses a hardcoded fixed list of four labels and SetNodeLabels replaces the template kube-labels entirely. Two of the six keys listed as inherited (projectcalico.org/ds-ready and node.kubernetes.io/masq-agent-ds-ready) are not in the provisioning path at all. If this documentation lands before PR #485 is merged, operators will expect these labels on their nodes and will be surprised when they are absent.

docs/bootstrap-pool.md — the new readiness-gate labels subsection should be verified against the actual implementation (pkg/providers/metadata/utils.go BaselineKubeEnvLabels) before merging, or merged only after PR #485 lands.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/bootstrap-pool.md | Adds a new GKE readiness-gate labels section documenting label inheritance from the source pool template, but the described behavior (inheritance instead of a fixed list, and two extra labels) does not match the current implementation in pkg/providers/metadata/utils.go |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Source Pool Instance Template] -->|kube-labels / kube-env read| B{Readiness-gate label extraction}
    B -->|Documented: inherit from template| C[Template readiness labels: calico, masq-agent, netd, kube-proxy, metadata-server, dns]
    B -->|Current code: BaselineKubeEnvLabels| D[Fixed list of 4 labels: netd, node-local-dns, metadata-server, kube-proxy]
    E[Karpenter-owned labels: nodeClaim + nodeClass] --> F[SetNodeLabels: wholesale replace kube-labels in template]
    C -.->|PR #485 not yet merged| F
    D --> F
    F --> G[Provisioned Node Labels]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Source Pool Instance Template] -->|kube-labels / kube-env read| B{Readiness-gate label extraction}
    B -->|Documented: inherit from template| C[Template readiness labels: calico, masq-agent, netd, kube-proxy, metadata-server, dns]
    B -->|Current code: BaselineKubeEnvLabels| D[Fixed list of 4 labels: netd, node-local-dns, metadata-server, kube-proxy]
    E[Karpenter-owned labels: nodeClaim + nodeClass] --> F[SetNodeLabels: wholesale replace kube-labels in template]
    C -.->|PR #485 not yet merged| F
    D --> F
    F --> G[Provisioned Node Labels]
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fbootstrap-pool.md%3A75-86%0A**Documented%20behavior%20does%20not%20match%20the%20current%20implementation**%0A%0AThe%20section%20claims%20Karpenter%20%22inherits%20these%20readiness-gate%20labels%20from%20the%20source%20pool's%20template%20rather%20than%20rebuilding%20them%20from%20a%20fixed%20list%2C%22%20but%20the%20actual%20code%20in%20%60pkg%2Fproviders%2Fmetadata%2Futils.go%60%20%28%60BaselineKubeEnvLabels%60%2C%20lines%20503%E2%80%93514%29%20does%20the%20opposite%3A%20it%20builds%20a%20**fixed%20set%20of%204%20labels**%20and%20then%20%60SetNodeLabels%60%20wholesale-replaces%20the%20kube-labels%20in%20the%20template%2C%20discarding%20whatever%20the%20template%20contained.%0A%0AAdditionally%2C%20%60projectcalico.org%2Fds-ready%60%20and%20%60node.kubernetes.io%2Fmasq-agent-ds-ready%60%20are%20listed%20here%20as%20inherited%20keys%20but%20they%20do%20not%20appear%20in%20%60BaselineKubeEnvLabels%60%20or%20anywhere%20else%20in%20the%20provisioning%20path%20%E2%80%94%20they%20are%20only%20defined%20as%20constants%20for%20DaemonSet%20overhead%20simulation.%20An%20operator%20reading%20this%20doc%20will%20expect%20these%20two%20labels%20on%20provisioned%20nodes%2C%20but%20the%20current%20code%20never%20sets%20them.%20The%20referenced%20PR%20%23485%20that%20is%20supposed%20to%20introduce%20the%20inheritance%20logic%20is%20also%20not%20present%20in%20the%20git%20history%20of%20this%20branch.%0A%0A&pr=486&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fbootstrap-pool.md%3A75-86%0A**Documented%20behavior%20does%20not%20match%20the%20current%20implementation**%0A%0AThe%20section%20claims%20Karpenter%20%22inherits%20these%20readiness-gate%20labels%20from%20the%20source%20pool's%20template%20rather%20than%20rebuilding%20them%20from%20a%20fixed%20list%2C%22%20but%20the%20actual%20code%20in%20%60pkg%2Fproviders%2Fmetadata%2Futils.go%60%20%28%60BaselineKubeEnvLabels%60%2C%20lines%20503%E2%80%93514%29%20does%20the%20opposite%3A%20it%20builds%20a%20**fixed%20set%20of%204%20labels**%20and%20then%20%60SetNodeLabels%60%20wholesale-replaces%20the%20kube-labels%20in%20the%20template%2C%20discarding%20whatever%20the%20template%20contained.%0A%0AAdditionally%2C%20%60projectcalico.org%2Fds-ready%60%20and%20%60node.kubernetes.io%2Fmasq-agent-ds-ready%60%20are%20listed%20here%20as%20inherited%20keys%20but%20they%20do%20not%20appear%20in%20%60BaselineKubeEnvLabels%60%20or%20anywhere%20else%20in%20the%20provisioning%20path%20%E2%80%94%20they%20are%20only%20defined%20as%20constants%20for%20DaemonSet%20overhead%20simulation.%20An%20operator%20reading%20this%20doc%20will%20expect%20these%20two%20labels%20on%20provisioned%20nodes%2C%20but%20the%20current%20code%20never%20sets%20them.%20The%20referenced%20PR%20%23485%20that%20is%20supposed%20to%20introduce%20the%20inheritance%20logic%20is%20also%20not%20present%20in%20the%20git%20history%20of%20this%20branch.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=486&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22promptless%2Fdocument-inherited-gke-readiness-labels%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22promptless%2Fdocument-inherited-gke-readiness-labels%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fbootstrap-pool.md%3A75-86%0A**Documented%20behavior%20does%20not%20match%20the%20current%20implementation**%0A%0AThe%20section%20claims%20Karpenter%20%22inherits%20these%20readiness-gate%20labels%20from%20the%20source%20pool's%20template%20rather%20than%20rebuilding%20them%20from%20a%20fixed%20list%2C%22%20but%20the%20actual%20code%20in%20%60pkg%2Fproviders%2Fmetadata%2Futils.go%60%20%28%60BaselineKubeEnvLabels%60%2C%20lines%20503%E2%80%93514%29%20does%20the%20opposite%3A%20it%20builds%20a%20**fixed%20set%20of%204%20labels**%20and%20then%20%60SetNodeLabels%60%20wholesale-replaces%20the%20kube-labels%20in%20the%20template%2C%20discarding%20whatever%20the%20template%20contained.%0A%0AAdditionally%2C%20%60projectcalico.org%2Fds-ready%60%20and%20%60node.kubernetes.io%2Fmasq-agent-ds-ready%60%20are%20listed%20here%20as%20inherited%20keys%20but%20they%20do%20not%20appear%20in%20%60BaselineKubeEnvLabels%60%20or%20anywhere%20else%20in%20the%20provisioning%20path%20%E2%80%94%20they%20are%20only%20defined%20as%20constants%20for%20DaemonSet%20overhead%20simulation.%20An%20operator%20reading%20this%20doc%20will%20expect%20these%20two%20labels%20on%20provisioned%20nodes%2C%20but%20the%20current%20code%20never%20sets%20them.%20The%20referenced%20PR%20%23485%20that%20is%20supposed%20to%20introduce%20the%20inheritance%20logic%20is%20also%20not%20present%20in%20the%20git%20history%20of%20this%20branch.%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=486&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: document inherited GKE readiness-g..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/7533578f7beb3f4ff7d91ef4838cfe942921220f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39507853)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->