### PR TITLE
fix: Select non-stale node pool templates when provisioning nodes

### DIFF
--- a/docs/bootstrap-pool.md
+++ b/docs/bootstrap-pool.md
@@ -59,8 +59,8 @@ Once a pool is selected, Karpenter has to find the instance template that pool i
 Karpenter therefore asks GKE, on every provisioning attempt:
 
 1. Read the selected node pool and its managed instance groups (`instanceGroupUrls`).
-2. Read each instance group manager and take the instance template it is running now.
-3. Fetch that template, from the regional or global collection depending on its URL. If the pool's instance groups disagree (which happens mid-upgrade), the most recently created template wins.
+2. Read each instance group manager and take the instance template it is running now. A manager part-way through an update names more than one template through its `versions` field, which overrides the top-level `instanceTemplate`; all of them are considered.
+3. Fetch each template named, from the regional or global collection depending on its URL. Where more than one is named — across zones, or across versions mid-upgrade — the most recently created template wins.
 
 If that chain cannot be completed — for example the controller's IAM role is missing `compute.instanceGroupManagers.get` — Karpenter logs the reason and falls back to scanning regional instance templates for the pool's label, taking the most recently created match. Because the chain runs per provisioning attempt, a template rotation is picked up by the next node Karpenter launches; the controller logs `source instance template selected` whenever the resolved template changes.
 

--- a/docs/bootstrap-pool.md
+++ b/docs/bootstrap-pool.md
@@ -52,9 +52,21 @@ Karpenter patches the source pool's kube-env metadata when provisioning nodes wi
 
 This allows a single source pool to bootstrap nodes of any OS and architecture combination.
 
+## Resolving the bootstrap pool's instance template
+
+Once a pool is selected, Karpenter has to find the instance template that pool is *currently* running. GKE builds a new template for a node pool on every upgrade and on credential rotation, and leaves the superseded templates in place; they all keep the same `goog-k8s-node-pool-name` label and `cluster-name` metadata, so the label alone cannot identify the live one.
+
+Karpenter therefore asks GKE, on every provisioning attempt:
+
+1. Read the selected node pool and its managed instance groups (`instanceGroupUrls`).
+2. Read each instance group manager and take the instance template it is running now.
+3. Fetch that template, from the regional or global collection depending on its URL. If the pool's instance groups disagree (which happens mid-upgrade), the most recently created template wins.
+
+If that chain cannot be completed — for example the controller's IAM role is missing `compute.instanceGroupManagers.get` — Karpenter logs the reason and falls back to scanning regional instance templates for the pool's label, taking the most recently created match. Because the chain runs per provisioning attempt, a template rotation is picked up by the next node Karpenter launches; the controller logs `source instance template selected` whenever the resolved template changes.
+
 ## Metadata sources
 
-Karpenter reads kubelet bootstrap metadata from the bootstrap pool's instance template. Other instance settings are derived from GCENodeClass, cluster config, or Karpenter/provider defaults.
+Karpenter reads kubelet bootstrap metadata from that instance template. Other instance settings are derived from GCENodeClass, cluster config, or Karpenter/provider defaults.
 
 | Metadata                               | Source                                                                                                                                             |
 |----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -120,6 +132,22 @@ Common causes:
 **Fallback pool creation fails**
 
 If fallback creation fails due to org policy violations, the error message identifies the blocking constraint. Create a compliant pool manually and set `DEFAULT_NODEPOOL_TEMPLATE_NAME` to that pool's name.
+
+**Nodes fail to join after a cluster CA or credential rotation**
+
+Rotating the control plane's CA rotates the cluster CA cert embedded in each node pool's instance template. Confirm Karpenter is using the template the pool actually runs:
+
+```sh
+kubectl logs -n karpenter-system -l app.kubernetes.io/name=karpenter | grep "source instance template selected"
+
+# ground truth: the template the pool's instance groups are running
+gcloud container node-pools describe POOL --cluster CLUSTER --location LOCATION \
+  --format='value(instanceGroupUrls)'
+gcloud compute instance-groups managed describe MIG --zone ZONE \
+  --format='value(instanceTemplate)'
+```
+
+If the logs show a fallback to the label scan, grant the controller `compute.instanceGroupManagers.get` (see [`deploy/iam/karpenter-controller-role.yaml`](../deploy/iam/karpenter-controller-role.yaml)).
 
 **Nodes fail to join the cluster after switching bootstrap pools**
 

--- a/docs/bootstrap-pool.md
+++ b/docs/bootstrap-pool.md
@@ -62,7 +62,7 @@ Karpenter therefore asks GKE, on every provisioning attempt:
 2. Read each instance group manager and take the instance template it is running now. A manager part-way through an update names more than one template through its `versions` field, which overrides the top-level `instanceTemplate`; all of them are considered.
 3. Fetch each template named, from the regional or global collection depending on its URL. Where more than one is named — across zones, or across versions mid-upgrade — the most recently created template wins.
 
-If that chain cannot be completed — for example the controller's IAM role is missing `compute.instanceGroupManagers.get` — Karpenter logs the reason and falls back to scanning regional instance templates for the pool's label, taking the most recently created match. Because the chain runs per provisioning attempt, a template rotation is picked up by the next node Karpenter launches; the controller logs `source instance template selected` whenever the resolved template changes.
+The chain has to resolve completely. If any part of it cannot be read — the controller's IAM role is missing `compute.instanceGroupManagers.get`, an instance group is unreachable, or one of the templates it names cannot be fetched — Karpenter does not rank whatever it did read, because the piece it could not see may well be the newer template. It logs the reason and falls back to scanning regional instance templates for the pool's label, taking the most recently created match. Because the chain runs per provisioning attempt, a template rotation is picked up by the next node Karpenter launches; the controller logs `source instance template selected` whenever the resolved template changes.
 
 ## Metadata sources
 

--- a/pkg/providers/nodepooltemplate/nodepooltemplate.go
+++ b/pkg/providers/nodepooltemplate/nodepooltemplate.go
@@ -37,7 +37,8 @@ type Provider interface {
 	Sync(ctx context.Context) error
 	// EnsureFallbackPool creates the karpenter-fallback pool if it does not already exist.
 	EnsureFallbackPool(ctx context.Context) error
-	// GetSourceTemplateMetadata returns metadata from the currently selected source template.
+	// GetSourceTemplateMetadata returns metadata from the instance template that the selected
+	// source pool is currently running.
 	GetSourceTemplateMetadata(ctx context.Context) (*compute.Metadata, error)
 }
 
@@ -45,6 +46,9 @@ type DefaultProvider struct {
 	mu sync.RWMutex
 	// sourcePoolName is the currently selected bootstrap source pool.
 	sourcePoolName string
+	// lastTemplateName is the name of the instance template most recently resolved for
+	// sourcePoolName. Only used to log template rotations once instead of on every resolution.
+	lastTemplateName string
 
 	computeService        *compute.Service
 	containerService      *container.Service
@@ -213,34 +217,14 @@ func (p *DefaultProvider) getSourcePoolName(_ context.Context) (string, error) {
 	return name, nil
 }
 
-func (p *DefaultProvider) GetSourceTemplateMetadata(ctx context.Context) (*compute.Metadata, error) {
-	sourcePoolName, err := p.getSourcePoolName(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("getting source pool name: %w", err)
-	}
-
-	instanceTemplates, err := p.computeService.RegionInstanceTemplates.List(p.ClusterInfo.ProjectID, p.ClusterInfo.Region).Context(ctx).Do()
-	if err != nil {
-		return nil, fmt.Errorf("cannot list all instance templates for node pool name %q: %w", sourcePoolName, err)
-	}
-
-	for _, template := range instanceTemplates.Items {
-		if template.Properties == nil || template.Properties.Labels == nil || template.Properties.Metadata == nil {
-			continue
-		}
-		if !hasMetadataValue(template.Properties.Metadata, clusterNameMetadataKey, p.ClusterInfo.Name) {
-			continue
-		}
-		if template.Properties.Labels[nodePoolNameLabelKey] != sourcePoolName {
-			continue
-		}
-		log.FromContext(ctx).Info("Found instance template", "templateName", template.Name, "clusterName", p.ClusterInfo.Name)
-		return template.Properties.Metadata, nil
-	}
-
-	return nil, fmt.Errorf("no instance template found with label %s=%s", nodePoolNameLabelKey, sourcePoolName)
+// namesCluster reports whether instance template metadata identifies the given cluster.
+func namesCluster(meta *compute.Metadata, clusterName string) bool {
+	return hasMetadataValue(meta, clusterNameMetadataKey, clusterName)
 }
 
+// hasMetadataValue reports whether the metadata carries the given key with the given value.
+//
+//nolint:unparam // generic by design; every caller happens to pass clusterNameMetadataKey today.
 func hasMetadataValue(meta *compute.Metadata, key, value string) bool {
 	if meta == nil {
 		return false

--- a/pkg/providers/nodepooltemplate/nodepooltemplate_test.go
+++ b/pkg/providers/nodepooltemplate/nodepooltemplate_test.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
@@ -196,75 +195,6 @@ func TestGetSourcePoolNameInternal(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "default-pool", name)
 	})
-}
-
-func TestGetSourceTemplateMetadata(t *testing.T) {
-	t.Run("returns metadata from matching source pool template", func(t *testing.T) {
-		template := instanceTemplate("template", "cluster", "default-pool")
-		srv := sourceTemplateServer(t, []*compute.InstanceTemplate{template})
-		defer srv.Close()
-
-		p := sourceTemplateProvider(t, srv)
-		source, err := p.GetSourceTemplateMetadata(context.Background())
-		require.NoError(t, err)
-		require.True(t, hasMetadataValue(source, clusterNameMetadataKey, "cluster"))
-	})
-
-	t.Run("ignores templates from other clusters", func(t *testing.T) {
-		srv := sourceTemplateServer(t, []*compute.InstanceTemplate{
-			instanceTemplate("other-cluster", "other", "default-pool"),
-			instanceTemplate("target", "cluster", "default-pool"),
-		})
-		defer srv.Close()
-
-		source, err := sourceTemplateProvider(t, srv).GetSourceTemplateMetadata(context.Background())
-		require.NoError(t, err)
-		require.True(t, hasMetadataValue(source, clusterNameMetadataKey, "cluster"))
-	})
-
-	t.Run("missing matching template returns error", func(t *testing.T) {
-		srv := sourceTemplateServer(t, []*compute.InstanceTemplate{instanceTemplate("template", "cluster", "other-pool")})
-		defer srv.Close()
-
-		_, err := sourceTemplateProvider(t, srv).GetSourceTemplateMetadata(context.Background())
-		require.ErrorContains(t, err, "no instance template found")
-	})
-
-}
-
-func sourceTemplateProvider(t *testing.T, srv *httptest.Server) *DefaultProvider {
-	t.Helper()
-	return &DefaultProvider{
-		computeService: buildComputeService(t, srv),
-		sourcePoolName: "default-pool",
-		ClusterInfo: ClusterInfo{
-			ProjectID: "proj",
-			Region:    "us-central1",
-			Name:      "cluster",
-		},
-	}
-}
-
-func sourceTemplateServer(t *testing.T, templates []*compute.InstanceTemplate) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		if strings.Contains(r.URL.Path, "/regions/us-central1/instanceTemplates") {
-			_ = json.NewEncoder(w).Encode(&compute.InstanceTemplateList{Items: templates})
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-}
-
-func instanceTemplate(name, clusterName, nodePoolName string) *compute.InstanceTemplate {
-	return &compute.InstanceTemplate{
-		Name: name,
-		Properties: &compute.InstanceProperties{
-			Labels:   map[string]string{"goog-k8s-node-pool-name": nodePoolName},
-			Metadata: &compute.Metadata{Items: []*compute.MetadataItems{{Key: "cluster-name", Value: lo.ToPtr(clusterName)}}},
-		},
-	}
 }
 
 // --- ensureKarpenterNodePoolTemplate ---

--- a/pkg/providers/nodepooltemplate/sourcetemplate.go
+++ b/pkg/providers/nodepooltemplate/sourcetemplate.go
@@ -105,18 +105,21 @@ func (p *DefaultProvider) resolveTemplateFromNodePool(ctx context.Context, poolN
 		return nil, fmt.Errorf("node pool %q has no instance groups", poolName)
 	}
 
-	// A multi-zone pool has one instance group per zone, normally all on the same template. They
-	// only diverge mid-upgrade, in which case the newest template is the one being rolled out.
+	// A multi-zone pool has one instance group per zone, and an instance group part-way through an
+	// update names more than one template. Both normally collapse to a single template; where they
+	// do not, the newest one is the one being rolled out.
 	var templateURLs []string
 	var errs []error
 	for _, instanceGroupURL := range nodePool.InstanceGroupUrls {
-		templateURL, err := p.instanceGroupTemplateURL(ctx, instanceGroupURL)
+		urls, err := p.instanceGroupTemplateURLs(ctx, instanceGroupURL)
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
-		if !slices.Contains(templateURLs, templateURL) {
-			templateURLs = append(templateURLs, templateURL)
+		for _, templateURL := range urls {
+			if !slices.Contains(templateURLs, templateURL) {
+				templateURLs = append(templateURLs, templateURL)
+			}
 		}
 	}
 	if len(templateURLs) == 0 {
@@ -139,32 +142,43 @@ func (p *DefaultProvider) resolveTemplateFromNodePool(ctx context.Context, poolN
 	return newest, nil
 }
 
-// instanceGroupTemplateURL returns the URL of the instance template the given managed instance
-// group is currently running.
-func (p *DefaultProvider) instanceGroupTemplateURL(ctx context.Context, instanceGroupURL string) (string, error) {
+// instanceGroupTemplateURLs returns the URLs of the instance templates the given managed instance
+// group is running.
+//
+// A group normally names exactly one, in its top-level instanceTemplate. During an update it also
+// populates versions, which the Compute API defines as overriding that top-level field, so versions
+// wins wherever it is set. GKE uses a surge upgrade to roll out a new template, including on
+// credential rotation, so mid-update a group legitimately names two: the one being replaced and the
+// one being rolled out. Both are returned and the caller takes the newest.
+func (p *DefaultProvider) instanceGroupTemplateURLs(ctx context.Context, instanceGroupURL string) ([]string, error) {
 	ref, err := parseComputeResourceURL(instanceGroupURL, "instanceGroupManagers")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if ref.scope != scopeZone {
 		// GKE node pools always use zonal instance groups, and compute.regionInstanceGroupManagers.get
 		// is deliberately not in the controller's IAM role, so there is nothing to gain by calling
 		// the regional API here. The label scan covers this if GKE ever changes.
-		return "", fmt.Errorf("instance group %q is not zonal", instanceGroupURL)
+		return nil, fmt.Errorf("instance group %q is not zonal", instanceGroupURL)
 	}
 	manager, err := p.computeService.InstanceGroupManagers.Get(ref.project, ref.location, ref.name).Context(ctx).Do()
 	if err != nil {
-		return "", fmt.Errorf("getting instance group manager %q: %w", instanceGroupURL, err)
+		return nil, fmt.Errorf("getting instance group manager %q: %w", instanceGroupURL, err)
 	}
-	if manager.InstanceTemplate != "" {
-		return manager.InstanceTemplate, nil
-	}
+
+	var templateURLs []string
 	for _, version := range manager.Versions {
 		if version != nil && version.InstanceTemplate != "" {
-			return version.InstanceTemplate, nil
+			templateURLs = append(templateURLs, version.InstanceTemplate)
 		}
 	}
-	return "", fmt.Errorf("instance group manager %q names no instance template", instanceGroupURL)
+	if len(templateURLs) == 0 && manager.InstanceTemplate != "" {
+		templateURLs = append(templateURLs, manager.InstanceTemplate)
+	}
+	if len(templateURLs) == 0 {
+		return nil, fmt.Errorf("instance group manager %q names no instance template", instanceGroupURL)
+	}
+	return templateURLs, nil
 }
 
 // getInstanceTemplateByURL fetches a template from either the regional or the global collection,

--- a/pkg/providers/nodepooltemplate/sourcetemplate.go
+++ b/pkg/providers/nodepooltemplate/sourcetemplate.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2025 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodepooltemplate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"google.golang.org/api/compute/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type computeScope string
+
+const (
+	scopeGlobal computeScope = "global"
+	scopeRegion computeScope = "regions"
+	scopeZone   computeScope = "zones"
+)
+
+// computeResourceRef is a compute self-link broken into the parts the generated clients take.
+type computeResourceRef struct {
+	project  string
+	scope    computeScope
+	location string // zone or region name; empty when the scope is global
+	name     string
+}
+
+// GetSourceTemplateMetadata returns metadata from the instance template that the selected
+// bootstrap source pool is currently running.
+//
+// GKE builds a new instance template for a node pool on every upgrade and on credential rotation,
+// and leaves the superseded ones in place. They all keep the same goog-k8s-node-pool-name label
+// and cluster-name metadata, so a label scan cannot tell which one is live; picking a stale one
+// bakes an out-of-date cluster CA cert into every node we launch and those nodes never join.
+// Ask GKE instead: the node pool names its managed instance groups, and each instance group names
+// the template it is running right now.
+func (p *DefaultProvider) GetSourceTemplateMetadata(ctx context.Context) (*compute.Metadata, error) {
+	sourcePoolName, err := p.getSourcePoolName(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting source pool name: %w", err)
+	}
+
+	template, err := p.resolveTemplateFromNodePool(ctx, sourcePoolName)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "cannot resolve the instance template from the node pool, falling back to a label scan",
+			"pool", sourcePoolName)
+		if template, err = p.resolveTemplateByLabelScan(ctx, sourcePoolName); err != nil {
+			return nil, err
+		}
+	}
+
+	if template.Properties == nil || template.Properties.Metadata == nil {
+		return nil, fmt.Errorf("instance template %q for node pool %q has no metadata", template.Name, sourcePoolName)
+	}
+
+	p.mu.Lock()
+	previous := p.lastTemplateName
+	p.lastTemplateName = template.Name
+	p.mu.Unlock()
+
+	logger := log.FromContext(ctx).WithValues("templateName", template.Name,
+		"pool", sourcePoolName, "clusterName", p.ClusterInfo.Name)
+	if previous != template.Name {
+		logger.Info("source instance template selected", "previous", previous)
+	} else {
+		logger.V(1).Info("Found instance template")
+	}
+	if !namesCluster(template.Properties.Metadata, p.ClusterInfo.Name) {
+		// The node pool is the authority on which template is correct, so this is worth flagging
+		// but not worth failing a launch over.
+		logger.Info("instance template metadata does not name this cluster")
+	}
+
+	return template.Properties.Metadata, nil
+}
+
+// resolveTemplateFromNodePool walks NodePool -> managed instance groups -> instance template to
+// find the template the pool is running now.
+func (p *DefaultProvider) resolveTemplateFromNodePool(ctx context.Context, poolName string) (*compute.InstanceTemplate, error) {
+	nodePool, err := p.getNodePool(ctx, poolName)
+	if err != nil {
+		return nil, fmt.Errorf("getting node pool %q: %w", poolName, err)
+	}
+	if len(nodePool.InstanceGroupUrls) == 0 {
+		return nil, fmt.Errorf("node pool %q has no instance groups", poolName)
+	}
+
+	// A multi-zone pool has one instance group per zone, normally all on the same template. They
+	// only diverge mid-upgrade, in which case the newest template is the one being rolled out.
+	var templateURLs []string
+	var errs []error
+	for _, instanceGroupURL := range nodePool.InstanceGroupUrls {
+		templateURL, err := p.instanceGroupTemplateURL(ctx, instanceGroupURL)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if !slices.Contains(templateURLs, templateURL) {
+			templateURLs = append(templateURLs, templateURL)
+		}
+	}
+	if len(templateURLs) == 0 {
+		return nil, fmt.Errorf("no instance template named by the instance groups of node pool %q: %w",
+			poolName, errors.Join(errs...))
+	}
+
+	var newest *compute.InstanceTemplate
+	for _, templateURL := range templateURLs {
+		template, err := p.getInstanceTemplateByURL(ctx, templateURL)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		newest = newerTemplate(newest, template)
+	}
+	if newest == nil {
+		return nil, fmt.Errorf("fetching instance templates for node pool %q: %w", poolName, errors.Join(errs...))
+	}
+	return newest, nil
+}
+
+// instanceGroupTemplateURL returns the URL of the instance template the given managed instance
+// group is currently running.
+func (p *DefaultProvider) instanceGroupTemplateURL(ctx context.Context, instanceGroupURL string) (string, error) {
+	ref, err := parseComputeResourceURL(instanceGroupURL, "instanceGroupManagers")
+	if err != nil {
+		return "", err
+	}
+	if ref.scope != scopeZone {
+		// GKE node pools always use zonal instance groups, and compute.regionInstanceGroupManagers.get
+		// is deliberately not in the controller's IAM role, so there is nothing to gain by calling
+		// the regional API here. The label scan covers this if GKE ever changes.
+		return "", fmt.Errorf("instance group %q is not zonal", instanceGroupURL)
+	}
+	manager, err := p.computeService.InstanceGroupManagers.Get(ref.project, ref.location, ref.name).Context(ctx).Do()
+	if err != nil {
+		return "", fmt.Errorf("getting instance group manager %q: %w", instanceGroupURL, err)
+	}
+	if manager.InstanceTemplate != "" {
+		return manager.InstanceTemplate, nil
+	}
+	for _, version := range manager.Versions {
+		if version != nil && version.InstanceTemplate != "" {
+			return version.InstanceTemplate, nil
+		}
+	}
+	return "", fmt.Errorf("instance group manager %q names no instance template", instanceGroupURL)
+}
+
+// getInstanceTemplateByURL fetches a template from either the regional or the global collection,
+// whichever its URL points at. GKE uses regional templates today but has used global ones.
+func (p *DefaultProvider) getInstanceTemplateByURL(ctx context.Context, templateURL string) (*compute.InstanceTemplate, error) {
+	ref, err := parseComputeResourceURL(templateURL, "instanceTemplates")
+	if err != nil {
+		return nil, err
+	}
+	switch ref.scope {
+	case scopeRegion:
+		return p.computeService.RegionInstanceTemplates.Get(ref.project, ref.location, ref.name).Context(ctx).Do()
+	case scopeGlobal:
+		return p.computeService.InstanceTemplates.Get(ref.project, ref.name).Context(ctx).Do()
+	default:
+		return nil, fmt.Errorf("instance template %q is neither regional nor global", templateURL)
+	}
+}
+
+// resolveTemplateByLabelScan is the degraded path taken when GKE cannot tell us which template the
+// pool is running. Every template GKE has ever built for the pool carries the same label, so take
+// the most recently created match: after a rotation that is the live one.
+func (p *DefaultProvider) resolveTemplateByLabelScan(ctx context.Context, poolName string) (*compute.InstanceTemplate, error) {
+	var newest *compute.InstanceTemplate
+	err := p.computeService.RegionInstanceTemplates.List(p.ClusterInfo.ProjectID, p.ClusterInfo.Region).
+		Pages(ctx, func(page *compute.InstanceTemplateList) error {
+			for _, template := range page.Items {
+				if p.templateBelongsToPool(template, poolName) {
+					newest = newerTemplate(newest, template)
+				}
+			}
+			return nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("cannot list all instance templates for node pool name %q: %w", poolName, err)
+	}
+	if newest == nil {
+		return nil, fmt.Errorf("no instance template found with label %s=%s", nodePoolNameLabelKey, poolName)
+	}
+	return newest, nil
+}
+
+func (p *DefaultProvider) templateBelongsToPool(template *compute.InstanceTemplate, poolName string) bool {
+	if template == nil || template.Properties == nil || template.Properties.Labels == nil || template.Properties.Metadata == nil {
+		return false
+	}
+	if !namesCluster(template.Properties.Metadata, p.ClusterInfo.Name) {
+		return false
+	}
+	return template.Properties.Labels[nodePoolNameLabelKey] == poolName
+}
+
+// newerTemplate returns whichever of the two templates was created most recently.
+func newerTemplate(a, b *compute.InstanceTemplate) *compute.InstanceTemplate {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	if templateCreatedAt(b).After(templateCreatedAt(a)) {
+		return b
+	}
+	return a
+}
+
+// templateCreatedAt parses a template's creationTimestamp, treating a missing or malformed value
+// as the zero time so it sorts oldest. GCP returns RFC3339 with a real UTC offset
+// (2025-10-31T11:09:17.350-07:00), so these values cannot be compared as strings.
+func templateCreatedAt(template *compute.InstanceTemplate) time.Time {
+	parsed, err := time.Parse(time.RFC3339, template.CreationTimestamp)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
+}
+
+// parseComputeResourceURL splits a compute self-link naming a resource in the given collection.
+// Self-links take one of three shapes:
+//
+//	.../projects/{project}/zones/{zone}/{collection}/{name}
+//	.../projects/{project}/regions/{region}/{collection}/{name}
+//	.../projects/{project}/global/{collection}/{name}
+func parseComputeResourceURL(rawURL, collection string) (computeResourceRef, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return computeResourceRef{}, fmt.Errorf("parsing compute URL %q: %w", rawURL, err)
+	}
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	i := slices.Index(segments, collection)
+	if i < 0 || i == len(segments)-1 {
+		return computeResourceRef{}, fmt.Errorf("compute URL %q does not name a %s", rawURL, collection)
+	}
+
+	ref := computeResourceRef{name: segments[i+1]}
+	switch {
+	case i >= 3 && segments[i-1] == string(scopeGlobal) && segments[i-3] == "projects":
+		ref.scope = scopeGlobal
+		ref.project = segments[i-2]
+	case i >= 4 && segments[i-4] == "projects" &&
+		(segments[i-2] == string(scopeZone) || segments[i-2] == string(scopeRegion)):
+		ref.scope = computeScope(segments[i-2])
+		ref.location = segments[i-1]
+		ref.project = segments[i-3]
+	default:
+		return computeResourceRef{}, fmt.Errorf("compute URL %q is not a recognized %s self-link", rawURL, collection)
+	}
+	return ref, nil
+}

--- a/pkg/providers/nodepooltemplate/sourcetemplate.go
+++ b/pkg/providers/nodepooltemplate/sourcetemplate.go
@@ -18,7 +18,6 @@ package nodepooltemplate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"slices"
@@ -108,13 +107,18 @@ func (p *DefaultProvider) resolveTemplateFromNodePool(ctx context.Context, poolN
 	// A multi-zone pool has one instance group per zone, and an instance group part-way through an
 	// update names more than one template. Both normally collapse to a single template; where they
 	// do not, the newest one is the one being rolled out.
+	//
+	// Anything we cannot read fails the whole chain rather than narrowing it. More than one
+	// candidate means a rollout is in flight, which is how a credential rotation reaches a pool, so
+	// whatever we failed to read is as likely to be the new template as the old one. Ranking the
+	// remainder and reporting it as the pool's current template would hand the caller a stale
+	// bootstrap config while looking authoritative; giving up hands over to the label scan, which
+	// is also newest-wins and says so in the log.
 	var templateURLs []string
-	var errs []error
 	for _, instanceGroupURL := range nodePool.InstanceGroupUrls {
 		urls, err := p.instanceGroupTemplateURLs(ctx, instanceGroupURL)
 		if err != nil {
-			errs = append(errs, err)
-			continue
+			return nil, err
 		}
 		for _, templateURL := range urls {
 			if !slices.Contains(templateURLs, templateURL) {
@@ -123,21 +127,19 @@ func (p *DefaultProvider) resolveTemplateFromNodePool(ctx context.Context, poolN
 		}
 	}
 	if len(templateURLs) == 0 {
-		return nil, fmt.Errorf("no instance template named by the instance groups of node pool %q: %w",
-			poolName, errors.Join(errs...))
+		return nil, fmt.Errorf("no instance template named by the instance groups of node pool %q", poolName)
 	}
 
 	var newest *compute.InstanceTemplate
 	for _, templateURL := range templateURLs {
 		template, err := p.getInstanceTemplateByURL(ctx, templateURL)
 		if err != nil {
-			errs = append(errs, err)
-			continue
+			return nil, fmt.Errorf("fetching instance template for node pool %q: %w", poolName, err)
 		}
 		newest = newerTemplate(newest, template)
 	}
 	if newest == nil {
-		return nil, fmt.Errorf("fetching instance templates for node pool %q: %w", poolName, errors.Join(errs...))
+		return nil, fmt.Errorf("no instance template resolved for node pool %q", poolName)
 	}
 	return newest, nil
 }

--- a/pkg/providers/nodepooltemplate/sourcetemplate_test.go
+++ b/pkg/providers/nodepooltemplate/sourcetemplate_test.go
@@ -54,6 +54,12 @@ func globalTemplateURL(name string) string {
 		testProject, name)
 }
 
+// migOnTemplate builds a managed instance group running a single template, the way the Compute
+// API reports a group that is not mid-update.
+func migOnTemplate(templateURL string) *compute.InstanceGroupManager {
+	return &compute.InstanceGroupManager{InstanceTemplate: templateURL}
+}
+
 func instanceTemplate(name, clusterName, nodePoolName, creationTimestamp string) *compute.InstanceTemplate {
 	return &compute.InstanceTemplate{
 		Name:              name,
@@ -69,8 +75,8 @@ func instanceTemplate(name, clusterName, nodePoolName, creationTimestamp string)
 type sourceTemplateFake struct {
 	// nodePool is returned by container NodePools.Get. nil → 404.
 	nodePool *container.NodePool
-	// managers maps an instance group manager name to the template URL it is running.
-	managers map[string]string
+	// managers maps an instance group manager name to the manager served for it.
+	managers map[string]*compute.InstanceGroupManager
 	// managerStatus, when non-zero, is returned instead of serving managers.
 	managerStatus int
 	// templates are served by name from both the regional and global Get endpoints, and are
@@ -109,12 +115,13 @@ func (f *sourceTemplateFake) server(t *testing.T) *httptest.Server {
 				w.WriteHeader(f.managerStatus)
 				return
 			}
-			templateURL, ok := f.managers[name]
+			manager, ok := f.managers[name]
 			if !ok {
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}
-			_ = json.NewEncoder(w).Encode(&compute.InstanceGroupManager{Name: name, InstanceTemplate: templateURL})
+			manager.Name = name
+			_ = json.NewEncoder(w).Encode(manager)
 
 		// The List endpoint has no trailing name, so it must be matched before the Get endpoints.
 		case strings.HasSuffix(path, fmt.Sprintf("/regions/%s/instanceTemplates", testRegion)):
@@ -191,7 +198,7 @@ func TestGetSourceTemplateMetadata(t *testing.T) {
 		t.Parallel()
 		fake := &sourceTemplateFake{
 			nodePool:  &container.NodePool{Name: testPool, InstanceGroupUrls: []string{migURL(testZone, "grp-a")}},
-			managers:  map[string]string{"grp-a": regionalTemplateURL("gke-current")},
+			managers:  map[string]*compute.InstanceGroupManager{"grp-a": migOnTemplate(regionalTemplateURL("gke-current"))},
 			templates: []*compute.InstanceTemplate{stale, current},
 			// The pool names the current template, so the label scan must not be consulted at all.
 			listOnly: []*compute.InstanceTemplate{},
@@ -208,7 +215,7 @@ func TestGetSourceTemplateMetadata(t *testing.T) {
 		t.Parallel()
 		fake := &sourceTemplateFake{
 			nodePool:  &container.NodePool{Name: testPool, InstanceGroupUrls: []string{migURL(testZone, "grp-a")}},
-			managers:  map[string]string{"grp-a": globalTemplateURL("gke-current")},
+			managers:  map[string]*compute.InstanceGroupManager{"grp-a": migOnTemplate(globalTemplateURL("gke-current"))},
 			templates: []*compute.InstanceTemplate{current},
 			listOnly:  []*compute.InstanceTemplate{},
 		}
@@ -225,12 +232,92 @@ func TestGetSourceTemplateMetadata(t *testing.T) {
 			nodePool: &container.NodePool{Name: testPool, InstanceGroupUrls: []string{
 				migURL(testZone, "grp-a"), migURL("us-central1-b", "grp-b"),
 			}},
-			managers: map[string]string{
-				"grp-a": regionalTemplateURL("gke-stale"),
-				"grp-b": regionalTemplateURL("gke-current"),
+			managers: map[string]*compute.InstanceGroupManager{
+				"grp-a": migOnTemplate(regionalTemplateURL("gke-stale")),
+				"grp-b": migOnTemplate(regionalTemplateURL("gke-current")),
 			},
 			templates: []*compute.InstanceTemplate{stale, current},
 			listOnly:  []*compute.InstanceTemplate{},
+		}
+		p := fake.provider(t)
+
+		_, err := p.GetSourceTemplateMetadata(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "gke-current", templateName(p))
+	})
+
+	// The Compute API defines InstanceGroupManager.versions as overriding the top-level
+	// instanceTemplate. GKE puts a pool into that state for the duration of a surge upgrade, which
+	// is exactly how a credential rotation is rolled out — so reading the top-level field first
+	// would hand back the template being replaced.
+	t.Run("versions override the top-level instance template", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool: &container.NodePool{Name: testPool, InstanceGroupUrls: []string{migURL(testZone, "grp-a")}},
+			managers: map[string]*compute.InstanceGroupManager{"grp-a": {
+				InstanceTemplate: regionalTemplateURL("gke-stale"),
+				Versions: []*compute.InstanceGroupManagerVersion{
+					{Name: "v1", InstanceTemplate: regionalTemplateURL("gke-current")},
+				},
+			}},
+			templates: []*compute.InstanceTemplate{stale, current},
+			listOnly:  []*compute.InstanceTemplate{},
+		}
+		p := fake.provider(t)
+
+		_, err := p.GetSourceTemplateMetadata(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "gke-current", templateName(p))
+	})
+
+	t.Run("resolves from versions when no top-level instance template is set", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool: &container.NodePool{Name: testPool, InstanceGroupUrls: []string{migURL(testZone, "grp-a")}},
+			managers: map[string]*compute.InstanceGroupManager{"grp-a": {
+				Versions: []*compute.InstanceGroupManagerVersion{
+					{Name: "v1", InstanceTemplate: regionalTemplateURL("gke-current")},
+				},
+			}},
+			templates: []*compute.InstanceTemplate{current},
+			listOnly:  []*compute.InstanceTemplate{},
+		}
+		p := fake.provider(t)
+
+		_, err := p.GetSourceTemplateMetadata(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "gke-current", templateName(p))
+	})
+
+	t.Run("takes the newest template when an instance group carries two versions mid-surge", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool: &container.NodePool{Name: testPool, InstanceGroupUrls: []string{migURL(testZone, "grp-a")}},
+			managers: map[string]*compute.InstanceGroupManager{"grp-a": {
+				Versions: []*compute.InstanceGroupManagerVersion{
+					// The version being replaced is listed first and, as the one that applies to
+					// all remaining instances, is the one with no targetSize.
+					{Name: "v1", InstanceTemplate: regionalTemplateURL("gke-stale")},
+					{Name: "v2", InstanceTemplate: regionalTemplateURL("gke-current"),
+						TargetSize: &compute.FixedOrPercent{Fixed: 1}},
+				},
+			}},
+			templates: []*compute.InstanceTemplate{stale, current},
+			listOnly:  []*compute.InstanceTemplate{},
+		}
+		p := fake.provider(t)
+
+		_, err := p.GetSourceTemplateMetadata(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "gke-current", templateName(p))
+	})
+
+	t.Run("falls back to the label scan when the instance group names no template", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool:  &container.NodePool{Name: testPool, InstanceGroupUrls: []string{migURL(testZone, "grp-a")}},
+			managers:  map[string]*compute.InstanceGroupManager{"grp-a": {}},
+			templates: []*compute.InstanceTemplate{current},
 		}
 		p := fake.provider(t)
 

--- a/pkg/providers/nodepooltemplate/sourcetemplate_test.go
+++ b/pkg/providers/nodepooltemplate/sourcetemplate_test.go
@@ -1,0 +1,420 @@
+/*
+Copyright 2025 The CloudPilot AI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodepooltemplate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/container/v1"
+)
+
+const (
+	testProject = "proj"
+	testRegion  = "us-central1"
+	testZone    = "us-central1-a"
+	testCluster = "cluster"
+	testPool    = "default-pool"
+)
+
+func migURL(zone, name string) string {
+	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instanceGroupManagers/%s",
+		testProject, zone, name)
+}
+
+func regionalTemplateURL(name string) string {
+	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/instanceTemplates/%s",
+		testProject, testRegion, name)
+}
+
+func globalTemplateURL(name string) string {
+	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/instanceTemplates/%s",
+		testProject, name)
+}
+
+func instanceTemplate(name, clusterName, nodePoolName, creationTimestamp string) *compute.InstanceTemplate {
+	return &compute.InstanceTemplate{
+		Name:              name,
+		CreationTimestamp: creationTimestamp,
+		Properties: &compute.InstanceProperties{
+			Labels:   map[string]string{nodePoolNameLabelKey: nodePoolName},
+			Metadata: &compute.Metadata{Items: []*compute.MetadataItems{{Key: clusterNameMetadataKey, Value: lo.ToPtr(clusterName)}}},
+		},
+	}
+}
+
+// sourceTemplateFake serves the GKE and Compute endpoints GetSourceTemplateMetadata walks.
+type sourceTemplateFake struct {
+	// nodePool is returned by container NodePools.Get. nil → 404.
+	nodePool *container.NodePool
+	// managers maps an instance group manager name to the template URL it is running.
+	managers map[string]string
+	// managerStatus, when non-zero, is returned instead of serving managers.
+	managerStatus int
+	// templates are served by name from both the regional and global Get endpoints, and are
+	// returned by the regional List endpoint one item per page.
+	templates []*compute.InstanceTemplate
+	// listOnly restricts the regional List endpoint to these templates. nil → all templates.
+	listOnly []*compute.InstanceTemplate
+}
+
+func (f *sourceTemplateFake) templateByName(name string) *compute.InstanceTemplate {
+	for _, template := range f.templates {
+		if template.Name == name {
+			return template
+		}
+	}
+	return nil
+}
+
+func (f *sourceTemplateFake) server(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+		name := path[strings.LastIndex(path, "/")+1:]
+
+		switch {
+		case strings.Contains(path, "/nodePools/"):
+			if f.nodePool == nil {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(f.nodePool)
+
+		case strings.Contains(path, "/instanceGroupManagers/"):
+			if f.managerStatus != 0 {
+				w.WriteHeader(f.managerStatus)
+				return
+			}
+			templateURL, ok := f.managers[name]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(&compute.InstanceGroupManager{Name: name, InstanceTemplate: templateURL})
+
+		// The List endpoint has no trailing name, so it must be matched before the Get endpoints.
+		case strings.HasSuffix(path, fmt.Sprintf("/regions/%s/instanceTemplates", testRegion)):
+			f.serveList(w, r)
+
+		case strings.Contains(path, "/instanceTemplates/"):
+			template := f.templateByName(name)
+			if template == nil {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(template)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// serveList pages the regional instance template list one item at a time so that pagination is
+// exercised whenever more than one template is listed.
+func (f *sourceTemplateFake) serveList(w http.ResponseWriter, r *http.Request) {
+	items := f.listOnly
+	if items == nil {
+		items = f.templates
+	}
+	page := 0
+	if token := r.URL.Query().Get("pageToken"); token != "" {
+		_, _ = fmt.Sscanf(token, "page-%d", &page)
+	}
+	if page >= len(items) {
+		_ = json.NewEncoder(w).Encode(&compute.InstanceTemplateList{})
+		return
+	}
+	resp := &compute.InstanceTemplateList{Items: []*compute.InstanceTemplate{items[page]}}
+	if page+1 < len(items) {
+		resp.NextPageToken = fmt.Sprintf("page-%d", page+1)
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (f *sourceTemplateFake) provider(t *testing.T) *DefaultProvider {
+	t.Helper()
+	srv := f.server(t)
+	t.Cleanup(srv.Close)
+	return &DefaultProvider{
+		computeService:   buildComputeService(t, srv),
+		containerService: buildContainerService(t, srv),
+		sourcePoolName:   testPool,
+		ClusterInfo: ClusterInfo{
+			ProjectID:    testProject,
+			Region:       testRegion,
+			NodeLocation: testRegion,
+			Name:         testCluster,
+		},
+	}
+}
+
+// templateName reads back the template the provider resolved, which the metadata alone cannot
+// identify since every rotation of a pool's template carries identical cluster-name metadata.
+func templateName(p *DefaultProvider) string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.lastTemplateName
+}
+
+func TestGetSourceTemplateMetadata(t *testing.T) {
+	t.Parallel()
+
+	current := instanceTemplate("gke-current", testCluster, testPool, "2026-08-20T10:00:00.000-07:00")
+	stale := instanceTemplate("gke-stale", testCluster, testPool, "2026-01-02T10:00:00.000-07:00")
+
+	t.Run("resolves the regional template the node pool's instance group is running", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool:  &container.NodePool{Name: testPool, InstanceGroupUrls: []string{migURL(testZone, "grp-a")}},
+			managers:  map[string]string{"grp-a": regionalTemplateURL("gke-current")},
+			templates: []*compute.InstanceTemplate{stale, current},
+			// The pool names the current template, so the label scan must not be consulted at all.
+			listOnly: []*compute.InstanceTemplate{},
+		}
+		p := fake.provider(t)
+
+		md, err := p.GetSourceTemplateMetadata(context.Background())
+		require.NoError(t, err)
+		require.True(t, namesCluster(md, testCluster))
+		require.Equal(t, "gke-current", templateName(p))
+	})
+
+	t.Run("resolves a global template", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool:  &container.NodePool{Name: testPool, InstanceGroupUrls: []string{migURL(testZone, "grp-a")}},
+			managers:  map[string]string{"grp-a": globalTemplateURL("gke-current")},
+			templates: []*compute.InstanceTemplate{current},
+			listOnly:  []*compute.InstanceTemplate{},
+		}
+		p := fake.provider(t)
+
+		_, err := p.GetSourceTemplateMetadata(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "gke-current", templateName(p))
+	})
+
+	t.Run("takes the newest template when instance groups disagree mid-upgrade", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool: &container.NodePool{Name: testPool, InstanceGroupUrls: []string{
+				migURL(testZone, "grp-a"), migURL("us-central1-b", "grp-b"),
+			}},
+			managers: map[string]string{
+				"grp-a": regionalTemplateURL("gke-stale"),
+				"grp-b": regionalTemplateURL("gke-current"),
+			},
+			templates: []*compute.InstanceTemplate{stale, current},
+			listOnly:  []*compute.InstanceTemplate{},
+		}
+		p := fake.provider(t)
+
+		_, err := p.GetSourceTemplateMetadata(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "gke-current", templateName(p))
+	})
+
+	// Regression for cloudpilot-ai/karpenter-provider-gcp#577: GKE leaves every superseded
+	// template in place carrying the pool's label, and the list API does not order its results.
+	// Taking the first match handed out a pre-CA-rotation template and the nodes never joined.
+	for _, listOrder := range []struct {
+		name  string
+		items []*compute.InstanceTemplate
+	}{
+		{name: "newest first", items: []*compute.InstanceTemplate{current, stale}},
+		{name: "newest last", items: []*compute.InstanceTemplate{stale, current}},
+	} {
+		t.Run("label scan takes the newest match, listed "+listOrder.name, func(t *testing.T) {
+			t.Parallel()
+			fake := &sourceTemplateFake{
+				nodePool:      &container.NodePool{Name: testPool, InstanceGroupUrls: []string{migURL(testZone, "grp-a")}},
+				managerStatus: http.StatusForbidden,
+				templates:     listOrder.items,
+			}
+			p := fake.provider(t)
+
+			_, err := p.GetSourceTemplateMetadata(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, "gke-current", templateName(p))
+		})
+	}
+
+	t.Run("label scan reads past the first page", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool:      &container.NodePool{Name: testPool, InstanceGroupUrls: []string{migURL(testZone, "grp-a")}},
+			managerStatus: http.StatusForbidden,
+			// The fake serves one template per page, so the only match is on the third page.
+			templates: []*compute.InstanceTemplate{
+				instanceTemplate("gke-other-pool", testCluster, "other-pool", "2026-08-21T10:00:00.000-07:00"),
+				instanceTemplate("gke-other-cluster", "other", testPool, "2026-08-22T10:00:00.000-07:00"),
+				current,
+			},
+		}
+		p := fake.provider(t)
+
+		_, err := p.GetSourceTemplateMetadata(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "gke-current", templateName(p))
+	})
+
+	t.Run("falls back to the label scan when the pool has no instance groups", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool:  &container.NodePool{Name: testPool},
+			templates: []*compute.InstanceTemplate{current},
+		}
+		p := fake.provider(t)
+
+		_, err := p.GetSourceTemplateMetadata(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "gke-current", templateName(p))
+	})
+
+	t.Run("ignores templates from other clusters", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool:      &container.NodePool{Name: testPool},
+			managerStatus: http.StatusForbidden,
+			templates: []*compute.InstanceTemplate{
+				// Newer, so it would win on timestamp alone if the cluster were not checked.
+				instanceTemplate("gke-other-cluster", "other", testPool, "2026-08-24T10:00:00.000-07:00"),
+				current,
+			},
+		}
+		p := fake.provider(t)
+
+		md, err := p.GetSourceTemplateMetadata(context.Background())
+		require.NoError(t, err)
+		require.True(t, namesCluster(md, testCluster))
+		require.Equal(t, "gke-current", templateName(p))
+	})
+
+	t.Run("errors when neither path finds a template", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool:  &container.NodePool{Name: testPool},
+			templates: []*compute.InstanceTemplate{instanceTemplate("gke-other", testCluster, "other-pool", "")},
+		}
+
+		_, err := fake.provider(t).GetSourceTemplateMetadata(context.Background())
+		require.ErrorContains(t, err, "no instance template found")
+	})
+
+	t.Run("errors when the source pool has not been discovered", func(t *testing.T) {
+		t.Parallel()
+		p := (&sourceTemplateFake{}).provider(t)
+		p.sourcePoolName = ""
+
+		_, err := p.GetSourceTemplateMetadata(context.Background())
+		require.ErrorContains(t, err, "not yet discovered")
+	})
+}
+
+func TestParseComputeResourceURL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		rawURL     string
+		collection string
+		want       computeResourceRef
+		wantErr    string
+	}{
+		{
+			name:       "zonal instance group manager",
+			rawURL:     migURL(testZone, "gke-cluster-pool-abcd1234-grp"),
+			collection: "instanceGroupManagers",
+			want:       computeResourceRef{project: testProject, scope: scopeZone, location: testZone, name: "gke-cluster-pool-abcd1234-grp"},
+		},
+		{
+			name:       "regional instance template",
+			rawURL:     regionalTemplateURL("gke-cluster-pool-abcd1234"),
+			collection: "instanceTemplates",
+			want:       computeResourceRef{project: testProject, scope: scopeRegion, location: testRegion, name: "gke-cluster-pool-abcd1234"},
+		},
+		{
+			name:       "global instance template",
+			rawURL:     globalTemplateURL("gke-cluster-pool-abcd1234"),
+			collection: "instanceTemplates",
+			want:       computeResourceRef{project: testProject, scope: scopeGlobal, name: "gke-cluster-pool-abcd1234"},
+		},
+		{
+			name:       "regional instance group manager",
+			rawURL:     fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/regions/%s/instanceGroupManagers/grp", testProject, testRegion),
+			collection: "instanceGroupManagers",
+			want:       computeResourceRef{project: testProject, scope: scopeRegion, location: testRegion, name: "grp"},
+		},
+		{
+			name:       "wrong collection",
+			rawURL:     migURL(testZone, "grp"),
+			collection: "instanceTemplates",
+			wantErr:    "does not name a instanceTemplates",
+		},
+		{
+			name:       "missing name",
+			rawURL:     fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instanceGroupManagers", testProject, testZone),
+			collection: "instanceGroupManagers",
+			wantErr:    "does not name a instanceGroupManagers",
+		},
+		{
+			name:       "unrecognized shape",
+			rawURL:     "https://www.googleapis.com/compute/v1/instanceTemplates/tmpl",
+			collection: "instanceTemplates",
+			wantErr:    "not a recognized instanceTemplates self-link",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseComputeResourceURL(tc.rawURL, tc.collection)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestNewerTemplate(t *testing.T) {
+	t.Parallel()
+	older := instanceTemplate("older", testCluster, testPool, "2026-08-20T12:00:00.000-04:00") // 16:00Z
+	// An hour later in absolute terms but lexicographically smaller: the case a string comparison
+	// of creationTimestamp gets wrong.
+	newer := instanceTemplate("newer", testCluster, testPool, "2026-08-20T10:00:00.000-07:00") // 17:00Z
+	undated := instanceTemplate("undated", testCluster, testPool, "")
+
+	require.Equal(t, newer, newerTemplate(older, newer))
+	require.Equal(t, newer, newerTemplate(newer, older))
+	require.Equal(t, older, newerTemplate(nil, older))
+	require.Equal(t, older, newerTemplate(older, nil))
+	require.Nil(t, newerTemplate(nil, nil))
+	require.Equal(t, older, newerTemplate(older, undated))
+	require.Equal(t, older, newerTemplate(undated, older))
+}

--- a/pkg/providers/nodepooltemplate/sourcetemplate_test.go
+++ b/pkg/providers/nodepooltemplate/sourcetemplate_test.go
@@ -84,6 +84,10 @@ type sourceTemplateFake struct {
 	templates []*compute.InstanceTemplate
 	// listOnly restricts the regional List endpoint to these templates. nil → all templates.
 	listOnly []*compute.InstanceTemplate
+	// templateGetStatus fails the per-template Get for these names, leaving List unaffected.
+	// That asymmetry is what lets a test tell "the chain gave up" apart from "the chain settled
+	// for whichever candidate happened to be readable".
+	templateGetStatus map[string]int
 }
 
 func (f *sourceTemplateFake) templateByName(name string) *compute.InstanceTemplate {
@@ -128,6 +132,10 @@ func (f *sourceTemplateFake) server(t *testing.T) *httptest.Server {
 			f.serveList(w, r)
 
 		case strings.Contains(path, "/instanceTemplates/"):
+			if status, ok := f.templateGetStatus[name]; ok {
+				w.WriteHeader(status)
+				return
+			}
 			template := f.templateByName(name)
 			if template == nil {
 				w.WriteHeader(http.StatusNotFound)
@@ -324,6 +332,49 @@ func TestGetSourceTemplateMetadata(t *testing.T) {
 		_, err := p.GetSourceTemplateMetadata(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, "gke-current", templateName(p))
+	})
+
+	// Two candidates exist precisely when a pool is mid-rollout, which is how a CA rotation is
+	// delivered — so the candidate that fails to read is as likely to be the new template as the
+	// old. Ranking whatever was readable and presenting it as an authoritative resolution is #577
+	// again through a narrower door, so any gap has to hand over to the label scan instead.
+	t.Run("gives up rather than ranking when a candidate template cannot be read", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool: &container.NodePool{Name: testPool, InstanceGroupUrls: []string{
+				migURL(testZone, "grp-a"), migURL("us-central1-b", "grp-b"),
+			}},
+			managers: map[string]*compute.InstanceGroupManager{
+				"grp-a": migOnTemplate(regionalTemplateURL("gke-stale")),
+				"grp-b": migOnTemplate(regionalTemplateURL("gke-current")),
+			},
+			// gke-stale stays readable, so settling for the survivor would resolve the stale one.
+			templateGetStatus: map[string]int{"gke-current": http.StatusInternalServerError},
+			templates:         []*compute.InstanceTemplate{stale, current},
+		}
+		p := fake.provider(t)
+
+		_, err := p.GetSourceTemplateMetadata(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "gke-current", templateName(p), "expected the label-scan fallback, not the readable stale candidate")
+	})
+
+	t.Run("gives up rather than ranking when an instance group cannot be read", func(t *testing.T) {
+		t.Parallel()
+		fake := &sourceTemplateFake{
+			nodePool: &container.NodePool{Name: testPool, InstanceGroupUrls: []string{
+				migURL(testZone, "grp-a"), migURL("us-central1-b", "grp-b"),
+			}},
+			// grp-b is absent, so it 404s: the group carrying the newer template is the one we
+			// cannot see, which is exactly when a partial candidate set misleads.
+			managers:  map[string]*compute.InstanceGroupManager{"grp-a": migOnTemplate(regionalTemplateURL("gke-stale"))},
+			templates: []*compute.InstanceTemplate{stale, current},
+		}
+		p := fake.provider(t)
+
+		_, err := p.GetSourceTemplateMetadata(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "gke-current", templateName(p), "expected the label-scan fallback, not the readable stale candidate")
 	})
 
 	// Regression for cloudpilot-ai/karpenter-provider-gcp#577: GKE leaves every superseded


### PR DESCRIPTION
- change nodepooltemplate to resolve the template based on the template currently associated with the selected nodepool, falling back to select the newest  template associated with the pool via listing the templates

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Additional labels (applied directly, not via /kind):
  dependencies  — dependency update PRs
  release-prep  — release preparation PRs (see RELEASE.md)
-->

#### What this PR does / why we need it:

This PR fixes #577 , prevents a scenario where new nodes cannot be added to the cluster

#### Related proposal (if applicable):
<!--
Link the proposal this PR implements, e.g. proposals/0001-short-title.md
Leave blank if this PR does not correspond to a design proposal.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #577 

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:








<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates bootstrap template discovery to follow the selected node pool’s managed instance groups and conservatively fall back to a newest-first label scan.
- Honors managed instance group `versions` over the top-level template.
- Abandons partial node-pool resolution when any group or template cannot be read.
- Adds coverage for rollouts, partial failures, pagination, regional/global templates, and timestamp ordering.
- Documents template resolution and credential-rotation troubleshooting.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pkg/providers/nodepooltemplate/sourcetemplate.go | Implements current-template resolution through node-pool MIGs, correctly honors version overrides, and prevents partial resolution from returning a stale candidate. |
| pkg/providers/nodepooltemplate/sourcetemplate_test.go | Adds comprehensive regression coverage for MIG version overrides, incomplete reads, fallback scanning, pagination, URL scopes, and timestamp ordering. |
| pkg/providers/nodepooltemplate/nodepooltemplate.go | Moves source-template resolution into the dedicated implementation and adds synchronized tracking for template-rotation logging. |
| docs/bootstrap-pool.md | Documents the preferred MIG-based resolution chain, degraded label-scan behavior, and credential-rotation diagnostics. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Selected GKE node pool] --> B[Read managed instance groups]
  B --> C[Collect templates from MIG versions or top-level template]
  C --> D{All groups and templates resolved?}
  D -->|Yes| E[Select newest named template]
  D -->|No| F[Scan regional templates by cluster and pool]
  F --> G[Select newest matching template]
  E --> H[Return bootstrap metadata]
  G --> H
```
</details>

<sub>Reviews (4): Last reviewed commit: ["select\_template: - resolve the template ..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/bfe40e58cebd2e8b4b97ab61ca4a724ede238bb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56619617)</sub>

<!-- /greptile_comment -->