### PR TITLE
chore: prepare-0.6.0-release

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -5,6 +5,18 @@
 
 ## Unreleased
 
+---
+
+## v0.6.0
+
+### CapacityBuffer requires the CRD to already be installed; the CRD is not installed by this provider
+
+This provider does not ship the `CapacityBuffer` CRD in either the `karpenter` or `karpenter-crd`
+chart. GKE provides it natively starting at `1.35.2-gke.1842000`. Setting
+`controller.featureGates.capacityBuffer: true` now checks the cluster for the CRD
+(`autoscaling.x-k8s.io/v1beta1/CapacityBuffer`) at Helm template time and fails the install/upgrade
+if it isn't present, instead of silently enabling a feature the controller can't back with a CRD.
+
 ### Unsupported instance labels removed
 
 The provider no longer registers or exposes the following GCP instance labels:


### PR DESCRIPTION
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prepares the v0.6.0 migration guide by documenting the CapacityBuffer CRD prerequisite and removal of two unsupported instance labels.
- Explains that enabling CapacityBuffer requires its CRD to exist before Helm renders the provider chart.
- Directs operators to remove deprecated label constraints before upgrading and recommends the instance-family label for family-specific scheduling.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge with no actionable defects identified.

The new migration guidance aligns with the chart guard and label-removal behavior and provides the necessary operator actions.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| MIGRATION.md | Adds accurate, actionable v0.6.0 migration guidance for CapacityBuffer enablement and removed instance labels. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: prepare-0.6.0-release"](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/329655a3ecad0a445bac0c328df7761f9ba581da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52593190)</sub>

<!-- /greptile_comment -->