### PR TITLE
fix(instance): preserve GCE capacity error context

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -73,6 +73,13 @@ var InsufficientCapacityErrorCodes = sets.NewString(
 	"IP_SPACE_EXHAUSTED",
 )
 
+type insufficientCapacityDetails struct {
+	code             string
+	structuredReason string
+	message          string
+	operation        string
+}
+
 type Provider interface {
 	Create(context.Context, *v1alpha1.GCENodeClass, *karpv1.NodeClaim, []*cloudprovider.InstanceType) (*Instance, error)
 	Get(context.Context, string) (*Instance, error)
@@ -175,15 +182,11 @@ func waitForNextTick(ctx context.Context, ticker *time.Ticker) error {
 }
 
 func (p *DefaultProvider) handleZoneOperationError(ctx context.Context, op *compute.Operation, instanceType, zone, capacityType string) error {
-	capacityError, found := lo.Find(op.Error.Errors, isInsufficientCapacityError)
+	details, found := extractOperationInsufficientCapacityDetails(op)
 	if found {
-		reason := capacityError.Message
-		if reason == "" {
-			reason = capacityError.Code
-		}
-		ttl := insufficientCapacityBackoffTTL(capacityError.Code)
-		p.unavailableOfferings.MarkUnavailableWithTTL(ctx, reason, instanceType, zone, capacityType, ttl)
-		return cloudprovider.NewInsufficientCapacityError(fmt.Errorf("zone %s insufficient capacity: %s", zone, reason))
+		ttl := insufficientCapacityBackoffTTL(details.code)
+		p.unavailableOfferings.MarkUnavailableWithTTL(ctx, details.message, instanceType, zone, capacityType, ttl)
+		return newInsufficientCapacityError(instanceType, zone, capacityType, ttl, details)
 	}
 
 	errorMsgs := lo.Map(op.Error.Errors, func(e *compute.OperationErrorErrors, _ int) string {
@@ -207,23 +210,74 @@ func isInsufficientCapacityError(operationError *compute.OperationErrorErrors) b
 	return InsufficientCapacityErrorCodes.Has(operationError.Code)
 }
 
-func extractInsertInsufficientCapacityReason(err error) (string, string, bool) {
+func extractOperationInsufficientCapacityDetails(op *compute.Operation) (insufficientCapacityDetails, bool) {
+	if op == nil || op.Error == nil {
+		return insufficientCapacityDetails{}, false
+	}
+
+	capacityError, found := lo.Find(op.Error.Errors, isInsufficientCapacityError)
+	if !found {
+		return insufficientCapacityDetails{}, false
+	}
+
+	details := insufficientCapacityDetails{
+		code:      capacityError.Code,
+		message:   capacityError.Message,
+		operation: op.Name,
+	}
+	for _, detail := range capacityError.ErrorDetails {
+		if detail == nil {
+			continue
+		}
+		if details.structuredReason == "" && detail.ErrorInfo != nil {
+			details.structuredReason = detail.ErrorInfo.Reason
+		}
+		if detail.LocalizedMessage != nil && detail.LocalizedMessage.Message != "" {
+			details.message = detail.LocalizedMessage.Message
+		}
+	}
+	if details.message == "" {
+		details.message = details.code
+	}
+	return details, true
+}
+
+func extractInsertInsufficientCapacityDetails(err error) (insufficientCapacityDetails, bool) {
 	var apiError *googleapi.Error
 	if !errors.As(err, &apiError) {
-		return "", "", false
+		return insufficientCapacityDetails{}, false
 	}
 
 	for _, detail := range apiError.Errors {
 		if InsufficientCapacityErrorCodes.Has(detail.Reason) {
-			reason := detail.Message
-			if reason == "" {
-				reason = detail.Reason
+			message := detail.Message
+			if message == "" {
+				message = detail.Reason
 			}
-			return reason, detail.Reason, true
+			return insufficientCapacityDetails{
+				code:             detail.Reason,
+				structuredReason: detail.Reason,
+				message:          message,
+			}, true
 		}
 	}
 
-	return "", "", false
+	return insufficientCapacityDetails{}, false
+}
+
+func newInsufficientCapacityError(instanceType, zone, capacityType string, ttl time.Duration, details insufficientCapacityDetails) error {
+	gceDetails := []string{}
+	if details.structuredReason != "" && details.structuredReason != details.code {
+		gceDetails = append(gceDetails, "reason="+details.structuredReason)
+	}
+	if details.operation != "" {
+		gceDetails = append(gceDetails, "op="+details.operation)
+	}
+	gceDetails = append(gceDetails, "code="+details.code)
+	return cloudprovider.NewInsufficientCapacityError(fmt.Errorf(
+		"%s %s/%s unavailable %s (%s): %s",
+		instanceType, capacityType, zone, ttl, strings.Join(gceDetails, ", "), details.message,
+	))
 }
 
 func insufficientCapacityBackoffTTL(reasonCode string) time.Duration {
@@ -351,10 +405,6 @@ func (p *DefaultProvider) Create(ctx context.Context, nodeClass *v1alpha1.GCENod
 	}
 
 	joined := errors.Join(errs...)
-	if lo.SomeBy(errs, cloudprovider.IsInsufficientCapacityError) {
-		return nil, cloudprovider.NewInsufficientCapacityError(fmt.Errorf("failed to create instance after trying all instance types: %w", joined))
-	}
-
 	return nil, fmt.Errorf("failed to create instance after trying all instance types: %w", joined)
 }
 
@@ -414,18 +464,15 @@ func (p *DefaultProvider) getOrCreateInstance(ctx context.Context, nodeClaim *ka
 	}
 	op, err := p.computeService.Instances.Insert(p.projectID, zone, instance).Context(ctx).Do()
 	if err != nil {
-		reason, reasonCode, insufficient := extractInsertInsufficientCapacityReason(err)
+		details, insufficient := extractInsertInsufficientCapacityDetails(err)
 		if insufficient {
-			if reason == "" {
-				reason = "insufficient capacity"
-			}
-			ttl := insufficientCapacityBackoffTTL(reasonCode)
-			p.unavailableOfferings.MarkUnavailableWithTTL(ctx, reason, instanceType.Name, zone, capacityType, ttl)
-			err = cloudprovider.NewInsufficientCapacityError(fmt.Errorf("zone %s insufficient capacity: %s", zone, reason))
+			ttl := insufficientCapacityBackoffTTL(details.code)
+			p.unavailableOfferings.MarkUnavailableWithTTL(ctx, details.message, instanceType.Name, zone, capacityType, ttl)
+			err = newInsufficientCapacityError(instanceType.Name, zone, capacityType, ttl, details)
 
 			// If IP space is exhausted, trying other instance types won't help as they share the same subnet.
 			// We should fail fast to avoid unnecessary API calls and noise.
-			if reasonCode == "IP_SPACE_EXHAUSTED" || reasonCode == "IP_SPACE_EXHAUSTED_WITH_DETAILS" {
+			if details.code == "IP_SPACE_EXHAUSTED" || details.code == "IP_SPACE_EXHAUSTED_WITH_DETAILS" {
 				return nil, false, err
 			}
 		}

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -72,36 +72,126 @@ func TestIsInsufficientCapacityErrorNonMatching(t *testing.T) {
 	require.False(t, isInsufficientCapacityError(entry))
 }
 
-func TestExtractInsertInsufficientCapacityReasonMatchesReason(t *testing.T) {
+func TestExtractOperationInsufficientCapacityDetails(t *testing.T) {
 	t.Parallel()
 
-	reason, code, ok := extractInsertInsufficientCapacityReason(&googleapi.Error{
+	details, ok := extractOperationInsufficientCapacityDetails(&compute.Operation{
+		Name: "operation-123",
+		Error: &compute.OperationError{
+			Errors: []*compute.OperationErrorErrors{{
+				Code:    "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+				Message: "generic capacity message",
+				ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
+					{LocalizedMessage: &compute.LocalizedMessage{Message: "localized capacity message"}},
+					{ErrorInfo: &compute.ErrorInfo{Reason: "resource_availability"}},
+				},
+			}},
+		},
+	})
+
+	require.True(t, ok)
+	require.Equal(t, insufficientCapacityDetails{
+		code:             "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+		structuredReason: "resource_availability",
+		message:          "localized capacity message",
+		operation:        "operation-123",
+	}, details)
+}
+
+func TestExtractOperationInsufficientCapacityDetailsFallsBackToCode(t *testing.T) {
+	t.Parallel()
+
+	details, ok := extractOperationInsufficientCapacityDetails(&compute.Operation{
+		Name: "operation-123",
+		Error: &compute.OperationError{
+			Errors: []*compute.OperationErrorErrors{{
+				Code: "ZONE_RESOURCE_POOL_EXHAUSTED",
+			}},
+		},
+	})
+
+	require.True(t, ok)
+	require.Equal(t, "ZONE_RESOURCE_POOL_EXHAUSTED", details.message)
+	require.Empty(t, details.structuredReason)
+}
+
+func TestExtractInsertInsufficientCapacityDetailsMatchesReason(t *testing.T) {
+	t.Parallel()
+
+	details, ok := extractInsertInsufficientCapacityDetails(&googleapi.Error{
 		Errors: []googleapi.ErrorItem{{Reason: "IP_SPACE_EXHAUSTED_WITH_DETAILS"}},
 	})
 
 	require.True(t, ok)
-	require.Equal(t, "IP_SPACE_EXHAUSTED_WITH_DETAILS", reason)
-	require.Equal(t, "IP_SPACE_EXHAUSTED_WITH_DETAILS", code)
+	require.Equal(t, insufficientCapacityDetails{
+		code:             "IP_SPACE_EXHAUSTED_WITH_DETAILS",
+		structuredReason: "IP_SPACE_EXHAUSTED_WITH_DETAILS",
+		message:          "IP_SPACE_EXHAUSTED_WITH_DETAILS",
+	}, details)
 }
 
-func TestExtractInsertInsufficientCapacityReasonRequiresStructuredReason(t *testing.T) {
+func TestExtractInsertInsufficientCapacityDetailsRequiresStructuredReason(t *testing.T) {
 	t.Parallel()
 
-	reason, code, ok := extractInsertInsufficientCapacityReason(&googleapi.Error{
+	details, ok := extractInsertInsufficientCapacityDetails(&googleapi.Error{
 		Message: "some failure IP_SPACE_EXHAUSTED for range",
 	})
 
 	require.False(t, ok)
-	require.Empty(t, reason)
-	require.Empty(t, code)
+	require.Empty(t, details)
 }
 
-func TestExtractInsertInsufficientCapacityReasonNonMatching(t *testing.T) {
+func TestExtractInsertInsufficientCapacityDetailsNonMatching(t *testing.T) {
 	t.Parallel()
 
-	_, _, ok := extractInsertInsufficientCapacityReason(&googleapi.Error{Message: "some other issue"})
+	_, ok := extractInsertInsufficientCapacityDetails(&googleapi.Error{Message: "some other issue"})
 
 	require.False(t, ok)
+}
+
+func TestHandleZoneOperationErrorIncludesCapacityContext(t *testing.T) {
+	t.Parallel()
+
+	const operation = "operation-1788548040491-65aacca9e01b7-9614bc69-e30ce63a"
+	unavailable := unavailableofferings.NewUnavailableOfferings()
+	p := &DefaultProvider{unavailableOfferings: unavailable}
+	err := p.handleZoneOperationError(context.Background(), &compute.Operation{
+		Name: operation,
+		Error: &compute.OperationError{
+			Errors: []*compute.OperationErrorErrors{{
+				Code:    "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+				Message: "generic capacity message",
+				ErrorDetails: []*compute.OperationErrorErrorsErrorDetails{
+					{LocalizedMessage: &compute.LocalizedMessage{Message: "localized capacity message"}},
+					{ErrorInfo: &compute.ErrorInfo{Reason: "resource_availability"}},
+				},
+			}},
+		},
+	}, "z3-highmem-8-highlssd", "us-east4-a", karpv1.CapacityTypeOnDemand)
+
+	require.True(t, cloudprovider.IsInsufficientCapacityError(err))
+	require.ErrorContains(t, err, "insufficient capacity, z3-highmem-8-highlssd on-demand/us-east4-a unavailable 30m0s")
+	require.ErrorContains(t, err, "reason=resource_availability, op="+operation+", code=ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS")
+	require.ErrorContains(t, err, "localized capacity message")
+	require.True(t, unavailable.IsUnavailable("z3-highmem-8-highlssd", "us-east4-a", karpv1.CapacityTypeOnDemand))
+
+	wrappedErr := fmt.Errorf("creating instance, failed to create instance after trying all instance types: %w", err)
+	require.True(t, cloudprovider.IsInsufficientCapacityError(wrappedErr))
+	wrapped := wrappedErr.Error()
+	if len(wrapped) > 300 {
+		wrapped = wrapped[:300]
+	}
+	for _, field := range []string{
+		"z3-highmem-8-highlssd",
+		"on-demand",
+		"us-east4-a",
+		"30m0s",
+		"ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+		"resource_availability",
+		operation,
+	} {
+		require.Contains(t, wrapped, field)
+	}
 }
 
 func TestInsufficientCapacityBackoffTTLForIPSpace(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

Karpenter truncates NodeClaim error messages at 300 bytes. Capacity failures currently spend much of that budget on repeated error prefixes and omit the instance type, capacity type, backoff, GCE error code, structured reason, and operation ID.

Put offering context and GCE details before the free-form message, remove redundant insufficient-capacity wrapping, and prefer GCE's localized explanation when available. The existing NodeClaim Event and controller logs expose the improved error. The existing `Marking offering as unavailable` log also uses the localized explanation.

These are real before/after messages from GCE capacity failures. Identifiers are redacted and lines are wrapped for readability. The `...` endings in the Event examples were emitted by Karpenter, not added to shorten the examples.

**Karpenter controller logs**

The `error` field of `message="failed launching nodeclaim"`:

Before:

```text
creating instance, insufficient capacity, failed to create instance after
trying all instance types: insufficient capacity, zone us-east4-a
insufficient capacity: The zone 'projects/<project-id>/zones/us-east4-a'
does not have enough resources available to fulfill the request.
'NULL:0/NULL:0/NULL:0 (state:STOCKOUT, sub-state:STOCKOUT, resource type:compute)'.
```

After:

```text
creating instance, failed to create instance after trying all instance
types: insufficient capacity, z3-highmem-8-highlssd on-demand/us-east4-a
unavailable 30m0s (reason=resource_availability, op=<operation-id>,
code=ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS): A z3-highmem-8-highlssd
VM instance with 1 local SSD(s) is currently unavailable in the us-east4-a
zone. Consider trying your request in the us-east4-c zone(s), which
currently has capacity to accommodate your request. Alternatively, you
can try your request again with a different VM hardware configuration or
at a later time. For more information, see the troubleshooting documentation.
```

**NodeClaim Events captured by EventRouter**

The `message` field; `type=Warning` and `reason=InsufficientCapacityError` are unchanged:

Before:

```text
NodeClaim <nodeclaim> event: creating instance, insufficient capacity,
failed to create instance after trying all instance types: insufficient
capacity, zone us-east4-a insufficient capacity: The zone
'projects/<project-id>/zones/us-east4-a' does not have enough resources
available to fulfill the request.  'NULL:0/NULL:0...
```

After:

```text
NodeClaim <nodeclaim> event: creating instance, failed to create instance
after trying all instance types: insufficient capacity,
z3-highmem-8-highlssd on-demand/us-east4-a unavailable 30m0s
(reason=resource_availability, op=<operation-id>,
code=ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS)...
```

The complete operation ID and error code survived truncation in the captured Event; the operation ID above was redacted after capture. GCE's alternative-zone advice is a point-in-time suggestion, not a capacity guarantee.

**Related proposal (if applicable):**

None.

**Which issue(s) this PR fixes:**

No linked issue.

**Docs and examples**

No configuration, API, or migration changes. No documentation updates are needed.

**Special notes for your reviewer:**

Diagnostics only: error classification, offering-cache keys and TTLs, retry behavior, and NodeClaim lifecycle are unchanged. No new events or metrics.

Validated with live stockouts in three zones. `go test ./pkg/...`, `go vet ./pkg/providers/instance`, and diff checks pass under the repository's Go 1.26.6 toolchain. Targeted lint reports the existing `gocyclo` violation in unchanged `metadata_bootstrap.go:82` (`applyNodeClassKubeletConfig`, complexity 12 > 11).


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enriches GCE insufficient-capacity errors while preserving their existing classification and offering-backoff behavior.

- Extracts the GCE error code, structured reason, localized message, and operation ID.
- Places offering and structured GCE context before free-form text so it survives Karpenter’s message truncation.
- Removes a redundant insufficient-capacity wrapper while retaining error-chain classification.
- Adds focused coverage for extraction, fallback formatting, cache marking, and truncated diagnostic context.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations were identified.

Capacity failures remain discoverable through the wrapped and joined error chain, and the unavailable-offering key, expiry, classification, and retry paths are unchanged while diagnostics gain additional context.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pkg/providers/instance/instance.go | Refactors insufficient-capacity extraction and formatting while preserving cache identity, TTL selection, classification, and retry behavior. |
| pkg/providers/instance/instance_test.go | Adds focused tests for structured GCE details, localized-message fallback, offering unavailability, error classification, and 300-byte diagnostic retention. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    GCE[GCE insert or zone-operation failure] --> X[Extract capacity details]
    X --> C[Classify by structured error code]
    C --> U[Mark instance type / capacity type / zone unavailable]
    C --> E[Build context-rich insufficient-capacity error]
    E --> K[Karpenter error chain and NodeClaim event]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(instance): preserve GCE capacity err..."](https://github.com/cloudpilot-ai/karpenter-provider-gcp/commit/924bdc67f45a19c1cdd4588068fde200daaa0966) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60607548)</sub>

**Context used:**

- Knowledge Base — [GCP provisioning integration](https://app.greptile.com/karpenter-provider-gcp/-/custom-context/knowledge-base/cloudpilot-ai/karpenter-provider-gcp/-/docs/gcp-provisioning-integration.md)
- Knowledge Base — [Compute instance lifecycle and bootstrap](https://app.greptile.com/karpenter-provider-gcp/-/custom-context/knowledge-base/cloudpilot-ai/karpenter-provider-gcp/-/docs/compute-instance-lifecycle.md)

<!-- /greptile_comment -->