### PR TITLE
ci(dependabot): stop allowlist from blocking security updates in crd-tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,11 +51,23 @@ updates:
     directory: "/hack/crd-tools"
     schedule:
       interval: "weekly"
-    # kubectl-validate v0.0.4 is not compatible with newer transitive
-    # k8s.io/* releases, so only let Dependabot bump the tool itself.
+    # SECURITY updates only. `allow` also gates security updates, so the
+    # previous kubectl-validate-only allowlist silently blocked CVE fixes
+    # for every other dependency here (e.g. 13 golang.org/x/crypto
+    # advisories). Routine version bumps stay disabled (limit 0): this
+    # module's deps (etcd, cel-go, grpc-gateway, ...) are the dependency
+    # set matching the pinned k8s.io/* v0.30.x, and bumping them in
+    # isolation is likely to break kubectl-validate v0.0.4.
+    open-pull-requests-limit: 0
     allow:
-      - dependency-name: "sigs.k8s.io/kubectl-validate"
-        dependency-type: "all"
+      - dependency-type: "all"
+    ignore:
+      - dependency-name: "k8s.io/*"
+    groups:
+      crd-tools-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/hack/pdcsi-data"


### PR DESCRIPTION
## Problem

The `/hack/crd-tools` Dependabot entry uses an `allow` list containing only `sigs.k8s.io/kubectl-validate`. Per [GitHub's reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference), `allow` (and `ignore`) apply to **security updates as well as version updates** — so this allowlist silently blocked Dependabot from opening CVE-fix PRs for every other package in the module.

That is why the 13 `golang.org/x/crypto` advisories (7 critical / 2 high / 4 medium) sat open until fixed manually in #518, and why the SOC 2 package-vulnerability tests in Vanta kept requiring manual remediation each cycle.

## Change — security updates only

- `open-pull-requests-limit: 0` — routine version-update PRs stay **off**. This module's dependencies (etcd, cel-go, grpc-gateway, …) are the dependency set matching the pinned `k8s.io/* v0.30.x`; bumping them in isolation is likely to break kubectl-validate v0.0.4, which is exactly what the original config was guarding against. Security updates use a separate limit and still fire.
- `allow: dependency-type: all` — makes all packages (incl. transitive deps like `golang.org/x/crypto`) eligible for those security fixes.
- `ignore: k8s.io/*` — keeps `k8s.io/*` fully pinned. Conscious trade-off: a CVE in `k8s.io/*` itself will still need manual handling.
- `groups: crd-tools-security (applies-to: security-updates)` — batches security fixes into one PR.

## Not changed (flagging for a conscious decision)

`/hack/pdcsi-data` has the same allowlist pattern (only `sigs.k8s.io/gcp-compute-persistent-disk-csi-driver` allowed), so security updates for its transitives are also blocked. Left as-is because that module intentionally mirrors the pinned upstream's dependency set; if Dependabot alerts ever fire there, the same fix applies.

## Verification

- YAML parses (ruby `YAML.safe_load`), fields per Dependabot v2 reference.
- Real-world validation will come from the next CVE in this module producing an automatic Dependabot PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JiqUDqmhJRLqtndYsgJQCY

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a Dependabot misconfiguration in the `/hack/crd-tools` entry where an `allow` list scoped to only `sigs.k8s.io/kubectl-validate` was silently blocking security-update PRs for all other dependencies in that module, including the 13 `golang.org/x/crypto` advisories cited.

- Replaces the narrow `allow` with `dependency-type: all` and adds `ignore: k8s.io/*` to preserve the original pin intent (kubectl-validate v0.0.4 incompatibility), matching the pattern already used in `/hack/tools`.
- Adds `open-pull-requests-limit: 0` to suppress routine version bumps while leaving security-update PRs unaffected (per GitHub docs, this limit does not apply to security updates).
- Adds a `groups: crd-tools-security` scoped with `applies-to: security-updates` so CVE-fix PRs arrive batched rather than one-per-package.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a pure Dependabot configuration fix with no code execution impact.

The config change is a narrow, well-scoped YAML edit. The allow/ignore/limit interplay is correct per GitHub's documented behavior (open-pull-requests-limit does not affect security updates), the k8s.io/* ignore intentionally preserves the existing pin, and the groups scoping matches the established pattern in /hack/tools.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Correctly unblocks security updates for crd-tools by replacing the narrow allow list with dependency-type:all plus an explicit k8s.io/* ignore; version bump PRs are suppressed with open-pull-requests-limit:0 which GitHub explicitly exempts from security updates. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot scans /hack/crd-tools] --> B{Update type?}
    B -->|Version update| C{open-pull-requests-limit: 0}
    C --> D[❌ PR blocked — version bumps disabled]
    B -->|Security update| E{dependency in ignore list?}
    E -->|k8s.io/*| F[❌ PR blocked — k8s.io/* pinned intentionally]
    E -->|All other deps e.g. golang.org/x/crypto| G{allow: dependency-type: all}
    G --> H[✅ Security PR opened]
    H --> I[Grouped into crd-tools-security PR]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Dependabot scans /hack/crd-tools] --> B{Update type?}
    B -->|Version update| C{open-pull-requests-limit: 0}
    C --> D[❌ PR blocked — version bumps disabled]
    B -->|Security update| E{dependency in ignore list?}
    E -->|k8s.io/*| F[❌ PR blocked — k8s.io/* pinned intentionally]
    E -->|All other deps e.g. golang.org/x/crypto| G{allow: dependency-type: all}
    G --> H[✅ Security PR opened]
    H --> I[Grouped into crd-tools-security PR]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["ci(dependabot): stop allowlist from bloc..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/4b3c33ffff25079edf178c618c8fcc42fd85e856) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44035247)</sub>

<!-- /greptile_comment -->