### PR TITLE
fix: normalize kube-proxy image arch in kube-env

### DIFF
--- a/pkg/providers/metadata/kubeenv_arch.go
+++ b/pkg/providers/metadata/kubeenv_arch.go
@@ -35,6 +35,9 @@ var (
 	serverBinaryArchRegex = regexp.MustCompile(`kubernetes-server-linux-(amd64|arm64)\.tar\.gz`)
 	// gkeReleaseVersionRegex extracts the GKE release version from a binary URL.
 	gkeReleaseVersionRegex = regexp.MustCompile(`/release/(v[^/]+)/`)
+	// kubeProxyArchImageRegex matches GKE kube-proxy image repositories with an
+	// architecture suffix. The suffix is stripped to use the multi-arch image tag.
+	kubeProxyArchImageRegex = regexp.MustCompile(`kube-proxy-(amd64|arm64)(:[A-Za-z0-9._+\-]+)`)
 )
 
 // archHashCache caches GCS-fetched SHA-512 hashes keyed by "arch:version".
@@ -73,6 +76,8 @@ func PatchKubeEnvForArch(ctx context.Context, metaData *compute.Metadata, target
 
 // patchServerBinaryForArch performs the actual string replacement on a kube-env string.
 func patchServerBinaryForArch(ctx context.Context, kubeEnv, targetArch, gkeVersion string, httpClient *http.Client) (string, error) {
+	kubeEnv = normalizeKubeProxyImage(kubeEnv)
+
 	urlMatch := serverBinaryArchRegex.FindStringSubmatch(kubeEnv)
 	if urlMatch == nil {
 		return kubeEnv, nil
@@ -114,6 +119,10 @@ func patchServerBinaryForArch(ctx context.Context, kubeEnv, targetArch, gkeVersi
 		return "", fmt.Errorf("SERVER_BINARY_TAR_HASH not found in kube-env after URL patch")
 	}
 	return strings.Join(lines, "\n"), nil
+}
+
+func normalizeKubeProxyImage(kubeEnv string) string {
+	return kubeProxyArchImageRegex.ReplaceAllString(kubeEnv, "kube-proxy$2")
 }
 
 // getArchHash returns the SHA-512 hash for the given GKE binary tarball, fetching

--- a/pkg/providers/metadata/kubeenv_arch_test.go
+++ b/pkg/providers/metadata/kubeenv_arch_test.go
@@ -89,6 +89,37 @@ func TestPatchKubeEnvForArch_NoServerBinaryURL_NoOp(t *testing.T) {
 	require.Equal(t, "KUBELET_ARGS: --v=2\n", lo.FromPtr(meta.Items[0].Value))
 }
 
+func TestPatchKubeEnvForArch_NormalizesArchSpecificKubeProxyImage(t *testing.T) {
+	kubeEnv := "SERVER_BINARY_TAR_URL: https://storage.googleapis.com/gke-release/kubernetes/release/v1.35.5-gke.1057002/kubernetes-server-linux-amd64.tar.gz\n" +
+		"SERVER_BINARY_TAR_HASH: " + strings.Repeat("0", 128) + "\n" +
+		"KUBE_PROXY_IMAGE: europe-west4-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy-amd64:v1.35.5-gke.1057002\n"
+
+	srv := hashServer(t, fakeHash, http.StatusOK)
+	defer srv.Close()
+	client := srv.Client()
+	client.Transport = rewriteHostTransport{base: http.DefaultTransport, target: srv.URL}
+
+	meta := kubeEnvMeta(kubeEnv)
+	require.NoError(t, PatchKubeEnvForArch(context.Background(), meta, "arm64", "", client))
+
+	got := lo.FromPtr(meta.Items[0].Value)
+	require.Contains(t, got, "linux-arm64.tar.gz")
+	require.Contains(t, got, "europe-west4-artifactregistry.gcr.io/gke-release/gke-release/kube-proxy:v1.35.5-gke.1057002")
+	require.NotContains(t, got, "kube-proxy-amd64")
+}
+
+func TestPatchKubeEnvForArch_KubeProxyImageNormalizationDoesNotRequireServerBinaryURL(t *testing.T) {
+	meta := kubeEnvMeta("KUBE_PROXY_IMAGE: gke.gcr.io/kube-proxy-arm64:v1.35.5-gke.1057002\n")
+	require.NoError(t, PatchKubeEnvForArch(context.Background(), meta, "amd64", "", nil))
+	require.Equal(t, "KUBE_PROXY_IMAGE: gke.gcr.io/kube-proxy:v1.35.5-gke.1057002\n", lo.FromPtr(meta.Items[0].Value))
+}
+
+func TestPatchKubeEnvForArch_LeavesMultiArchKubeProxyImageUnchanged(t *testing.T) {
+	meta := kubeEnvMeta("KUBE_PROXY_IMAGE: gke.gcr.io/kube-proxy:v1.35.5-gke.1057002\n")
+	require.NoError(t, PatchKubeEnvForArch(context.Background(), meta, "arm64", "", nil))
+	require.Equal(t, "KUBE_PROXY_IMAGE: gke.gcr.io/kube-proxy:v1.35.5-gke.1057002\n", lo.FromPtr(meta.Items[0].Value))
+}
+
 func TestPatchKubeEnvForArch_VersionFallbackToGKEVersion(t *testing.T) {
 	// URL has no /release/<version>/ segment; gkeVersion should be used instead.
 	// Use a distinct version to avoid hitting the cache populated by TestPatchKubeEnvForArch_AMD64ToARM64.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Normalizes architecture-suffixed GKE `kube-proxy` image references in `kube-env` from `kube-proxy-{amd64,arm64}:<version>` to the multi-arch `kube-proxy:<version>` tag while applying the existing architecture bootstrap patch.

This keeps static/node-owned kube-proxy bootstrap metadata safe when the discovered GKE source nodepool architecture differs from the Karpenter target NodeClaim architecture. It complements the DaemonSet readiness-label work in #481 by covering the node-owned/static kube-proxy path instead of the addonmanager-managed DaemonSet path.

Implemented red-green TDD coverage for:

- arch-specific kube-proxy image normalization during amd64 -> arm64 patching
- normalization even when no `SERVER_BINARY_TAR_URL` is present
- already multi-arch kube-proxy images remaining unchanged

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

Fixes #487

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

Validation run locally:

```console
go test ./pkg/providers/...
```
