### PR TITLE
Document kubelet serializeImagePulls/maxParallelImagePulls on GCENodeClass

### DIFF
--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -129,6 +129,19 @@ kubeletConfiguration:
 - `cpuCFSQuota` — enable or disable CPU CFS quota enforcement for containers with CPU limits
 - `imageGCHighThresholdPercent` / `imageGCLowThresholdPercent` — control when kubelet garbage-collects unused container images
 
+By default, kubelet pulls container images one at a time per node. This serializes every DaemonSet image (CNI, logging, CSI, metrics) on freshly provisioned nodes and adds bootstrap latency. Setting `serializeImagePulls: false` together with `maxParallelImagePulls` parallelizes pulls to reduce that latency, mirroring GKE's [`NodeKubeletConfig.maxParallelImagePulls`](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/NodeKubeletConfig).
+
+```yaml
+kubeletConfiguration:
+  serializeImagePulls: false
+  maxParallelImagePulls: 4
+```
+
+- `serializeImagePulls` — controls whether kubelet pulls images one at a time; defaults to `true` (serialized) and must be set to `false` explicitly to allow parallel pulls
+- `maxParallelImagePulls` — maximum number of image pulls kubelet performs in parallel; minimum accepted value is `2`
+
+> **Note:** `maxParallelImagePulls` is rejected unless `serializeImagePulls` is explicitly set to `false`, failing admission with `maxParallelImagePulls requires serializeImagePulls to be explicitly set to false`. Omitting both fields preserves the default serialized behavior.
+
 ## Shielded VM
 
 Shielded VM provides verifiable integrity for your instances, protecting against boot-level and kernel-level malware. GCP organizations that enforce `constraints/compute.requireShieldedVm` require these settings on all instances. Without them, Karpenter-provisioned nodes fail with a `412 conditionNotMet` error.

--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -137,10 +137,10 @@ kubeletConfiguration:
   maxParallelImagePulls: 4
 ```
 
-- `serializeImagePulls` — controls whether kubelet pulls images one at a time; defaults to `true` (serialized) and must be set to `false` explicitly to allow parallel pulls
-- `maxParallelImagePulls` — maximum number of image pulls kubelet performs in parallel; minimum accepted value is `2`
+- `serializeImagePulls` — controls whether kubelet pulls images one at a time; defaults to `true` (serialized)
+- `maxParallelImagePulls` — maximum number of image pulls kubelet performs in parallel; the minimum is `1` (the kubelet default)
 
-> **Note:** `maxParallelImagePulls` is rejected unless `serializeImagePulls` is explicitly set to `false`, failing admission with `maxParallelImagePulls requires serializeImagePulls to be explicitly set to false`. Omitting both fields preserves the default serialized behavior.
+> **Note:** Setting `maxParallelImagePulls` to `2` or greater requires `serializeImagePulls: false`; admission otherwise fails with `maxParallelImagePulls greater than 1 requires serializeImagePulls to be explicitly set to false`. `maxParallelImagePulls: 1` on its own is accepted without any `serializeImagePulls` change, and omitting both fields preserves the default serialized behavior.
 
 ## Shielded VM
 


### PR DESCRIPTION
[Open in Promptless](<https://app.gopromptless.ai/suggestions/ebdf6e5e-c212-432e-871f-9f0e18b0920f>)

Kubelet serializes container image pulls one at a time per node by default, which queues every DaemonSet image (CNI, logging, CSI, metrics) behind a single pull on freshly provisioned nodes and adds bootstrap latency. GCENodeClass now exposes two kubelet fields — `serializeImagePulls` and `maxParallelImagePulls` — so operators can parallelize image pulls and cut that startup delay.

This documents both fields in the "Custom kubelet settings" → "Other settings" section of the advanced examples page: an example manifest, per-field descriptions, and the cross-field validation rule. Following PR #565, `maxParallelImagePulls` accepts a minimum of `1` (the kubelet default), and `serializeImagePulls: false` is required only for values of `2` or greater — the note quotes the exact admission error for that case.

Files touched: docs/examples/advanced.md

**Trigger Events**
- [GitHub PR #554: Support kubelet serializeImagePulls/maxParallelImagePulls on GCENodeClass](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/554)
- [GitHub PR #565: Allow maxParallelImagePulls of 1 on GCENodeClass](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/565)



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents the newly supported kubelet image-pull concurrency settings for `GCENodeClass`.
- Adds an example using `serializeImagePulls` and `maxParallelImagePulls`.
- Explains defaults, minimum values, and the cross-field admission rule.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/examples/advanced.md | Adds focused documentation and a valid example for configuring parallel kubelet image pulls. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: update maxParallelImagePulls valid..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/7650a679a98850f4fa4547bccfbd6476f736d20c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55434028)</sub>

<!-- /greptile_comment -->