### PR TITLE
Correct CapacityBuffer CRD installation guidance in settings reference

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -25,7 +25,7 @@ controller:
 
 ### CapacityBuffer (Alpha)
 
-`CapacityBuffer` is an Alpha feature that pre-provisions spare capacity so pending pods can schedule without waiting for new nodes. It is disabled by default; enable it with `controller.featureGates.capacityBuffer`. The `karpenter-crd` chart installs the upstream `autoscaling.x-k8s.io/v1beta1` `CapacityBuffer` CRD whenever CRDs are applied, regardless of the gate, but Karpenter acts on `CapacityBuffer` resources only when the gate is enabled.
+`CapacityBuffer` is an Alpha feature that pre-provisions spare capacity so pending pods can schedule without waiting for new nodes. It is disabled by default; enable it with `controller.featureGates.capacityBuffer`. This provider does not install the `autoscaling.x-k8s.io/v1beta1` `CapacityBuffer` CRD; neither the `karpenter-crd` chart nor the `karpenter` chart ships it. GKE provides the CRD natively starting at cluster version `1.35.2-gke.1842000`. Enabling `controller.featureGates.capacityBuffer` on a cluster where the CRD is not already installed fails at template-render time during `helm install` or `helm upgrade`.
 
 ```yaml
 controller:


### PR DESCRIPTION
[Open in Promptless](https://app.gopromptless.ai/suggestions/f9ef65d6-64c7-4fdc-a63a-76dcbe9972df)

The CapacityBuffer (Alpha) section of the settings reference stated that the `karpenter-crd` chart installs the upstream `autoscaling.x-k8s.io/v1beta1` `CapacityBuffer` CRD whenever CRDs are applied. That is no longer true: the CapacityBuffer CRD was removed from both Helm charts, so the provider no longer ships it.

This updates the section to reflect the current behavior: the provider does not install the CapacityBuffer CRD, GKE provides it natively starting at cluster version `1.35.2-gke.1842000`, and enabling `controller.featureGates.capacityBuffer` on a cluster where the CRD is not already installed fails at Helm template-render time. Operators enabling the feature gate now have accurate guidance on the CRD prerequisite.

**Trigger Events**
- [Merged PR #557: chore: prerelease fixes](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/557)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the CapacityBuffer settings documentation to clarify its installation prerequisite.
- States that neither provider Helm chart ships the CapacityBuffer CRD.
- Documents the GKE version that provides the CRD natively.
- Warns that enabling the feature gate without the CRD causes Helm template rendering to fail.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/settings.md | Corrects the CapacityBuffer CRD installation and feature-gate guidance; no eligible follow-up issue was identified. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: correct CapacityBuffer CRD install..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/d215296bbf3b8c466b54d5478779ab7afbe5d7b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52247722)</sub>

<!-- /greptile_comment -->