### PR TITLE
chore: modernize Go code per gopls modernize analyzer

### DIFF
--- a/pkg/apis/v1alpha1/gcenodeclass.go
+++ b/pkg/apis/v1alpha1/gcenodeclass.go
@@ -387,7 +387,7 @@ const (
 )
 
 func (in *GCENodeClass) Hash() string {
-	return fmt.Sprint(lo.Must(hashstructure.Hash([]interface{}{
+	return fmt.Sprint(lo.Must(hashstructure.Hash([]any{
 		in.Spec,
 		in.ImageFamily(),
 	}, hashstructure.FormatV2, &hashstructure.HashOptions{

--- a/pkg/metadata/compute_metadata.go
+++ b/pkg/metadata/compute_metadata.go
@@ -160,12 +160,8 @@ func (m *InstanceMetadata) ToComputeMetadata() (*compute.Metadata, error) {
 		return toComputeMetadata(metadataValues{}), nil
 	}
 	values := metadataValues{}
-	for key, value := range m.sourceMetadata {
-		values[key] = value
-	}
-	for key, value := range m.customMetadata {
-		values[key] = value
-	}
+	maps.Copy(values, m.sourceMetadata)
+	maps.Copy(values, m.customMetadata)
 	values[KubeEnvKey] = m.kubeEnv.String()
 	values[KubeLabelsKey] = m.kubeLabels.String()
 	rawKubeletConfig, err := yaml.Marshal(m.kubeletConfig)
@@ -184,9 +180,7 @@ func (m *InstanceMetadata) ToComputeInstanceLabels() map[string]string {
 	if m == nil {
 		return labels
 	}
-	for key, value := range m.instanceLabels {
-		labels[key] = value
-	}
+	maps.Copy(labels, m.instanceLabels)
 	return labels
 }
 

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -23,6 +23,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"math/big"
 	"sort"
@@ -192,8 +193,7 @@ func (p *DefaultProvider) handleZoneOperationError(ctx context.Context, op *comp
 }
 
 func isTransientError(err error) bool {
-	var apiErr *googleapi.Error
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := errors.AsType[*googleapi.Error](err); ok {
 		return apiErr.Code >= 500
 	}
 	return false
@@ -315,8 +315,7 @@ func (p *DefaultProvider) Create(ctx context.Context, nodeClass *v1alpha1.GCENod
 	for _, instanceType := range instanceTypes {
 		instance, zone, err := p.tryCreateInstance(ctx, nodeClass, nodeClaim, instanceType, capacityType)
 		if err != nil {
-			var retryableErr *retryableError
-			if errors.As(err, &retryableErr) {
+			if retryableErr, ok := errors.AsType[*retryableError](err); ok {
 				errs = append(errs, retryableErr.err)
 				continue
 			}
@@ -1052,9 +1051,7 @@ func setupScheduling(capacityType string) *compute.Scheduling {
 // be inherited by the provisioned instance.
 func initializeInstanceLabels(nodeClass *v1alpha1.GCENodeClass) map[string]string {
 	labels := make(map[string]string)
-	for k, v := range nodeClass.Spec.Labels {
-		labels[k] = v
-	}
+	maps.Copy(labels, nodeClass.Spec.Labels)
 	return labels
 }
 
@@ -1291,9 +1288,7 @@ func (p *DefaultProvider) CreateTags(ctx context.Context, providerID string, tag
 	if newLabels == nil {
 		newLabels = make(map[string]string)
 	}
-	for k, v := range tags {
-		newLabels[k] = v
-	}
+	maps.Copy(newLabels, tags)
 
 	req := &compute.InstancesSetLabelsRequest{
 		Labels:           newLabels,
@@ -1332,8 +1327,7 @@ func parseGCEProviderID(providerID string) (project, zone, instance string, err 
 }
 
 func isInstanceNotFoundError(err error) bool {
-	var apiErr *googleapi.Error
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := errors.AsType[*googleapi.Error](err); ok {
 		return apiErr.Code == 404
 	}
 	return false

--- a/pkg/providers/instance/metadata_bootstrap.go
+++ b/pkg/providers/instance/metadata_bootstrap.go
@@ -18,6 +18,7 @@ package instance
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 	"time"
 
@@ -139,7 +140,5 @@ func mergeStringMap(target *map[string]string, values map[string]string) {
 	if *target == nil {
 		*target = map[string]string{}
 	}
-	for key, value := range values {
-		(*target)[key] = value
-	}
+	maps.Copy(*target, values)
 }

--- a/pkg/providers/offerings/unavailableofferings/cache.go
+++ b/pkg/providers/offerings/unavailableofferings/cache.go
@@ -46,7 +46,7 @@ type UnavailableOfferings struct {
 
 func NewUnavailableOfferingsWithCache(c *cache.Cache) *UnavailableOfferings {
 	uo := &UnavailableOfferings{cache: c}
-	uo.cache.OnEvicted(func(_ string, _ interface{}) {
+	uo.cache.OnEvicted(func(_ string, _ any) {
 		atomic.AddUint64(&uo.seqNum, 1)
 	})
 	return uo

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -178,13 +178,7 @@ func ResolveReservedEphemeralStorage(bootDiskGiB, totalSSDGiB, localSSDCount int
 	option2 := int64(math.Round(float64(bootDiskGiB)*0.35 + 6))
 	option3 := int64(100)
 
-	systemReservation = option1
-	if option2 < systemReservation {
-		systemReservation = option2
-	}
-	if option3 < systemReservation {
-		systemReservation = option3
-	}
+	systemReservation = min(option1, option2, option3)
 
 	return evictionThreshold, systemReservation
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Additional labels (applied directly, not via /kind):
  dependencies  — dependency update PRs
  release-prep  — release preparation PRs (see RELEASE.md)
-->

#### What this PR does / why we need it:

- Replace errors.As with errors.AsType[T] (Go 1.26)
- Replace m[k]=v copy loops with maps.Copy
- Replace if-chain with min() builtin
- Replace interface{} with any

Generated files (zz_generated.deepcopy.go) and debatable ptr.To/lo.ToPtr -> new(T) suggestions are intentionally skipped.

#### Related proposal (if applicable):
<!--
Link the proposal this PR implements, e.g. proposals/0001-short-title.md
Leave blank if this PR does not correspond to a design proposal.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
n/a

#### Docs and examples

- [ ] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [ ] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

AI-assisted change; reviewed and validated by the author.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Mechanical Go modernization with no behavioral changes identified:
- Replaces `interface{}` with `any`.
- Replaces map-copy loops with `maps.Copy`.
- Replaces typed `errors.As` calls with `errors.AsType`.
- Replaces sequential minimum comparisons with the `min` builtin.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/apis/v1alpha1/gcenodeclass.go | Modernizes an empty-interface slice to `[]any` without changing NodeClass hash inputs. |
| pkg/metadata/compute_metadata.go | Replaces map-copy loops with equivalent `maps.Copy` calls while preserving fresh output-map ownership. |
| pkg/providers/instance/instance.go | Modernizes typed error matching and label copying without changing lifecycle, retry, or tag behavior. |
| pkg/providers/instance/metadata_bootstrap.go | Uses `maps.Copy` after retaining the existing nil-target initialization. |
| pkg/providers/offerings/unavailableofferings/cache.go | Replaces the eviction callback's empty-interface parameter with the equivalent `any` alias. |
| pkg/utils/utils.go | Uses the `min` builtin to preserve the existing minimum-of-three reservation calculation. |

</details>

<sub>Reviews (5): Last reviewed commit: ["chore: modernize Go code per gopls moder..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/7fd2cad3e1cd66d947e93e50c681db8f479e8582) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47384986)</sub>

<!-- /greptile_comment -->