### PR TITLE
feat(chart): expose preference policy

### DIFF
--- a/charts/karpenter/README.md
+++ b/charts/karpenter/README.md
@@ -122,6 +122,7 @@ serviceMonitor:
 | controller.settings.defaultNodepoolServiceAccount | string | `""` | Default GCP service account email to attach to provisioned nodes. When set, overrides the Compute Engine default SA. Corresponds to the DEFAULT_NODEPOOL_SERVICE_ACCOUNT env var. Recommended: set to a dedicated SA with roles/container.nodeServiceAccount. Can be overridden per-NodeClass via GCENodeClass.spec.serviceAccount. |
 | controller.settings.ignoreDRARequests | bool | `true` | ignoreDRARequests controls whether Karpenter ignores pods' Dynamic Resource Allocation requests during scheduling simulations. Keep true unless the cluster has DRA drivers and resource claims that Karpenter should account for. |
 | controller.settings.nodeLocation | string | `""` | The exact GCP cluster location for GKE API calls (e.g., us-central1-a for zonal, us-central1 for regional). If not set, defaults to 'clusterLocation' for backward compatibility. |
+| controller.settings.preferencePolicy | string | `"Respect"` | preferencePolicy controls how Karpenter handles soft scheduling preferences. `Respect` is the default; `Ignore` disregards preferred node/pod affinity and anti-affinity plus ScheduleAnyway topology spread constraints. |
 | controller.settings.projectID | string | `""` | The GCP project ID. |
 | controller.settings.vmMemoryOverheadPercent | float | `0.065` | The VM memory overhead as a percent that will be subtracted from the total memory for all instance types. The value of `0.075` equals to 7.5%. |
 | controller.strategy.rollingUpdate.maxUnavailable | int | `1` |  |

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -116,6 +116,8 @@ spec:
             {{- end }}
             - name: IGNORE_DRA_REQUESTS
               value: "{{ .Values.controller.settings.ignoreDRARequests }}"
+            - name: PREFERENCE_POLICY
+              value: "{{ .Values.controller.settings.preferencePolicy }}"
             {{- with .Values.controller.settings.vmMemoryOverheadPercent }}
             - name: VM_MEMORY_OVERHEAD_PERCENT
               value: "{{ . }}"

--- a/charts/karpenter/values.schema.json
+++ b/charts/karpenter/values.schema.json
@@ -373,6 +373,12 @@
               "description": "When true, Karpenter ignores pods' Dynamic Resource Allocation requests during scheduling simulations.",
               "default": true
             },
+            "preferencePolicy": {
+              "type": "string",
+              "enum": ["Respect", "Ignore"],
+              "description": "How Karpenter handles soft scheduling preferences. Respect preserves them; Ignore disregards preferred node/pod affinity and anti-affinity plus ScheduleAnyway topology spread constraints.",
+              "default": "Respect"
+            },
             "defaultNodePoolTemplateName": {
               "type": "string",
               "description": "Pin the GKE node pool used as the bootstrap metadata source. Leave empty for automatic discovery.",

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -153,6 +153,9 @@ controller:
     # -- ignoreDRARequests controls whether Karpenter ignores pods' Dynamic Resource Allocation requests during scheduling simulations.
     # Keep true unless the cluster has DRA drivers and resource claims that Karpenter should account for.
     ignoreDRARequests: true
+    # -- preferencePolicy controls how Karpenter handles soft scheduling preferences. `Respect` is the default;
+    # `Ignore` disregards preferred node/pod affinity and anti-affinity plus ScheduleAnyway topology spread constraints.
+    preferencePolicy: Respect
     # -- Pin the GKE node pool used as the bootstrap metadata source. When set, Karpenter uses this pool
     # exclusively and returns an error if it is not RUNNING. Leave empty to use automatic discovery
     # (default-pool → first alphabetical RUNNING pool → fallback karpenter-fallback creation).

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -37,13 +37,26 @@ controller:
 
 These options configure the controller's runtime behavior.
 
-| Option                        | Env var                     | Helm value                              | Default | Description                                                                                                                                       |
-|-------------------------------|-----------------------------|-----------------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--disable-controller-warmup` | `DISABLE_CONTROLLER_WARMUP` | `controller.disableControllerWarmup`    | `true`  | When `false`, controllers pre-populate caches before winning leader election, reducing failover time. Set to `false` in production for better HA. |
-| `--log-level`                 | `LOG_LEVEL`                 | `logLevel`                              | `info`  | Controller log level (`debug`, `info`, `warn`, `error`).                                                                                          |
-| `--batch-max-duration`        | `BATCH_MAX_DURATION`        | `controller.settings.batchMaxDuration`  | `10s`   | Maximum time Karpenter batches incoming pods before provisioning.                                                                                 |
-| `--batch-idle-duration`       | `BATCH_IDLE_DURATION`       | `controller.settings.batchIdleDuration` | `1s`    | Idle time after the last pod event before Karpenter triggers provisioning.                                                                        |
-| `--ignore-dra-requests`       | `IGNORE_DRA_REQUESTS`       | `controller.settings.ignoreDRARequests` | `true`  | When `true`, Karpenter ignores pods' Dynamic Resource Allocation requests during scheduling simulations.                                          |
+| Option                        | Env var                     | Helm value                              | Default   | Description                                                                                                                                       |
+|-------------------------------|-----------------------------|-----------------------------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--disable-controller-warmup` | `DISABLE_CONTROLLER_WARMUP` | `controller.disableControllerWarmup`    | `true`    | When `false`, controllers pre-populate caches before winning leader election, reducing failover time. Set to `false` in production for better HA. |
+| `--log-level`                 | `LOG_LEVEL`                 | `logLevel`                              | `info`    | Controller log level (`debug`, `info`, `warn`, `error`).                                                                                          |
+| `--batch-max-duration`        | `BATCH_MAX_DURATION`        | `controller.settings.batchMaxDuration`  | `10s`     | Maximum time Karpenter batches incoming pods before provisioning.                                                                                 |
+| `--batch-idle-duration`       | `BATCH_IDLE_DURATION`       | `controller.settings.batchIdleDuration` | `1s`      | Idle time after the last pod event before Karpenter triggers provisioning.                                                                        |
+| `--ignore-dra-requests`       | `IGNORE_DRA_REQUESTS`       | `controller.settings.ignoreDRARequests` | `true`    | When `true`, Karpenter ignores pods' Dynamic Resource Allocation requests during scheduling simulations.                                          |
+| `--preference-policy`         | `PREFERENCE_POLICY`         | `controller.settings.preferencePolicy`  | `Respect` | How Karpenter handles soft scheduling preferences. Valid values are `Respect` and `Ignore`.                                                       |
+
+### Preference policy
+
+`controller.settings.preferencePolicy` defaults to `Respect`, which retains soft scheduling preferences during provisioning and consolidation. Set it to `Ignore` to disregard `preferredDuringSchedulingIgnoredDuringExecution` node affinity, pod affinity, and pod anti-affinity, as well as topology spread constraints with `whenUnsatisfiable: ScheduleAnyway`.
+
+`Ignore` does not bypass required node or pod affinity/anti-affinity, topology spread constraints with `whenUnsatisfiable: DoNotSchedule`, taints, resource requirements, PodDisruptionBudgets, or other disruption controls.
+
+```yaml
+controller:
+  settings:
+    preferencePolicy: Ignore
+```
 
 ### Dynamic Resource Allocation (DRA)
 


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:

Exposes Karpenter core's preference policy through the Provider GCP Helm chart. The chart now accepts `controller.settings.preferencePolicy`, validates `Respect` and `Ignore`, and passes the selected value as `PREFERENCE_POLICY` to the controller.

#### Related proposal (if applicable):

#### Which issue(s) this PR fixes:

Fixes #566

#### Docs and examples

- [x] `docs/` and examples updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:

`Respect` remains the default. `Ignore` only drops soft affinity/anti-affinity and `ScheduleAnyway` topology preferences; hard scheduling constraints and disruption controls remain enforced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable preference policy for handling soft scheduling preferences.
  * Supports `Respect` (default) and `Ignore` modes.
  * Helm configuration now includes validation, defaults, and usage guidance.

* **Documentation**
  * Documented the new controller option, configuration methods, supported behaviors, and Helm example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR exposes Karpenter core’s preference policy through the Helm chart while preserving `Respect` as the default.
- Adds the schema-validated `controller.settings.preferencePolicy` value with `Respect` and `Ignore` options.
- Passes the configured policy to the controller through `PREFERENCE_POLICY`.
- Documents the setting, its default, and the constraints unaffected by `Ignore`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the chart value, schema, deployment environment variable, runtime option contract, and documentation are consistent.

The new setting defaults to existing behavior, validates exactly the values supported by the vendored Karpenter runtime, and reaches the controller through the expected environment variable without weakening hard scheduling or disruption constraints.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| charts/karpenter/templates/deployment.yaml | Adds the correctly named PREFERENCE_POLICY environment variable using the chart setting. |
| charts/karpenter/values.schema.json | Adds a string schema constrained to the two values accepted by the vendored runtime. |
| charts/karpenter/values.yaml | Introduces the backward-compatible Respect default and accurately describes Ignore behavior. |
| charts/karpenter/README.md | Adds the new setting to the generated chart value reference with consistent defaults and semantics. |
| docs/settings.md | Documents configuration, supported values, and the distinction between ignored soft preferences and retained hard constraints. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Values[controller.settings.preferencePolicy] --> Schema{Helm schema validation}
    Schema -->|Respect or Ignore| Deployment[Controller Deployment]
    Deployment -->|PREFERENCE_POLICY| Options[Karpenter runtime options]
    Options --> Scheduler[Provisioning and consolidation policy]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(chart): expose preference policy"](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/c4c02d537b887e87b4e40ffd86f58aacd7d4d065) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53766338)</sub>

<!-- /greptile_comment -->