### PR TITLE
docs: add ADOPTERS.md with BEAT81 as first adopter

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,13 @@
+# Adopters
+
+This page contains a non-comprehensive list of organizations that use the [Karpenter GCP Cloud Provider](https://github.com/cloudpilot-ai/karpenter-provider-gcp), either as end users or to build higher-level products and services, that we know of.
+
+## Adding your organization to this list
+
+If you are using the Karpenter GCP Cloud Provider and would like to be listed here, we would love to have you! Please open a pull request adding your organization's name, a link, and a short description of your use case. Entries are kept in alphabetical order.
+
+## Adopters (in alphabetical order)
+
+| Organization | Description |
+| --- | --- |
+| [BEAT81](https://www.beat81.com) | The Karpenter GCP Cloud Provider is the core of their autoscaling. They run Spot instances for cost efficiency and provision dedicated nodes for mission-critical workloads. |


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Introduces an `ADOPTERS.md` file listing organizations that use the Karpenter GCP
Cloud Provider. Maintaining a public list of adopters helps demonstrate real-world
usage and supports a potential future CNCF adoption effort. BEAT81 is added as the
first adopter. Entries are kept in alphabetical order.

#### Related proposal (if applicable):

#### Which issue(s) this PR fixes:

Fixes #

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

Format follows the headlamp [`ADOPTERS.md`](https://github.com/kubernetes-sigs/headlamp/blob/main/ADOPTERS.md)
referenced in the community Slack discussion, including alphabetical ordering as is
typical for CNCF-style adopter lists.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new `ADOPTERS.md` file to publicly document organizations using the Karpenter GCP Cloud Provider, adding BEAT81 as the first listed adopter.

- Adds `ADOPTERS.md` with a Markdown table for adopter entries (alphabetical order), contribution instructions, and a description of BEAT81's use case (Spot instances for cost efficiency, dedicated nodes for mission-critical workloads).
- No code changes are included; this is a purely documentation-only addition with no impact on provider logic or runtime behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge — it only adds a new documentation file with no changes to any code, configuration, or provider logic.

A single new Markdown file is added with no modifications to provider packages, Kubernetes resources, GCE VM lifecycle code, or any other executable path. The content is well-formed and follows the referenced CNCF-style adopter list format.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ADOPTERS.md | New documentation file listing adopters of the Karpenter GCP Cloud Provider; adds BEAT81 as the first entry with alphabetical ordering and contribution instructions. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Organization uses Karpenter GCP Provider] --> B[Open Pull Request]
    B --> C[Add entry to ADOPTERS.md table]
    C --> D{Alphabetical order?}
    D -- Yes --> E[PR reviewed & merged]
    D -- No --> F[Reorder entry]
    F --> E
    E --> G[Organization listed as Adopter]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Organization uses Karpenter GCP Provider] --> B[Open Pull Request]
    B --> C[Add entry to ADOPTERS.md table]
    C --> D{Alphabetical order?}
    D -- Yes --> E[PR reviewed & merged]
    D -- No --> F[Reorder entry]
    F --> E
    E --> G[Organization listed as Adopter]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: add ADOPTERS.md with BEAT81 as fir..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/a2e3ab13a553af9ae76894c842e5949751fa9d7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41137658)</sub>

<!-- /greptile_comment -->