### PR TITLE
chore: prepare v0.5.0 release

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,19 +5,60 @@
 
 ## Unreleased
 
+---
+
+## v0.5.0
+
 ### Empty-node disruption now follows upstream Karpenter NodePool rules
 
 The provider no longer runs its separate empty-node cleanup controller. Empty nodes are now removed only through Karpenter's standard disruption controller, so NodePool `spec.disruption.consolidateAfter`, `consolidationPolicy`, and disruption budgets are honored consistently.
 
 A node that only contains a GKE `konnectivity-agent` Deployment pod is not considered empty by Karpenter core because the pod is Deployment-owned, not DaemonSet-owned. This avoids provider-induced delete/provision churn, but it can leave a lightly used node in place until normal underutilized consolidation can safely remove or replace it. First-class handling for non-DaemonSet system workloads should be revisited after upstream Karpenter support matures.
 
-**Action required:** review NodePool disruption settings if you relied on immediate provider-side empty-node deletion. Use `WhenEmptyOrUnderutilized` when you want Karpenter to consider consolidating lightly loaded nodes, including nodes that only run reschedulable system Deployment pods.
+**Action required:** review NodePool disruption settings if you relied on immediate provider-side empty-node deletion:
+
+```bash
+kubectl get nodepools -o yaml
+```
+
+Use `WhenEmptyOrUnderutilized` when you want Karpenter to consider consolidating lightly loaded nodes, including nodes that only run reschedulable system Deployment pods.
 
 ### Reserved `GCENodeClass.spec.metadata` keys are rejected
 
-`GCENodeClass.spec.metadata` remains available for custom Compute Engine instance metadata, but it now rejects keys reserved by GKE bootstrap metadata, including `kube-env`, `cluster-name`, `cluster-location`, `instance-template`, `startup-script`, `user-data`, `kubeconfig`, and `kubelet-config`.
+`GCENodeClass.spec.metadata` remains available for custom Compute Engine instance metadata, but it now rejects keys reserved by GKE bootstrap metadata.
 
-**Action required:** audit existing `GCENodeClass` objects that set bootstrap-owned metadata keys and remove those entries before upgrading the CRD. Non-reserved custom metadata keys continue to work.
+The following keys are rejected:
+
+- `cluster-location`
+- `cluster-name`
+- `cluster-uid`
+- `common-psm1`
+- `configure-sh`
+- `containerd-configure-sh`
+- `disable-address-manager`
+- `enable-os-login`
+- `gci-ensure-gke-docker`
+- `gci-metrics-enabled`
+- `gci-update-strategy`
+- `instance-template`
+- `install-ssh-psm1`
+- `k8s-node-setup-psm1`
+- `kube-env`
+- `kube-labels`
+- `kubeconfig`
+- `kubelet-config`
+- `startup-script`
+- `user-data`
+- `user-profile-psm1`
+- `windows-startup-script-ps1`
+
+**Action required:** audit existing `GCENodeClass` objects and remove these keys from `spec.metadata` before upgrading the CRD:
+
+```bash
+kubectl get gcenodeclasses -o yaml
+```
+
+Non-reserved custom metadata keys continue to work.
 
 ---
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

Additional labels: release-prep

#### What this PR does / why we need it:

Prepares the v0.5.0 minor release migration notes by moving the current `Unreleased` entries into a new `v0.5.0` section and leaving `Unreleased` empty for future changes.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

N/A

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

Validation:

- `make docs-lint`
- `git diff --check`

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prepares the v0.5.0 migration notes for release.

- Moves the current migration entries under a new `v0.5.0` section.
- Leaves `Unreleased` empty for future changes.
- Expands the reserved `GCENodeClass.spec.metadata` key list.
- Adds audit commands for NodePools and GCENodeClasses.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed documentation.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| MIGRATION.md | Updates the v0.5.0 migration notes and expands the upgrade guidance. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into release-v0.5-pr..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/2b872ab1f2345ee58fcdc3b6e418265d43357acb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42082444)</sub>

<!-- /greptile_comment -->