### PR TITLE
Document omitting disk category for machine-family default disk types

### DIFF
--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -206,6 +206,30 @@ spec:
 
 This NodePool provisions only instance types from families that support Hyperdisk Balanced (such as n2, n4, c3, c4). Instance types from families without Hyperdisk Balanced support (such as e2, n1) are excluded.
 
+### Spanning machine families with default disk types
+
+The `category` field in a `spec.disks[]` entry is optional. When you omit it, Karpenter leaves the disk type unset and Compute Engine applies the machine-family default disk type for whichever family it provisions. When `category` is set, behavior is unchanged: Karpenter uses the disk type you specify.
+
+GCP capacity shortages are often isolated to specific machine families. Omitting `category` lets one GCENodeClass (and the NodePool that references it) span families that support different disk technologies, both persistent disk families and Hyperdisk families. This widens capacity options without requiring a separate GCENodeClass or NodePool per family. The default varies by family. For example:
+
+- **N2, N2D** — default to a persistent disk type such as `pd-standard`
+- **C3, C3D** — default to `pd-balanced`
+- **N4, N4D** — default to `hyperdisk-balanced`
+
+These illustrate GCE's per-family defaults, not a complete or Karpenter-owned mapping; see the [GCP machine family disk support matrix](https://cloud.google.com/compute/docs/disks#disk-types) for which families support which disk types.
+
+> **Note:** Because each family falls back to its own default disk type, nodes in a single NodePool can end up with different disk types, which differ in performance and cost. For performance-sensitive workloads, set `category` explicitly — optionally combined with the `disk-type.gke.io/*` requirement labels — rather than relying on the per-family default.
+
+The following fragment shows the `spec.disks` portion of a GCENodeClass with `category` omitted. It is partial: `disks` nests directly under `spec`, and you supply the rest of a valid GCENodeClass (for example `imageSelectorTerms`) — see the [quick start](../getting-started/quick-start.md) for a complete manifest. The `boot: true` entry here is just a typical boot-disk entry; omitting `category` works the same on any `disks[]` entry, boot or not.
+
+```yaml
+disks:
+  - sizeGiB: 60
+    boot: true
+```
+
+This is the GCENodeClass-side complement to the NodePool `disk-type.gke.io/*` requirements described above. Those requirement labels constrain only which instance types Karpenter selects (see [Constraining instance types by disk support](#constraining-instance-types-by-disk-support)); they do not pin the disk type GCE attaches when `category` is unset. To guarantee a specific applied disk type, set `category` explicitly. For the full `disks[]` field spec, see the [GCENodeClass reference](../reference/gcenodeclass.md).
+
 ### Available disk-type labels
 
 The supported labels correspond to GCP disk types:


### PR DESCRIPTION
[Open in Promptless](<https://app.gopromptless.ai/suggestions/5b66ae41-5849-4636-98c6-b54fbd3a7879>)

The `Disk type scheduling` guide in `docs/examples/advanced.md` explained how to constrain instance types with `disk-type.gke.io/*` NodePool requirement labels, but did not cover the GCENodeClass-side control: leaving `spec.disks[].category` unset. This adds a "Spanning machine families with default disk types" subsection documenting that `category` is optional and that omitting it lets Compute Engine apply each machine family's default disk type. That lets a single GCENodeClass and NodePool span Persistent Disk families and Hyperdisk families — useful because GCP capacity shortages are often isolated to particular machine families — without maintaining a separate node class or pool per family. The subsection includes a partial `spec.disks` example that omits `category`, illustrative per-family defaults, a note on the resulting per-node disk-type performance/cost variance, and guidance to set `category` explicitly when a workload needs a specific disk type.

**Trigger Events**
- [GitHub PR #585: fix(instance): allow GCE to select default disk type](https://github.com/cloudpilot-ai/karpenter-provider-gcp/pull/585)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents how omitting a GCENodeClass disk category delegates disk-type selection to Compute Engine, allowing a NodePool to span machine families with different disk technologies.
- Adds illustrative machine-family defaults and warns about performance and cost variance.
- Adds a partial disk configuration and explains how omission interacts with disk-support scheduling labels.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking documentation gap around provisioned-performance disk configurations.

The core category-omission behavior matches the implementation, but users combining omission with provisioned IOPS or throughput can receive admission failures that the new guidance does not explain.

**Files Needing Attention:** docs/examples/advanced.md
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/examples/advanced.md | Adds useful default-disk guidance, but omits the validation restriction for disks that specify provisioned IOPS or throughput. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20cloudpilot-ai%2Fkarpenter-provider-gcp%20PR%20%23586%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=586&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Adocs%2Fexamples%2Fadvanced.md%3A211%0A**Document%20provisioned%20performance%20restriction**%0A%0AThe%20guidance%20presents%20%60category%60%20omission%20as%20generally%20available%2C%20but%20a%20disk%20that%20also%20specifies%20%60provisionedIOPS%60%20or%20%60provisionedThroughput%60%20requires%20a%20compatible%20explicit%20category.%20Without%20that%20qualification%2C%20users%20can%20follow%20this%20section%20and%20have%20their%20GCENodeClass%20rejected%20during%20admission.%0A%0A%60%60%60suggestion%0AThe%20%60category%60%20field%20in%20a%20%60spec.disks%5B%5D%60%20entry%20is%20optional.%20When%20you%20omit%20it%2C%20Karpenter%20leaves%20the%20disk%20type%20unset%20and%20Compute%20Engine%20applies%20the%20machine-family%20default%20disk%20type%20for%20whichever%20family%20it%20provisions.%20When%20%60category%60%20is%20set%2C%20behavior%20is%20unchanged%3A%20Karpenter%20uses%20the%20disk%20type%20you%20specify.%20Disks%20that%20specify%20%60provisionedIOPS%60%20or%20%60provisionedThroughput%60%20still%20require%20an%20explicit%20compatible%20%60category%60.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=586&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adocs%2Fexamples%2Fadvanced.md%3A211%0A**Document%20provisioned%20performance%20restriction**%0A%0AThe%20guidance%20presents%20%60category%60%20omission%20as%20generally%20available%2C%20but%20a%20disk%20that%20also%20specifies%20%60provisionedIOPS%60%20or%20%60provisionedThroughput%60%20requires%20a%20compatible%20explicit%20category.%20Without%20that%20qualification%2C%20users%20can%20follow%20this%20section%20and%20have%20their%20GCENodeClass%20rejected%20during%20admission.%0A%0A%60%60%60suggestion%0AThe%20%60category%60%20field%20in%20a%20%60spec.disks%5B%5D%60%20entry%20is%20optional.%20When%20you%20omit%20it%2C%20Karpenter%20leaves%20the%20disk%20type%20unset%20and%20Compute%20Engine%20applies%20the%20machine-family%20default%20disk%20type%20for%20whichever%20family%20it%20provisions.%20When%20%60category%60%20is%20set%2C%20behavior%20is%20unchanged%3A%20Karpenter%20uses%20the%20disk%20type%20you%20specify.%20Disks%20that%20specify%20%60provisionedIOPS%60%20or%20%60provisionedThroughput%60%20still%20require%20an%20explicit%20compatible%20%60category%60.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=586&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22cloudpilot-ai%2Fkarpenter-provider-gcp%22%20on%20the%20existing%20branch%20%22promptless%2Fpr585-optional-disk-category%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22promptless%2Fpr585-optional-disk-category%22.%0A%0A%23%23%23%20Issue%201%0Adocs%2Fexamples%2Fadvanced.md%3A211%0A**Document%20provisioned%20performance%20restriction**%0A%0AThe%20guidance%20presents%20%60category%60%20omission%20as%20generally%20available%2C%20but%20a%20disk%20that%20also%20specifies%20%60provisionedIOPS%60%20or%20%60provisionedThroughput%60%20requires%20a%20compatible%20explicit%20category.%20Without%20that%20qualification%2C%20users%20can%20follow%20this%20section%20and%20have%20their%20GCENodeClass%20rejected%20during%20admission.%0A%0A%60%60%60suggestion%0AThe%20%60category%60%20field%20in%20a%20%60spec.disks%5B%5D%60%20entry%20is%20optional.%20When%20you%20omit%20it%2C%20Karpenter%20leaves%20the%20disk%20type%20unset%20and%20Compute%20Engine%20applies%20the%20machine-family%20default%20disk%20type%20for%20whichever%20family%20it%20provisions.%20When%20%60category%60%20is%20set%2C%20behavior%20is%20unchanged%3A%20Karpenter%20uses%20the%20disk%20type%20you%20specify.%20Disks%20that%20specify%20%60provisionedIOPS%60%20or%20%60provisionedThroughput%60%20still%20require%20an%20explicit%20compatible%20%60category%60.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=cloudpilot-ai%2Fkarpenter-provider-gcp&pr=586&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(examples): document omitting disk c..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/8b56658eae71e4ccd9e06dea97a3bd6c21e8c2c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59858145)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->