### PR TITLE
fix(instance): allow GCE to select default disk type

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -590,8 +590,10 @@ func (p *DefaultProvider) renderDiskProperties(instanceType *cloudprovider.Insta
 	for i, disk := range disks {
 		// Create a new disk configuration for each disk to avoid sharing references
 		initParams := &compute.AttachedDiskInitializeParams{
-			DiskType:   fmt.Sprintf("projects/%s/zones/%s/diskTypes/%s", p.projectID, zone, disk.Category),
 			DiskSizeGb: int64(disk.SizeGiB),
+		}
+		if disk.Category != "" {
+			initParams.DiskType = fmt.Sprintf("projects/%s/zones/%s/diskTypes/%s", p.projectID, zone, disk.Category)
 		}
 		if disk.ProvisionedIOPS != nil {
 			initParams.ProvisionedIops = *disk.ProvisionedIOPS

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -663,6 +663,19 @@ func TestRenderDiskProperties_NoProvisioningWhenFieldsAreNil(t *testing.T) {
 	require.Zero(t, disks[0].InitializeParams.ProvisionedThroughput)
 }
 
+func TestRenderDiskProperties_OmitsEmptyDiskCategory(t *testing.T) {
+	t.Parallel()
+
+	p := &DefaultProvider{projectID: "my-project"}
+	nodeClass := bootDiskNodeClass("", nil, nil)
+
+	disks, err := p.renderDiskProperties(amd64InstanceType(), nodeClass, "us-central1-a")
+	require.NoError(t, err)
+
+	require.Len(t, disks, 1)
+	require.Empty(t, disks[0].InitializeParams.DiskType)
+}
+
 func TestRenderDiskProperties_SetsProvisionedIOPS(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`GCENodeClass.spec.disks[].category` is optional, but the instance renderer currently sends an invalid disk type URL when it is omitted. This change leaves `diskType` unset so Compute Engine selects the machine-series default.

GCP capacity shortages are often isolated to particular machine families. Allowing one NodePool and NodeClass to span Persistent Disk-only and Hyperdisk-only families gives Karpenter more capacity options without separate pools and node classes.

#### Related proposal (if applicable):

None.

#### Which issue(s) this PR fixes:

None.

#### Docs and examples

- [x] The API reference already documents `category` as optional.
- [x] This change requires no migration.

#### Special notes for your reviewer:

Validated one NodeClass across N2/N2D, C3/C3D, and N4/N4D. Compute Engine selected `pd-standard`, `pd-balanced`, and `hyperdisk-balanced` respectively.

Tests:
- `make ut-test`
- `./e2e/run make e2e-tests` — 31 passed, 1 GPU quota spec skipped


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes rendering for disks whose optional category is omitted by leaving `DiskType` unset, allowing Compute Engine to select the machine-series default.
- Conditionally renders the fully qualified disk type only when a category is provided.
- Adds a focused unit test confirming that an empty category results in an omitted disk type.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The change is confined to the instance provider’s disk rendering boundary, preserves explicit disk categories, and correctly delegates default disk selection to Compute Engine when the optional category is absent.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pkg/providers/instance/instance.go | Correctly avoids constructing an invalid disk-type URL from an empty optional category while preserving explicit category behavior. |
| pkg/providers/instance/instance_test.go | Adds focused coverage verifying that the renderer omits `DiskType` when the disk category is empty. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(instance): allow GCE to select defau..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/725940eb2478640c00cb7cc6d13677a45b11146d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59589562)</sub>

<!-- /greptile_comment -->