### PR TITLE
docs: add planetscale to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -12,3 +12,4 @@ If you are using the Karpenter GCP Cloud Provider and would like to be listed he
 | --- | --- |
 | [BEAT81](https://www.beat81.com) | The Karpenter GCP Cloud Provider is the core of their autoscaling. They run Spot instances for cost efficiency and provision dedicated nodes for mission-critical workloads. |
 | [CloudPilot AI](https://www.cloudpilot.ai/en/) | CloudPilot AI leverages the Karpenter GCP Provider to provision and balance Spot and on-demand instances, maximizing cloud cost savings while maintaining workload stability. |
+| [PlanetScale](https://planetscale.com/) | PlanetScale uses the Karpenter GCP Cloud Provider to dynamically scale their database infrastructure, ensuring optimal performance and cost efficiency for their global user base. |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Additional labels (applied directly, not via /kind):
  dependencies  — dependency update PRs
  release-prep  — release preparation PRs (see RELEASE.md)
-->

#### What this PR does / why we need it:

@planetscale has adopted karpenter-gcp

#### Related proposal (if applicable):
<!--
Link the proposal this PR implements, e.g. proposals/0001-short-title.md
Leave blank if this PR does not correspond to a design proposal.
-->

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
none

#### Docs and examples

- [x] `docs/` and `examples/` updated (or this PR does not affect user-facing behaviour, configuration, or APIs)
- [x] `MIGRATION.md` updated (or this PR does not require any migration steps)

#### Special notes for your reviewer:




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62156878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/karpenter-provider-gcp/-/pull-requests/cloudpilot-ai/karpenter-provider-gcp/598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only change appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Adds one entry to the existing adopters table.
- Does not change application code, configuration, dependencies, or runtime behavior.
</details>

<!-- /greptile_comment -->