### PR TITLE
Correct CapacityBuffer CRD installation behavior in settings reference

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -25,7 +25,12 @@ controller:
 
 ### CapacityBuffer (Alpha)
 
-`CapacityBuffer` is an Alpha feature that pre-provisions spare capacity so pending pods can schedule without waiting for new nodes. It is disabled by default; enable it with `controller.featureGates.capacityBuffer`. The `karpenter-crd` chart installs the upstream `autoscaling.x-k8s.io/v1beta1` `CapacityBuffer` CRD whenever CRDs are applied, regardless of the gate, but Karpenter acts on `CapacityBuffer` resources only when the gate is enabled.
+`CapacityBuffer` is an Alpha feature that pre-provisions spare capacity so pending pods can schedule without waiting for new nodes. It is disabled by default; enable it with `controller.featureGates.capacityBuffer`. Karpenter acts on `CapacityBuffer` resources only when the gate is enabled.
+
+The CRD is the upstream `autoscaling.x-k8s.io/v1beta1` `CapacityBuffer` CRD. GKE provides it natively on clusters at or above `1.35.2-gke.1842000`; below that version the chart installs it to avoid CRD ownership conflicts with GKE:
+
+- `karpenter-crd` chart: renders the CRD only when the cluster is below `1.35.2-gke.1842000`.
+- `karpenter` chart: renders the CRD only when `controller.featureGates.capacityBuffer` is enabled and the cluster is below `1.35.2-gke.1842000`.
 
 ```yaml
 controller:


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/ea6b9108-5ac1-478c-a6ef-3cad28287925)

The CapacityBuffer (Alpha) section of the settings reference said the `karpenter-crd` chart installs the `autoscaling.x-k8s.io/v1beta1` `CapacityBuffer` CRD "whenever CRDs are applied, regardless of the gate." That is no longer accurate. The CRD is now installed conditionally: the `karpenter-crd` chart renders it only on clusters below GKE `1.35.2-gke.1842000` (at or above that version GKE provides the CRD natively, so the chart skips it to avoid CRD ownership conflicts), and the `karpenter` chart additionally requires the `controller.featureGates.capacityBuffer` gate to be enabled. This updates the paragraph to describe the per-chart, version-gated behavior and splits the CRD-rendering conditions into a short list for clarity.

**Trigger Events**
- [GitHub PR #557: chore: prerelease fixes](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/557)
