### PR TITLE
Support kubelet serializeImagePulls/maxParallelImagePulls on GCENodeClass

### DIFF
--- a/charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -385,6 +385,16 @@ spec:
                       rule: self.all(x, !self[x].startsWith('-'))
                     - message: kubeReserved values must be a resource.Quantity
                       rule: self.all(x, self[x].matches('^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$'))
+                  maxParallelImagePulls:
+                    description: |-
+                      MaxParallelImagePulls sets the maximum number of image pulls in parallel.
+                      Requires SerializeImagePulls to be explicitly set to false. Nodes with many
+                      DaemonSets pulling cold images concurrently (a common case right after a
+                      fresh node joins the cluster) benefit most from raising this above the
+                      kubelet default of 1.
+                    format: int32
+                    minimum: 2
+                    type: integer
                   maxPods:
                     description: |-
                       MaxPods is an override for the maximum number of pods that can run on
@@ -400,6 +410,12 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                  serializeImagePulls:
+                    description: |-
+                      SerializeImagePulls, when enabled, tells the kubelet to pull images one at a
+                      time. Must be explicitly set to false to use MaxParallelImagePulls.
+                      Default: true
+                    type: boolean
                   systemReserved:
                     additionalProperties:
                       description: KubeletQuantity is a bounded kubelet resource quantity
@@ -431,6 +447,10 @@ spec:
                     evictionSoft
                   rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e,
                     (e in self.evictionSoft)):true
+                - message: maxParallelImagePulls requires serializeImagePulls to be
+                    explicitly set to false
+                  rule: '!has(self.maxParallelImagePulls) || (has(self.serializeImagePulls)
+                    && self.serializeImagePulls == false)'
               labels:
                 additionalProperties:
                   type: string

--- a/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
+++ b/charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml
@@ -382,6 +382,16 @@ spec:
                       rule: self.all(x, !self[x].startsWith('-'))
                     - message: kubeReserved values must be a resource.Quantity
                       rule: self.all(x, self[x].matches('^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$'))
+                  maxParallelImagePulls:
+                    description: |-
+                      MaxParallelImagePulls sets the maximum number of image pulls in parallel.
+                      Requires SerializeImagePulls to be explicitly set to false. Nodes with many
+                      DaemonSets pulling cold images concurrently (a common case right after a
+                      fresh node joins the cluster) benefit most from raising this above the
+                      kubelet default of 1.
+                    format: int32
+                    minimum: 2
+                    type: integer
                   maxPods:
                     description: |-
                       MaxPods is an override for the maximum number of pods that can run on
@@ -397,6 +407,12 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                  serializeImagePulls:
+                    description: |-
+                      SerializeImagePulls, when enabled, tells the kubelet to pull images one at a
+                      time. Must be explicitly set to false to use MaxParallelImagePulls.
+                      Default: true
+                    type: boolean
                   systemReserved:
                     additionalProperties:
                       description: KubeletQuantity is a bounded kubelet resource quantity
@@ -428,6 +444,10 @@ spec:
                     evictionSoft
                   rule: has(self.evictionSoftGracePeriod) ? self.evictionSoftGracePeriod.all(e,
                     (e in self.evictionSoft)):true
+                - message: maxParallelImagePulls requires serializeImagePulls to be
+                    explicitly set to false
+                  rule: '!has(self.maxParallelImagePulls) || (has(self.serializeImagePulls)
+                    && self.serializeImagePulls == false)'
               labels:
                 additionalProperties:
                   type: string

--- a/docs/reference/gcenodeclass.md
+++ b/docs/reference/gcenodeclass.md
@@ -202,6 +202,8 @@ _Appears in:_
 | `imageGCHighThresholdPercent` _integer_ | ImageGCHighThresholdPercent is the percent of disk usage after which image<br />garbage collection is always run. The percent is calculated by dividing this<br />field value by 100, so this field must be between 0 and 100, inclusive.<br />When specified, the value must be greater than ImageGCLowThresholdPercent. |  | Maximum: 100 <br />Minimum: 0 <br />Optional: \{\} <br /> |
 | `imageGCLowThresholdPercent` _integer_ | ImageGCLowThresholdPercent is the percent of disk usage before which image<br />garbage collection is never run. Lowest disk usage to garbage collect to.<br />The percent is calculated by dividing this field value by 100,<br />so the field value must be between 0 and 100, inclusive.<br />When specified, the value must be less than imageGCHighThresholdPercent |  | Maximum: 100 <br />Minimum: 0 <br />Optional: \{\} <br /> |
 | `cpuCFSQuota` _boolean_ | CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits. |  | Optional: \{\} <br /> |
+| `serializeImagePulls` _boolean_ | SerializeImagePulls, when enabled, tells the kubelet to pull images one at a<br />time. Must be explicitly set to false to use MaxParallelImagePulls.<br />Default: true |  | Optional: \{\} <br /> |
+| `maxParallelImagePulls` _integer_ | MaxParallelImagePulls sets the maximum number of image pulls in parallel.<br />Requires SerializeImagePulls to be explicitly set to false. Nodes with many<br />DaemonSets pulling cold images concurrently (a common case right after a<br />fresh node joins the cluster) benefit most from raising this above the<br />kubelet default of 1. |  | Minimum: 2 <br />Optional: \{\} <br /> |
 
 
 #### KubeletQuantity

--- a/pkg/apis/v1alpha1/gcenodeclass.go
+++ b/pkg/apis/v1alpha1/gcenodeclass.go
@@ -217,6 +217,7 @@ type KubeletQuantity string
 // Wherever possible, the types and names should reflect the upstream kubelet types.
 // https://pkg.go.dev/k8s.io/kubelet/config/v1beta1#KubeletConfiguration
 // https://github.com/kubernetes/kubernetes/blob/9f82d81e55cafdedab619ea25cabf5d42736dacf/cmd/kubelet/app/options/options.go#L53
+// +kubebuilder:validation:XValidation:message="maxParallelImagePulls requires serializeImagePulls to be explicitly set to false",rule="!has(self.maxParallelImagePulls) || (has(self.serializeImagePulls) && self.serializeImagePulls == false)"
 type KubeletConfiguration struct {
 	// clusterDNS is a list of IP addresses for the cluster DNS server.
 	// Note that not all providers may use all addresses.
@@ -288,6 +289,19 @@ type KubeletConfiguration struct {
 	// CPUCFSQuota enables CPU CFS quota enforcement for containers that specify CPU limits.
 	// +optional
 	CPUCFSQuota *bool `json:"cpuCFSQuota,omitempty"`
+	// SerializeImagePulls, when enabled, tells the kubelet to pull images one at a
+	// time. Must be explicitly set to false to use MaxParallelImagePulls.
+	// Default: true
+	// +optional
+	SerializeImagePulls *bool `json:"serializeImagePulls,omitempty"`
+	// MaxParallelImagePulls sets the maximum number of image pulls in parallel.
+	// Requires SerializeImagePulls to be explicitly set to false. Nodes with many
+	// DaemonSets pulling cold images concurrently (a common case right after a
+	// fresh node joins the cluster) benefit most from raising this above the
+	// kubelet default of 1.
+	// +kubebuilder:validation:Minimum:=2
+	// +optional
+	MaxParallelImagePulls *int32 `json:"maxParallelImagePulls,omitempty"`
 }
 
 // +kubebuilder:validation:XValidation:message="provisionedIOPS is only applicable for pd-extreme, hyperdisk-balanced, hyperdisk-balanced-high-availability, and hyperdisk-extreme",rule="!has(self.provisionedIOPS) || self.category in ['pd-extreme', 'hyperdisk-balanced', 'hyperdisk-balanced-high-availability', 'hyperdisk-extreme']"

--- a/pkg/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/v1alpha1/zz_generated.deepcopy.go
@@ -366,6 +366,16 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SerializeImagePulls != nil {
+		in, out := &in.SerializeImagePulls, &out.SerializeImagePulls
+		*out = new(bool)
+		**out = **in
+	}
+	if in.MaxParallelImagePulls != nil {
+		in, out := &in.MaxParallelImagePulls, &out.MaxParallelImagePulls
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/providers/instance/metadata_bootstrap.go
+++ b/pkg/providers/instance/metadata_bootstrap.go
@@ -109,6 +109,12 @@ func applyNodeClassKubeletConfig(config *kubeletconfig.KubeletConfiguration, ove
 	if overlay.CPUCFSQuota != nil {
 		config.CPUCFSQuota = overlay.CPUCFSQuota
 	}
+	if overlay.SerializeImagePulls != nil {
+		config.SerializeImagePulls = overlay.SerializeImagePulls
+	}
+	if overlay.MaxParallelImagePulls != nil {
+		config.MaxParallelImagePulls = overlay.MaxParallelImagePulls
+	}
 }
 
 func mergeKubeletQuantityMap(target *map[string]string, overlay map[string]v1alpha1.KubeletQuantity) {

--- a/pkg/providers/instance/metadata_bootstrap_test.go
+++ b/pkg/providers/instance/metadata_bootstrap_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	kubeletconfig "k8s.io/kubelet/config/v1beta1"
+
+	"github.com/cloudpilot-ai/karpenter-provider-gcp/pkg/apis/v1alpha1"
+)
+
+func TestApplyNodeClassKubeletConfigSetsImagePullParallelism(t *testing.T) {
+	config := &kubeletconfig.KubeletConfiguration{}
+	serialize := false
+	maxParallel := int32(4)
+	overlay := &v1alpha1.KubeletConfiguration{
+		SerializeImagePulls:   &serialize,
+		MaxParallelImagePulls: &maxParallel,
+	}
+
+	applyNodeClassKubeletConfig(config, overlay)
+
+	require.NotNil(t, config.SerializeImagePulls)
+	require.False(t, *config.SerializeImagePulls)
+	require.NotNil(t, config.MaxParallelImagePulls)
+	require.Equal(t, int32(4), *config.MaxParallelImagePulls)
+}
+
+func TestApplyNodeClassKubeletConfigLeavesImagePullParallelismUnsetWhenOverlayOmitsIt(t *testing.T) {
+	config := &kubeletconfig.KubeletConfiguration{}
+	maxPods := int32(64)
+	overlay := &v1alpha1.KubeletConfiguration{MaxPods: &maxPods}
+
+	applyNodeClassKubeletConfig(config, overlay)
+
+	require.Nil(t, config.SerializeImagePulls)
+	require.Nil(t, config.MaxParallelImagePulls)
+	require.Equal(t, int32(64), config.MaxPods)
+}


### PR DESCRIPTION
## Summary
- Adds `serializeImagePulls` and `maxParallelImagePulls` to `GCENodeClass.spec.kubeletConfiguration`, mirroring GKE's `NodeKubeletConfig.max_parallel_image_pulls` (available on standard GKE-managed node pools) which was not yet exposed through Karpenter's overlay.
- Field names/semantics match upstream `k8s.io/kubelet/config/v1beta1.KubeletConfiguration` exactly, per this file's existing convention, so no further plumbing is needed beyond the merge in `applyNodeClassKubeletConfig` — the value is JSON-marshaled straight into the `kubelet-config` bootstrap metadata.
- Adds a CEL validation rule enforcing the same constraint upstream documents on the field: `maxParallelImagePulls` requires `serializeImagePulls` to be explicitly set to `false` (kubelet defaults `serializeImagePulls` to `true`).

## Motivation
Kubelet serializes image pulls one at a time per node by default. On a freshly provisioned node this means every DaemonSet pod (CNI, logging, CSI drivers, metrics, etc.) queues behind a single pull at a time even though each individual pull is fast — we observed nodes taking 5-8 minutes to become fully useful purely from this queuing, not from slow downloads. This is especially costly on nodes that churn frequently (spot preemption, consolidation), since the multi-minute bootstrap window recurs on every replacement. GKE already supports raising this via `NodeKubeletConfig`, but that wasn't reachable from `GCENodeClass`.

## Testing
- `go build ./...`
- `go test -race ./pkg/... -cover`
- `make verify-crds`
- `make chart-lint`
- `make verify-deadcode`
- `make docs-lint`
- `make update` run twice to confirm generated CRD/deepcopy/docs are stable (no further diff on re-run)
- Added `pkg/providers/instance/metadata_bootstrap_test.go` covering the new merge behavior (fields copied when set, left untouched when overlay omits them)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable kubelet image-pull serialization and parallelism settings to GCENodeClass.
  * `maxParallelImagePulls` supports values of 2 or higher.
  * Parallel image pulls require serialized image pulls to be explicitly disabled.
* **Documentation**
  * Updated GCENodeClass reference documentation with the new settings and validation requirements.
* **Bug Fixes**
  * Node configuration now correctly applies the selected image-pull settings during instance setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR exposes kubelet image-pull concurrency controls through GCENodeClass and carries them into generated bootstrap metadata.
- Adds `serializeImagePulls` and `maxParallelImagePulls` to the API, generated CRDs, deepcopy implementation, and reference documentation.
- Enforces that a parallel-pull limit requires image-pull serialization to be explicitly disabled.
- Extends the instance-provider overlay and tests its set and omitted-field behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pkg/apis/v1alpha1/gcenodeclass.go | Adds correctly typed kubelet image-pull fields and their cross-field admission validation. |
| pkg/providers/instance/metadata_bootstrap.go | Applies the new NodeClass pointers to the upstream kubelet configuration within the correct provider-policy boundary. |
| pkg/providers/instance/metadata_bootstrap_test.go | Covers propagation of configured values and preservation of unset values. |
| pkg/apis/v1alpha1/zz_generated.deepcopy.go | Correctly deep-copies both newly added pointer fields. |
| charts/karpenter/crds/karpenter.k8s.gcp_gcenodeclasses.yaml | Publishes the new schema fields, minimum constraint, and CEL validation in the application chart. |
| charts/karpenter-crd/templates/karpenter.k8s.gcp_gcenodeclasses.yaml | Keeps the standalone CRD chart synchronized with the application chart. |
| docs/reference/gcenodeclass.md | Documents both new kubelet configuration fields and their relationship. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  NC[GCENodeClass kubeletConfiguration] --> V[CRD CEL validation]
  V --> O[Instance provider overlay]
  O --> K[Upstream KubeletConfiguration]
  K --> M[kubelet-config bootstrap metadata]
  M --> N[Provisioned node kubelet]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Add serializeImagePulls/maxParallelImage..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/aa242495be8d59e651140cf5f7fa40ea7077c8df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51981989)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [GCENodeClass API Types](https://app.greptile.com/karpenter-provider-gcp/-/custom-context/knowledge-base/cloudpilot-ai/karpenter-provider-gcp/-/docs/gcenodeclass-api.md)
- Knowledge Base — [Instance Provider](https://app.greptile.com/karpenter-provider-gcp/-/custom-context/knowledge-base/cloudpilot-ai/karpenter-provider-gcp/-/docs/instance-provider.md)
- Knowledge Base — [Helm Deployment and CRD Packaging](https://app.greptile.com/karpenter-provider-gcp/-/custom-context/knowledge-base/cloudpilot-ai/karpenter-provider-gcp/-/docs/helm-crd-packaging.md)
</details>

<!-- /greptile_comment -->