### PR TITLE
docs: Document empty-node disruption behavior and drop kube-labels from reserved metadata keys

### DIFF
--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -27,7 +27,6 @@ The following GKE bootstrap metadata keys are reserved and cannot be set in `spe
 - `install-ssh-psm1`
 - `k8s-node-setup-psm1`
 - `kube-env`
-- `kube-labels`
 - `kubeconfig`
 - `kubelet-config`
 - `startup-script`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -232,13 +232,12 @@ To resolve:
 
 Karpenter removes empty nodes through its disruption controller, which honors each NodePool's `spec.disruption` settings (`consolidationPolicy`, `consolidateAfter`, and disruption budgets). A node counts as empty only when every pod on it is owned by a DaemonSet. Pods owned by a Deployment are reschedulable, so a node running one is not treated as empty — this includes GKE system components such as the `konnectivity-agent` Deployment. Such a node stays in place until underutilized consolidation can safely remove or replace it.
 
-To let Karpenter consolidate lightly loaded nodes that only run reschedulable system Deployment pods, set `consolidationPolicy: WhenEmptyOrUnderutilized` on the NodePool:
+To let Karpenter consolidate lightly loaded nodes that only run reschedulable system Deployment pods, ensure underutilized consolidation is still enabled and that `consolidateAfter` has not been set to `Never`:
 
 ```yaml
 disruption:
   consolidationPolicy: WhenEmptyOrUnderutilized
   consolidateAfter: 30s
-```
 
 Check the current disruption settings on your NodePools with:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -225,3 +225,23 @@ To resolve:
    ```
 
 2. Update the NodePool `topology.kubernetes.io/zone` requirement to match available zones, or remove the requirement to let Karpenter use any configured cluster zone.
+
+---
+
+## Empty-looking nodes are not removed
+
+Karpenter removes empty nodes through its disruption controller, which honors each NodePool's `spec.disruption` settings (`consolidationPolicy`, `consolidateAfter`, and disruption budgets). A node counts as empty only when every pod on it is owned by a DaemonSet. Pods owned by a Deployment are reschedulable, so a node running one is not treated as empty — this includes GKE system components such as the `konnectivity-agent` Deployment. Such a node stays in place until underutilized consolidation can safely remove or replace it.
+
+To let Karpenter consolidate lightly loaded nodes that only run reschedulable system Deployment pods, set `consolidationPolicy: WhenEmptyOrUnderutilized` on the NodePool:
+
+```yaml
+disruption:
+  consolidationPolicy: WhenEmptyOrUnderutilized
+  consolidateAfter: 30s
+```
+
+Check the current disruption settings on your NodePools with:
+
+```sh
+kubectl get nodepools -o yaml
+```


### PR DESCRIPTION
[Open this suggestion in Promptless to view citations and reasoning process](https://app.gopromptless.ai/suggestions/b73cba30-bed2-4fc4-aa11-e9b0cea67173)

Adds a troubleshooting entry explaining that Karpenter treats a node as empty only when its remaining pods are all DaemonSet-owned, so nodes running reschedulable system Deployment pods (e.g. GKE `konnectivity-agent`) stay until underutilized consolidation — with guidance to use `WhenEmptyOrUnderutilized`. Also removes `kube-labels` from the reserved `GCENodeClass.spec.metadata` keys list per the customer directive not to document it. Prompted by v0.5.0 release PR #507.

**Trigger Events**
- [cloudpilot-ai/karpenter-provider-gcp PR #507: chore: prepare v0.5.0 release](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/507)

---

_Tip: Sort by Shortest Review in the [Dashboard](https://app.gopromptless.ai) to find quick wins ⚡_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates docs for GKE metadata and node disruption troubleshooting.

- Removes `kube-labels` from the documented reserved metadata key list.
- Adds guidance for nodes that look empty but still run Deployment-owned system pods.
- Shows NodePool disruption settings and a command for inspecting current settings.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

This is close, but the markdown rendering issue should be fixed before merging.

- The new troubleshooting section opens a YAML code block and does not close it before the next prose and shell snippet.
- The rendered docs can hide the intended diagnostic command inside the YAML example.

docs/troubleshooting.md
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/examples/advanced.md | Updates the documented reserved metadata key list. |
| docs/troubleshooting.md | Adds empty-node troubleshooting guidance, but the new YAML snippet is missing its closing markdown fence. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Ftroubleshooting.md%3A237-246%0A**Close%20YAML%20Fence**%0A%0AThe%20YAML%20fence%20opened%20here%20is%20not%20closed%20before%20the%20prose%20and%20shell%20snippet.%20Markdown%20renderers%20can%20treat%20the%20%60Check%20the%20current%20disruption%20settings...%60%20text%20and%20the%20%60sh%60%20fence%20as%20part%20of%20the%20YAML%20block%2C%20so%20the%20troubleshooting%20command%20will%20not%20render%20as%20an%20executable%20shell%20snippet.%0A%0A%60%60%60suggestion%0A%60%60%60yaml%0Adisruption%3A%0A%20%20consolidationPolicy%3A%20WhenEmptyOrUnderutilized%0A%20%20consolidateAfter%3A%2030s%0A%60%60%60%0A%0ACheck%20the%20current%20disruption%20settings%20on%20your%20NodePools%20with%3A%0A%0A%60%60%60sh%0Akubectl%20get%20nodepools%20-o%20yaml%0A%60%60%60%0A%60%60%60%0A%0A&pr=508&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Ftroubleshooting.md%3A237-246%0A**Close%20YAML%20Fence**%0A%0AThe%20YAML%20fence%20opened%20here%20is%20not%20closed%20before%20the%20prose%20and%20shell%20snippet.%20Markdown%20renderers%20can%20treat%20the%20%60Check%20the%20current%20disruption%20settings...%60%20text%20and%20the%20%60sh%60%20fence%20as%20part%20of%20the%20YAML%20block%2C%20so%20the%20troubleshooting%20command%20will%20not%20render%20as%20an%20executable%20shell%20snippet.%0A%0A%60%60%60suggestion%0A%60%60%60yaml%0Adisruption%3A%0A%20%20consolidationPolicy%3A%20WhenEmptyOrUnderutilized%0A%20%20consolidateAfter%3A%2030s%0A%60%60%60%0A%0ACheck%20the%20current%20disruption%20settings%20on%20your%20NodePools%20with%3A%0A%0A%60%60%60sh%0Akubectl%20get%20nodepools%20-o%20yaml%0A%60%60%60%0A%60%60%60%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=508&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22promptless%2Fv0.5.0-empty-node-metadata-docs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22promptless%2Fv0.5.0-empty-node-metadata-docs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Ftroubleshooting.md%3A237-246%0A**Close%20YAML%20Fence**%0A%0AThe%20YAML%20fence%20opened%20here%20is%20not%20closed%20before%20the%20prose%20and%20shell%20snippet.%20Markdown%20renderers%20can%20treat%20the%20%60Check%20the%20current%20disruption%20settings...%60%20text%20and%20the%20%60sh%60%20fence%20as%20part%20of%20the%20YAML%20block%2C%20so%20the%20troubleshooting%20command%20will%20not%20render%20as%20an%20executable%20shell%20snippet.%0A%0A%60%60%60suggestion%0A%60%60%60yaml%0Adisruption%3A%0A%20%20consolidationPolicy%3A%20WhenEmptyOrUnderutilized%0A%20%20consolidateAfter%3A%2030s%0A%60%60%60%0A%0ACheck%20the%20current%20disruption%20settings%20on%20your%20NodePools%20with%3A%0A%0A%60%60%60sh%0Akubectl%20get%20nodepools%20-o%20yaml%0A%60%60%60%0A%60%60%60%0A%0A&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=508&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Apply suggestion from @greptile-apps\[bot..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/8d7b68c0dbe014e0b3cdd02876e683773ad19300) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42132554)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->