### PR TITLE
fix(imagefamily): resolve Ubuntu arm64 images independently and reject variant builds

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -152,6 +152,13 @@ Karpenter detects arm64 architecture directly from the GCP Compute API. All arm6
 
 Image resolution queries GCP image catalogs directly and does not depend on the bootstrap pool. Bootstrap pool discovery and kube-env patching allow a single source pool (of any architecture) to bootstrap nodes of any OS and architecture combination. See [Bootstrap pool selection](bootstrap-pool.md) for details.
 
+For the `Ubuntu` families, each architecture is resolved independently from the image catalog: Karpenter selects the newest clean `amd64` image and the newest clean `arm64` image separately, and excludes specialized variant builds (e.g. `-tpu`, `-cgroupsv1`, `-linux64k`, `-test`). If no usable `arm64` image exists for the cluster's Kubernetes minor version, the `GCENodeClass` reports `ImagesReady=False` with reason `ImageResolutionFailed` rather than resolving an `amd64`-only image set — so an arm64 pool never appears ready while it cannot actually provision. If you see this, confirm an `arm64` image is published for your Kubernetes version:
+
+```sh
+gcloud compute images list --project=ubuntu-os-gke-cloud \
+  --filter="name~'^ubuntu-gke-2404-<major>-<minor>-arm64-v'" --sort-by=~creationTimestamp
+```
+
 To verify arm64 machine types are available in your cluster's region:
 
 ```sh

--- a/pkg/providers/imagefamily/ubuntu.go
+++ b/pkg/providers/imagefamily/ubuntu.go
@@ -34,8 +34,18 @@ import (
 
 const ubuntuGKEImageProject = "ubuntu-os-gke-cloud"
 
-var ubuntuVersionRe = regexp.MustCompile(`-v\d+(-|$)`)
+// ubuntuPinnedVersionRe validates a pinned image version (vYYYYMMDD).
 var ubuntuPinnedVersionRe = regexp.MustCompile(`^v\d{8}$`)
+
+// Clean-name allowlists per release and architecture: anchoring on the version end rejects
+// variant builds (-tpu, -cgroupsv1, -linux64k, ...) while allowing a trailing date letter
+// (v20251218a). 2204 amd64 names carry no arch token.
+var (
+	ubuntu2404AMD64Re = regexp.MustCompile(`^ubuntu-gke-2404-\d+-\d+-amd64-v\d+[a-z]?$`)
+	ubuntu2404ARM64Re = regexp.MustCompile(`^ubuntu-gke-2404-\d+-\d+-arm64-v\d+[a-z]?$`)
+	ubuntu2204AMD64Re = regexp.MustCompile(`^ubuntu-gke-2204-\d+-\d+-v\d+[a-z]?$`)
+	ubuntu2204ARM64Re = regexp.MustCompile(`^ubuntu-gke-2204-\d+-\d+-arm64-v\d+[a-z]?$`)
+)
 
 // Ubuntu resolves GKE Ubuntu images from the ubuntu-os-gke-cloud project.
 // The release field selects the OS series: "2404" for Ubuntu 24.04 or "2204" for Ubuntu 22.04.
@@ -49,105 +59,133 @@ func (u *Ubuntu) imagePrefix() string {
 	return "ubuntu-gke-" + u.release
 }
 
+// architecture requirements this provider resolves an image for, in output order.
+var ubuntuArchitectures = []string{OSArchAMD64Requirement, OSArchARM64Requirement}
+
 func (u *Ubuntu) ResolveImages(ctx context.Context, version string) (Images, error) {
 	if version != "latest" && !ubuntuPinnedVersionRe.MatchString(version) {
 		return nil, &imageResolutionError{msg: fmt.Sprintf(
 			"invalid Ubuntu version %q: must be 'latest' or 'vYYYYMMDD' (e.g. 'v20260416')", version)}
 	}
 
-	sourceImage, err := u.resolveLatestUbuntuImage(ctx)
+	images, err := u.listImages(ctx)
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to resolve Ubuntu GKE image from catalog")
 		return Images{}, err
 	}
 
-	if version != "latest" {
-		sourceImage = ubuntuVersionRe.ReplaceAllStringFunc(sourceImage, func(m string) string {
-			suffix := ""
-			if strings.HasSuffix(m, "-") {
-				suffix = "-"
-			}
-			return "-" + version + suffix
+	// Resolve each arch to a real listed image; a missing one (incl. a pinned date absent for
+	// one arch) fails resolution instead of a single-arch set that reads as ImagesReady=True.
+	ret := Images{}
+	for _, arch := range ubuntuArchitectures {
+		name, ok := u.selectImage(images, arch, version)
+		if !ok {
+			return nil, &imageResolutionError{msg: fmt.Sprintf(
+				"no ubuntu-gke-%s %s image found for version %q in %s",
+				u.release, arch, version, ubuntuGKEImageProject)}
+		}
+		ret = append(ret, Image{
+			SourceImage:  fmt.Sprintf("projects/%s/global/images/%s", ubuntuGKEImageProject, name),
+			Requirements: ubuntuRequirementsForArch(arch),
 		})
 	}
-
-	return u.resolveImages(sourceImage), nil
+	return ret, nil
 }
 
-// resolveLatestUbuntuImage queries the ubuntu-os-gke-cloud project for the most recent
-// non-deprecated amd64 Ubuntu GKE image matching the cluster's K8s minor version.
-// The arm64 variant is derived by resolveImages.
-func (u *Ubuntu) resolveLatestUbuntuImage(ctx context.Context) (string, error) {
+// listImages returns all Ubuntu GKE images matching the cluster's K8s minor version.
+func (u *Ubuntu) listImages(ctx context.Context) ([]*compute.Image, error) {
 	filter := u.buildImageFilter(ctx)
-
-	var best *compute.Image
+	var images []*compute.Image
 	err := u.computeService.Images.List(ubuntuGKEImageProject).
 		Filter(filter).
 		Pages(ctx, func(page *compute.ImageList) error {
-			for _, img := range page.Items {
-				if u.isUsable(img) && (best == nil || img.CreationTimestamp > best.CreationTimestamp) {
-					best = img
-				}
-			}
+			images = append(images, page.Items...)
 			return nil
 		})
 	if err != nil {
-		return "", fmt.Errorf("listing Ubuntu GKE images in %s: %w", ubuntuGKEImageProject, err)
+		return nil, fmt.Errorf("listing Ubuntu GKE images in %s: %w", ubuntuGKEImageProject, err)
+	}
+	return images, nil
+}
+
+// selectImage returns the newest usable image name for arch ("latest") or the exact-dated
+// usable image for a pinned vYYYYMMDD; ok=false if none matches, so a pinned date missing for
+// one arch fails resolution rather than resolving a single-arch set.
+func (u *Ubuntu) selectImage(images []*compute.Image, arch, version string) (string, bool) {
+	var best *compute.Image
+	for _, img := range images {
+		if !u.isUsableForArch(img, arch) {
+			continue
+		}
+		if version != "latest" && !strings.HasSuffix(img.Name, "-"+version) {
+			continue
+		}
+		if best == nil || img.CreationTimestamp > best.CreationTimestamp {
+			best = img
+		}
 	}
 	if best == nil {
-		return "", fmt.Errorf("no non-deprecated ubuntu-gke-%s amd64 image found in %s (filter: %s)",
-			u.release, ubuntuGKEImageProject, filter)
+		return "", false
 	}
-	return fmt.Sprintf("projects/%s/global/images/%s", ubuntuGKEImageProject, best.Name), nil
+	return best.Name, true
 }
 
-// isUsable dispatches to the release-specific usability check.
-func (u *Ubuntu) isUsable(img *compute.Image) bool {
-	if u.release == "2204" {
+// isUsableForArch dispatches to the release- and architecture-specific usability check.
+func (u *Ubuntu) isUsableForArch(img *compute.Image, arch string) bool {
+	switch {
+	case u.release == "2204" && arch == OSArchARM64Requirement:
+		return isUsableUbuntu2204Arm64Image(img)
+	case u.release == "2204":
 		return isUsableUbuntu2204Image(img)
+	case arch == OSArchARM64Requirement:
+		return isUsableUbuntuArm64Image(img)
+	default:
+		return isUsableUbuntuImage(img)
 	}
-	return isUsableUbuntuImage(img)
 }
 
-// isUsableUbuntuImage reports whether img is a non-deprecated general-purpose amd64
-// ubuntu-gke-2404 image. The 2404 series uses explicit "-amd64-" in the name.
+// ubuntuRequirementsForArch builds the scheduling requirements for a resolved image.
+func ubuntuRequirementsForArch(arch string) scheduling.Requirements {
+	if arch == OSArchARM64Requirement {
+		return scheduling.NewRequirements(
+			scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, OSArchARM64Requirement),
+			scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpDoesNotExist))
+	}
+	return scheduling.NewRequirements(
+		scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, OSArchAMD64Requirement))
+}
+
+// ubuntuImageDeprecated reports whether img has been retired by GCP (an empty state is active).
+func ubuntuImageDeprecated(img *compute.Image) bool {
+	if img.Deprecated == nil {
+		return false
+	}
+	switch img.Deprecated.State {
+	case "DEPRECATED", "OBSOLETE", "DELETED":
+		return true
+	}
+	return false
+}
+
+// isUsableUbuntuImage reports whether img is a non-deprecated, clean amd64 ubuntu-gke-2404 image.
 func isUsableUbuntuImage(img *compute.Image) bool {
-	if img.Deprecated != nil {
-		switch img.Deprecated.State {
-		case "DEPRECATED", "OBSOLETE", "DELETED":
-			return false
-		}
-	}
-	if !strings.Contains(img.Name, "-amd64-") {
-		return false
-	}
-	for _, skip := range []string{"cgroupsv1", "linux64k", "-tpu-", "-test"} {
-		if strings.Contains(img.Name, skip) {
-			return false
-		}
-	}
-	return true
+	return !ubuntuImageDeprecated(img) && ubuntu2404AMD64Re.MatchString(img.Name)
 }
 
-// isUsableUbuntu2204Image reports whether img is a non-deprecated amd64
-// ubuntu-gke-2204 image. Unlike 2404, the 2204 series does not include "-amd64-"
-// in the name for amd64 images, so we exclude arm64 images instead of requiring -amd64-.
+// isUsableUbuntuArm64Image reports whether img is a non-deprecated, clean arm64 ubuntu-gke-2404 image.
+func isUsableUbuntuArm64Image(img *compute.Image) bool {
+	return !ubuntuImageDeprecated(img) && ubuntu2404ARM64Re.MatchString(img.Name)
+}
+
+// isUsableUbuntu2204Image reports whether img is a non-deprecated, clean amd64 ubuntu-gke-2204 image
+// (the 2204 series carries no arch token for amd64).
 func isUsableUbuntu2204Image(img *compute.Image) bool {
-	if img.Deprecated != nil {
-		switch img.Deprecated.State {
-		case "DEPRECATED", "OBSOLETE", "DELETED":
-			return false
-		}
-	}
-	if strings.Contains(img.Name, "-arm64-") {
-		return false
-	}
-	for _, skip := range []string{"cgroupsv1", "linux64k", "-tpu-", "-test"} {
-		if strings.Contains(img.Name, skip) {
-			return false
-		}
-	}
-	return true
+	return !ubuntuImageDeprecated(img) && ubuntu2204AMD64Re.MatchString(img.Name)
+}
+
+// isUsableUbuntu2204Arm64Image reports whether img is a non-deprecated, clean arm64 ubuntu-gke-2204 image.
+func isUsableUbuntu2204Arm64Image(img *compute.Image) bool {
+	return !ubuntuImageDeprecated(img) && ubuntu2204ARM64Re.MatchString(img.Name)
 }
 
 // buildImageFilter returns a GCP Images.List filter scoped to the cluster's K8s minor version.
@@ -167,43 +205,4 @@ func (u *Ubuntu) buildImageFilter(ctx context.Context) string {
 		return fmt.Sprintf(`name=%s*`, prefix)
 	}
 	return fmt.Sprintf(`name=%s-%d-%d*`, prefix, parsed.Major(), parsed.Minor())
-}
-
-func (u *Ubuntu) resolveImages(sourceImage string) Images {
-	ret := Images{}
-
-	// amd64
-	ret = append(ret, Image{
-		SourceImage: sourceImage,
-		Requirements: scheduling.NewRequirements(
-			scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, OSArchAMD64Requirement)),
-	})
-
-	// arm64: derivation is release-specific.
-	arm64Image := u.deriveArm64Image(sourceImage)
-	ret = append(ret, Image{
-		SourceImage: arm64Image,
-		Requirements: scheduling.NewRequirements(
-			scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, OSArchARM64Requirement),
-			scheduling.NewRequirement(v1alpha1.LabelInstanceGPUCount, v1.NodeSelectorOpDoesNotExist)),
-	})
-
-	return ret
-}
-
-// deriveArm64Image returns the arm64 variant of a source Ubuntu image.
-//   - 2404: replace "-amd64-" with "-arm64-" (explicit arch in name)
-//   - 2204: insert "-arm64" before the "-v{date}" version suffix
-func (u *Ubuntu) deriveArm64Image(sourceImage string) string {
-	if u.release == "2404" {
-		return strings.Replace(sourceImage, "-amd64-", "-arm64-", 1)
-	}
-	// 2204: ubuntu-gke-2204-1-34-v20231201 → ubuntu-gke-2204-1-34-arm64-v20231201
-	return ubuntuVersionRe.ReplaceAllStringFunc(sourceImage, func(m string) string {
-		suffix := ""
-		if strings.HasSuffix(m, "-") {
-			suffix = "-"
-		}
-		return "-arm64-v" + strings.TrimSuffix(strings.TrimPrefix(m, "-v"), "-") + suffix
-	})
 }

--- a/pkg/providers/imagefamily/ubuntu_test.go
+++ b/pkg/providers/imagefamily/ubuntu_test.go
@@ -27,53 +27,29 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
-func TestResolveLatestUbuntuImage_PicksNewestNonDeprecated(t *testing.T) {
+func TestSelectImage_Ubuntu_PicksNewestNonDeprecatedAmd64(t *testing.T) {
 	images := []*compute.Image{
-		{
-			Name:              "ubuntu-gke-2404-1-35-amd64-v20260420",
-			CreationTimestamp: "2026-04-20T00:00:00Z",
-		},
-		{
-			Name:              "ubuntu-gke-2404-1-35-amd64-v20260401",
-			CreationTimestamp: "2026-04-01T00:00:00Z",
-		},
-		{
-			// deprecated — must be excluded
-			Name:              "ubuntu-gke-2404-1-35-amd64-v20260301",
-			CreationTimestamp: "2026-03-01T00:00:00Z",
-			Deprecated:        &compute.DeprecationStatus{State: "DEPRECATED"},
-		},
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260420", CreationTimestamp: "2026-04-20T00:00:00Z"},
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260401", CreationTimestamp: "2026-04-01T00:00:00Z"},
+		// deprecated — must be excluded
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260301", CreationTimestamp: "2026-03-01T00:00:00Z",
+			Deprecated: &compute.DeprecationStatus{State: "DEPRECATED"}},
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := &compute.ImageList{Items: images}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer srv.Close()
-
-	p := &Ubuntu{
-		computeService:  buildComputeService(t, srv),
-		versionProvider: &fakeVersionProvider{version: "v1.35.1"},
-		release:         "2404",
-	}
-
-	got, err := p.resolveLatestUbuntuImage(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2404-1-35-amd64-v20260420", got)
+	p := &Ubuntu{release: "2404"}
+	got, ok := p.selectImage(images, OSArchAMD64Requirement, "latest")
+	require.True(t, ok)
+	require.Equal(t, "ubuntu-gke-2404-1-35-amd64-v20260420", got)
 }
 
-func TestResolveLatestUbuntuImage_ExcludesNonUsable(t *testing.T) {
+func TestSelectImage_Ubuntu_ExcludesNonCleanAmd64(t *testing.T) {
 	images := []*compute.Image{
-		// excluded: arm64 (no -amd64-)
+		// excluded: arm64 (different architecture)
 		{Name: "ubuntu-gke-2404-1-35-arm64-v20260420", CreationTimestamp: "2026-04-20T00:00:00Z"},
-		// excluded: test variant
+		// excluded: variants, in either infix or trailing-suffix position
 		{Name: "ubuntu-gke-2404-1-35-amd64-v20260419-test", CreationTimestamp: "2026-04-19T00:00:00Z"},
-		// excluded: cgroupsv1
 		{Name: "ubuntu-gke-2404-1-35-amd64-cgroupsv1-v20260418", CreationTimestamp: "2026-04-18T00:00:00Z"},
-		// excluded: tpu
-		{Name: "ubuntu-gke-2404-1-35-amd64-tpu-v20260417", CreationTimestamp: "2026-04-17T00:00:00Z"},
-		// excluded: linux64k
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260418-tpu", CreationTimestamp: "2026-04-18T12:00:00Z"},
 		{Name: "ubuntu-gke-2404-1-35-amd64-linux64k-v20260416", CreationTimestamp: "2026-04-16T00:00:00Z"},
 		// excluded: obsolete
 		{Name: "ubuntu-gke-2404-1-35-amd64-v20260301", CreationTimestamp: "2026-03-01T00:00:00Z", Deprecated: &compute.DeprecationStatus{State: "OBSOLETE"}},
@@ -81,38 +57,10 @@ func TestResolveLatestUbuntuImage_ExcludesNonUsable(t *testing.T) {
 		{Name: "ubuntu-gke-2404-1-35-amd64-v20260401", CreationTimestamp: "2026-04-01T00:00:00Z"},
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := &compute.ImageList{Items: images}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer srv.Close()
-
-	p := &Ubuntu{
-		computeService:  buildComputeService(t, srv),
-		versionProvider: &fakeVersionProvider{version: "v1.35.1"},
-		release:         "2404",
-	}
-
-	got, err := p.resolveLatestUbuntuImage(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2404-1-35-amd64-v20260401", got)
-}
-
-func TestResolveImages_Ubuntu_DrivesArm64Variant(t *testing.T) {
 	p := &Ubuntu{release: "2404"}
-	sourceImage := "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2404-1-35-amd64-v20260420"
-
-	imgs := p.resolveImages(sourceImage)
-	require.Len(t, imgs, 2)
-
-	var srcs []string
-	for _, img := range imgs {
-		srcs = append(srcs, img.SourceImage)
-	}
-
-	require.Contains(t, srcs, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2404-1-35-amd64-v20260420")
-	require.Contains(t, srcs, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2404-1-35-arm64-v20260420")
+	got, ok := p.selectImage(images, OSArchAMD64Requirement, "latest")
+	require.True(t, ok)
+	require.Equal(t, "ubuntu-gke-2404-1-35-amd64-v20260401", got)
 }
 
 func TestBuildImageFilter_Ubuntu_UsesVersionPrefix(t *testing.T) {
@@ -129,36 +77,51 @@ func TestBuildImageFilter_Ubuntu_FallsBackOnNilProvider(t *testing.T) {
 
 func TestResolveImages_Ubuntu_PinnedVersion_Valid(t *testing.T) {
 	images := []*compute.Image{
-		{
-			Name:              "ubuntu-gke-2404-1-35-amd64-v20260420",
-			CreationTimestamp: "2026-04-20T00:00:00Z",
-		},
+		// newer builds that must be ignored in favor of the pinned date
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260420", CreationTimestamp: "2026-04-20T00:00:00Z"},
+		{Name: "ubuntu-gke-2404-1-35-arm64-v20260420", CreationTimestamp: "2026-04-20T00:05:00Z"},
+		// the pinned date, present for both architectures
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260416", CreationTimestamp: "2026-04-16T00:00:00Z"},
+		{Name: "ubuntu-gke-2404-1-35-arm64-v20260416", CreationTimestamp: "2026-04-16T00:05:00Z"},
 	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := &compute.ImageList{Items: images}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
+	srv := imageListServer(t, images)
 	defer srv.Close()
 
 	p := &Ubuntu{
-		computeService:  buildComputeService(t, srv),
-		versionProvider: &fakeVersionProvider{version: "v1.35.1"},
-		release:         "2404",
+		computeService: buildComputeService(t, srv),
+		release:        "2404",
 	}
 
-	// Pin to an older date than the latest image.
-	// Verifies the ubuntuVersionRe substitution replaces the -v<date> segment.
+	// Each architecture resolves to that exact catalog image, not the newest.
 	got, err := p.ResolveImages(context.Background(), "v20260416")
 	require.NoError(t, err)
 	require.Len(t, got, 2) // amd64, arm64
 
-	srcs := make([]string, len(got))
-	for i, img := range got {
-		srcs[i] = img.SourceImage
-	}
+	srcs := imageSources(got)
 	require.Contains(t, srcs, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2404-1-35-amd64-v20260416")
 	require.Contains(t, srcs, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2404-1-35-arm64-v20260416")
+}
+
+// A pinned date present for one architecture but absent for the other must fail resolution,
+// not return a single-arch set that reads as ImagesReady=True — the arm64 image is selected
+// from the catalog, never constructed by rewriting the amd64 date.
+func TestResolveImages_Ubuntu_PinnedVersion_MissingArm64_IsResolutionError(t *testing.T) {
+	images := []*compute.Image{
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260416", CreationTimestamp: "2026-04-16T00:00:00Z"},
+		// arm64 exists only at another date, so the pinned arm64 image is absent
+		{Name: "ubuntu-gke-2404-1-35-arm64-v20260420", CreationTimestamp: "2026-04-20T00:00:00Z"},
+	}
+	srv := imageListServer(t, images)
+	defer srv.Close()
+
+	p := &Ubuntu{
+		computeService: buildComputeService(t, srv),
+		release:        "2404",
+	}
+
+	_, err := p.ResolveImages(context.Background(), "v20260416")
+	require.Error(t, err)
+	require.True(t, IsImageResolutionError(err), "expected an imageResolutionError, got %v", err)
 }
 
 func TestResolveImages_Ubuntu_PinnedVersion_InvalidFormat(t *testing.T) {
@@ -170,9 +133,14 @@ func TestResolveImages_Ubuntu_PinnedVersion_InvalidFormat(t *testing.T) {
 	}
 }
 
+// TestIsUsableUbuntuImage asserts the 2404 amd64 predicate: it accepts a clean amd64 image
+// (including the -v<date>a letter suffix) and rejects deprecated images, the other arch, and
+// every variant build, whether the variant token is a trailing suffix (the real GCP form) or
+// an infix.
 func TestIsUsableUbuntuImage(t *testing.T) {
 	usable := []*compute.Image{
 		{Name: "ubuntu-gke-2404-1-35-amd64-v20260420"},
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20251218a"},
 		{Name: "ubuntu-gke-2404-1-35-amd64-v20260420", Deprecated: &compute.DeprecationStatus{State: ""}},
 	}
 	for _, img := range usable {
@@ -184,9 +152,14 @@ func TestIsUsableUbuntuImage(t *testing.T) {
 		{Name: "ubuntu-gke-2404-1-35-amd64-v20260420", Deprecated: &compute.DeprecationStatus{State: "OBSOLETE"}},
 		{Name: "ubuntu-gke-2404-1-35-amd64-v20260420", Deprecated: &compute.DeprecationStatus{State: "DELETED"}},
 		{Name: "ubuntu-gke-2404-1-35-arm64-v20260420"},
-		{Name: "ubuntu-gke-2404-1-35-amd64-v20260420-test"},
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260722-tpu"},
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260722-cgroupsv1"},
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260722-linux64k"},
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260722-test"},
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260722-devel"},
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260722-tpu-test"},
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260722-custom-test"},
 		{Name: "ubuntu-gke-2404-1-35-amd64-cgroupsv1-v20260420"},
-		{Name: "ubuntu-gke-2404-1-35-amd64-linux64k-v20260420"},
 		{Name: "ubuntu-gke-2404-1-35-amd64-tpu-v20260420"},
 	}
 	for _, img := range unusable {
@@ -194,12 +167,11 @@ func TestIsUsableUbuntuImage(t *testing.T) {
 	}
 }
 
-// Ubuntu 2204 tests
-
+// TestIsUsableUbuntu2204Image asserts the 2204 amd64 predicate, where amd64 names carry no arch token.
 func TestIsUsableUbuntu2204Image(t *testing.T) {
 	usable := []*compute.Image{
-		// 2204 amd64 images have no -amd64- suffix
 		{Name: "ubuntu-gke-2204-1-34-v20260420"},
+		{Name: "ubuntu-gke-2204-1-34-v20251218a"},
 		{Name: "ubuntu-gke-2204-1-34-v20260420", Deprecated: &compute.DeprecationStatus{State: ""}},
 	}
 	for _, img := range usable {
@@ -210,30 +182,151 @@ func TestIsUsableUbuntu2204Image(t *testing.T) {
 		{Name: "ubuntu-gke-2204-1-34-v20260420", Deprecated: &compute.DeprecationStatus{State: "DEPRECATED"}},
 		{Name: "ubuntu-gke-2204-1-34-v20260420", Deprecated: &compute.DeprecationStatus{State: "OBSOLETE"}},
 		{Name: "ubuntu-gke-2204-1-34-arm64-v20260420"},
-		{Name: "ubuntu-gke-2204-1-34-v20260420-test"},
-		{Name: "ubuntu-gke-2204-1-34-cgroupsv1-v20260420"},
-		{Name: "ubuntu-gke-2204-1-34-linux64k-v20260420"},
-		{Name: "ubuntu-gke-2204-1-34-tpu-v20260420"},
+		{Name: "ubuntu-gke-2204-1-34-v20260722-tpu"},
+		{Name: "ubuntu-gke-2204-1-34-v20260722-cgroupsv1"},
+		{Name: "ubuntu-gke-2204-1-34-v20260722-linux64k"},
+		{Name: "ubuntu-gke-2204-1-34-v20260722-test"},
+		{Name: "ubuntu-gke-2204-1-34-v20260722-devel"},
+		{Name: "ubuntu-gke-2204-1-34-v20260722-cgroupsv1-devel"},
 	}
 	for _, img := range unusable {
 		require.False(t, isUsableUbuntu2204Image(img), "expected %q to be unusable", img.Name)
 	}
 }
 
-func TestResolveImages_Ubuntu2204_DrivesArm64Variant(t *testing.T) {
-	p := &Ubuntu{release: "2204"}
-	sourceImage := "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2204-1-34-v20260420"
+// TestIsUsableUbuntuArm64Image covers the arm64 predicates added for independent arm64 resolution.
+func TestIsUsableUbuntuArm64Image(t *testing.T) {
+	require.True(t, isUsableUbuntuArm64Image(&compute.Image{Name: "ubuntu-gke-2404-1-35-arm64-v20260420"}))
+	require.True(t, isUsableUbuntuArm64Image(&compute.Image{Name: "ubuntu-gke-2404-1-35-arm64-v20251218a"}))
+	require.True(t, isUsableUbuntu2204Arm64Image(&compute.Image{Name: "ubuntu-gke-2204-1-34-arm64-v20260420"}))
 
-	imgs := p.resolveImages(sourceImage)
-	require.Len(t, imgs, 2)
-
-	var srcs []string
-	for _, img := range imgs {
-		srcs = append(srcs, img.SourceImage)
+	for _, img := range []*compute.Image{
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260420"},          // amd64, not arm64
+		{Name: "ubuntu-gke-2404-1-35-arm64-v20260722-linux64k"}, // variant
+		{Name: "ubuntu-gke-2404-1-35-arm64-v20260420", Deprecated: &compute.DeprecationStatus{State: "DEPRECATED"}},
+	} {
+		require.False(t, isUsableUbuntuArm64Image(img), "expected %q to be unusable", img.Name)
 	}
-	// 2204 arm64: insert -arm64- before the -v{date} suffix
-	require.Contains(t, srcs, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2204-1-34-v20260420")
-	require.Contains(t, srcs, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2204-1-34-arm64-v20260420")
+	require.False(t, isUsableUbuntu2204Arm64Image(&compute.Image{Name: "ubuntu-gke-2204-1-34-v20260420"}))
+}
+
+// Regression coverage for arm64 / trailing-variant-suffix resolution: each architecture is
+// resolved independently to a real image, and a missing architecture fails resolution.
+
+func imageListServer(t *testing.T, images []*compute.Image) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := &compute.ImageList{Items: images}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func imageSources(imgs Images) []string {
+	srcs := make([]string, len(imgs))
+	for i, img := range imgs {
+		srcs[i] = img.SourceImage
+	}
+	return srcs
+}
+
+func TestResolveImages_Ubuntu_SelectsLetterSuffixVersion(t *testing.T) {
+	images := []*compute.Image{
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20251218a", CreationTimestamp: "2025-12-18T02:00:00Z"},
+		{Name: "ubuntu-gke-2404-1-35-arm64-v20251218a", CreationTimestamp: "2025-12-18T02:05:00Z"},
+	}
+	srv := imageListServer(t, images)
+	defer srv.Close()
+
+	p := &Ubuntu{
+		computeService: buildComputeService(t, srv),
+		release:        "2404",
+	}
+
+	got, err := p.ResolveImages(context.Background(), "latest")
+	require.NoError(t, err)
+	srcs := imageSources(got)
+	require.Contains(t, srcs, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2404-1-35-amd64-v20251218a")
+	require.Contains(t, srcs, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2404-1-35-arm64-v20251218a")
+}
+
+// Core bug: when the newest amd64 image is a trailing -tpu variant, amd64 must resolve
+// to the newest real (non-variant) amd64 image, and arm64 must resolve to the real
+// -arm64- image — never a name derived from the amd64 pick.
+func TestResolveImages_Ubuntu_ResolvesRealArm64_WhenNewestAmd64IsTpuSuffix(t *testing.T) {
+	images := []*compute.Image{
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260722", CreationTimestamp: "2026-07-22T14:04:32Z"},
+		// newest amd64-named build, but a -tpu variant → must not be selected
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260722-tpu", CreationTimestamp: "2026-07-22T14:04:40Z"},
+		// real arm64 image, newest overall
+		{Name: "ubuntu-gke-2404-1-35-arm64-v20260722", CreationTimestamp: "2026-07-22T14:05:00Z"},
+	}
+	srv := imageListServer(t, images)
+	defer srv.Close()
+
+	p := &Ubuntu{
+		computeService: buildComputeService(t, srv),
+		release:        "2404",
+	}
+
+	got, err := p.ResolveImages(context.Background(), "latest")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	srcs := imageSources(got)
+	require.Contains(t, srcs, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2404-1-35-amd64-v20260722")
+	require.Contains(t, srcs, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2404-1-35-arm64-v20260722")
+	for _, s := range srcs {
+		require.NotContains(t, s, "-tpu", "no variant image should be selected, got %q", s)
+	}
+}
+
+// Honest readiness: if no usable arm64 image exists for the family, resolution fails
+// rather than returning an amd64-only set (which would read as ImagesReady=True).
+func TestResolveImages_Ubuntu_MissingArm64_IsResolutionError(t *testing.T) {
+	images := []*compute.Image{
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260722", CreationTimestamp: "2026-07-22T14:04:32Z"},
+		{Name: "ubuntu-gke-2404-1-35-amd64-v20260722-tpu", CreationTimestamp: "2026-07-22T14:04:40Z"},
+		// no arm64 image present
+	}
+	srv := imageListServer(t, images)
+	defer srv.Close()
+
+	p := &Ubuntu{
+		computeService: buildComputeService(t, srv),
+		release:        "2404",
+	}
+
+	_, err := p.ResolveImages(context.Background(), "latest")
+	require.Error(t, err)
+	require.True(t, IsImageResolutionError(err), "expected an imageResolutionError, got %v", err)
+}
+
+// 2204 equivalent: amd64 has no -amd64- token; arm64 is a distinct -arm64- image.
+func TestResolveImages_Ubuntu2204_ResolvesRealArm64_WhenNewestAmd64IsTpuSuffix(t *testing.T) {
+	images := []*compute.Image{
+		{Name: "ubuntu-gke-2204-1-34-v20260722", CreationTimestamp: "2026-07-22T14:04:32Z"},
+		{Name: "ubuntu-gke-2204-1-34-v20260722-tpu", CreationTimestamp: "2026-07-22T14:04:40Z"},
+		{Name: "ubuntu-gke-2204-1-34-arm64-v20260722", CreationTimestamp: "2026-07-22T14:05:00Z"},
+	}
+	srv := imageListServer(t, images)
+	defer srv.Close()
+
+	p := &Ubuntu{
+		computeService: buildComputeService(t, srv),
+		release:        "2204",
+	}
+
+	got, err := p.ResolveImages(context.Background(), "latest")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	srcs := imageSources(got)
+	require.Contains(t, srcs, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2204-1-34-v20260722")
+	require.Contains(t, srcs, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2204-1-34-arm64-v20260722")
+	for _, s := range srcs {
+		require.NotContains(t, s, "-tpu", "no variant image should be selected, got %q", s)
+	}
 }
 
 func TestBuildImageFilter_Ubuntu2204_UsesVersionPrefix(t *testing.T) {
@@ -248,28 +341,16 @@ func TestBuildImageFilter_Ubuntu2204_FallsBackOnNilProvider(t *testing.T) {
 	require.Equal(t, `name=ubuntu-gke-2204*`, got)
 }
 
-func TestResolveLatestUbuntu2204Image_PicksAmd64NotArm64(t *testing.T) {
+func TestSelectImage_Ubuntu2204_PicksAmd64NotArm64(t *testing.T) {
 	images := []*compute.Image{
-		// arm64 — must be excluded
+		// arm64 — different architecture, must not be selected for amd64
 		{Name: "ubuntu-gke-2204-1-34-arm64-v20260420", CreationTimestamp: "2026-04-20T00:00:00Z"},
-		// valid amd64 (no -amd64- suffix in 2204)
+		// valid amd64 (no arch token in 2204)
 		{Name: "ubuntu-gke-2204-1-34-v20260401", CreationTimestamp: "2026-04-01T00:00:00Z"},
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := &compute.ImageList{Items: images}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer srv.Close()
-
-	p := &Ubuntu{
-		computeService:  buildComputeService(t, srv),
-		versionProvider: &fakeVersionProvider{version: "v1.34.7"},
-		release:         "2204",
-	}
-
-	got, err := p.resolveLatestUbuntuImage(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, "projects/ubuntu-os-gke-cloud/global/images/ubuntu-gke-2204-1-34-v20260401", got)
+	p := &Ubuntu{release: "2204"}
+	got, ok := p.selectImage(images, OSArchAMD64Requirement, "latest")
+	require.True(t, ok)
+	require.Equal(t, "ubuntu-gke-2204-1-34-v20260401", got)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes broken arm64 provisioning for `Ubuntu` `GCENodeClass` (#535).

Ubuntu resolution derived the arm64 image from the newest amd64 pick via `-amd64-`→`-arm64-` substitution. GKE publishes variant builds (`-tpu`, `-cgroupsv1`, …) as a trailing suffix after the version, which the substring denylist missed — so a `…-amd64-v<date>-tpu` build was selected and the derived `…-arm64-v<date>-tpu` name didn't exist. It was dropped with no fallback, leaving an amd64-only set that still reported `ImagesReady=True`; arm64 nodes then failed with `no target image found`.

This PR resolves each architecture independently from the catalog (no cross-arch derivation), gates selection on a strict per-release allowlist that rejects variant builds while keeping the real `v<date>a` letter-suffix builds, and reports `ImagesReady=False` when an expected architecture has no usable image.

#### Related proposal (if applicable):

N/A

#### Which issue(s) this PR fixes:

Fixes #535

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Release note (gitautomator asked for one)

```release-note
fix(imagefamily): Ubuntu arm64 node pools now resolve the correct image. Each architecture is resolved independently from the image catalog and variant builds (e.g. -tpu) are rejected, so arm64 provisioning no longer breaks when the newest amd64 build is a variant. A GCENodeClass now reports ImagesReady=False when a requested architecture's image is missing (including a pinned date present for only one arch) instead of silently resolving amd64-only.
```

#### Special notes for your reviewer:

- Based on fetching real `ubuntu-os-gke-cloud` catalog data.
- Behavior change: a genuinely arm64-less class now fails resolution (visible) instead of resolving amd64-only. No new API/condition.
- Scope: `Ubuntu2404`/`Ubuntu2204` only; `ContainerOptimizedOS`
- Verified locally: `golangci-lint` v2.12.2 (0 issues), `go test -race ./pkg/...`, `deadcode`, `docs-lint`, `chart-lint`, `verify-crds`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a broken arm64 image resolution path in the `Ubuntu` image family by replacing cross-architecture name derivation (amd64→arm64 string substitution) with independent per-arch catalog lookups guarded by strict allowlist regexes. It also ensures `ImagesReady=False` is reported when an expected architecture has no usable image, and updates the troubleshooting docs to document this behavior.

- **Independent resolution**: `selectImage` is now called once per architecture with per-release, per-arch allowlist regexes (`ubuntu2404AMD64Re`, `ubuntu2404ARM64Re`, etc.) that anchor on the version tail, rejecting trailing variant suffixes (`-tpu`, `-cgroupsv1`, `-linux64k`) while still accepting release-letter builds (`v20251218a`).
- **Honest failure mode**: `ResolveImages` returns an `imageResolutionError` immediately if any required architecture has no matching catalog image, preventing a single-arch set from being returned as `ImagesReady=True`.
- **Test coverage**: New unit tests cover the core regression scenario (newest amd64 is a `-tpu` variant), variant exclusion, letter-suffix acceptance, pinned-date resolution, and the missing-arm64 failure path for both 2404 and 2204 families.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is tightly scoped to Ubuntu image resolution, each code path is validated by the new test suite, and the behavior change (failing loudly when arm64 is missing) is strictly an improvement over silent amd64-only fallback.

All three files are clean. The core rewrite replaces a provably broken cross-arch substitution with independent per-arch catalog selection that is fully exercised by the new tests. No unaddressed logic errors or contract violations were found in the changed code.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/providers/imagefamily/ubuntu.go | Complete rewrite of Ubuntu image resolution: drops cross-arch name derivation in favour of independent per-arch catalog selection via strict allowlist regexes; correctly fails when any architecture is missing from the catalog. |
| pkg/providers/imagefamily/ubuntu_test.go | New comprehensive test suite covering variant exclusion, independent arm64 resolution, letter-suffix images, pinned-date resolution for both architectures, and honest failure when arm64 is absent; no issues found. |
| docs/troubleshooting.md | Adds a clear explanation of independent per-arch resolution, variant exclusion, and the ImagesReady=False behavior for the Ubuntu families, with a runnable gcloud command for diagnosis. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ResolveImages called\nversion = 'latest' or 'vYYYYMMDD'] --> B{Validate version format}
    B -- invalid --> C[return imageResolutionError]
    B -- valid --> D[listImages\nGCP API call with K8s-version prefix filter]
    D -- error --> E[return error]
    D -- ok --> F[For each arch: amd64, arm64]
    F --> G[selectImage\narch, version]
    G --> H{isUsableForArch\nallowlist regex match\n+ not deprecated}
    H -- no --> I[skip image]
    H -- yes --> J{version == 'latest'?}
    J -- no --> K{HasSuffix name\n'-'+version?}
    K -- no --> I
    K -- yes --> L[candidate]
    J -- yes --> L
    L --> M{newer than current best?}
    M -- yes --> N[update best]
    M -- no --> O[keep best]
    N --> P{more images?}
    O --> P
    I --> P
    P -- yes --> H
    P -- no --> Q{best == nil?}
    Q -- yes --> R[return imageResolutionError\narch missing]
    Q -- no --> S[append Image with SourceImage\n+ arch requirements]
    S --> T{more archs?}
    T -- yes --> F
    T -- no --> U[return Images amd64 + arm64]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(imagefamily): resolve Ubuntu arm64 i..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/8cbe6dbcdef0e3ed16f95e08790002dd60f0cabf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46504547)</sub>

<!-- /greptile_comment -->