### PR TITLE
docs: compare Karpenter with GKE ComputeClasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ Karpenter observes the aggregate resource requests of unscheduled pods and makes
   </p>
 </div>
 
+## Karpenter and GKE ComputeClasses
+
+Karpenter and [GKE custom ComputeClasses](https://cloud.google.com/kubernetes-engine/docs/concepts/about-custom-compute-classes) both provide workload-driven compute. ComputeClasses offer a GKE-managed way to describe preferred capacity, while Karpenter provides an open and extensible provisioning layer with direct control over compute selection and node lifecycle.
+
+Choose Karpenter when extensibility and infrastructure control matter:
+
+* **Extensible by design** — Karpenter's controller and cloud-provider architecture can be extended with new provisioning, scheduling, pricing, lifecycle, and repair capabilities. Teams can evolve the provisioner with their platform instead of waiting for those capabilities to become available in a specific GKE release.
+* **A consistent multi-cloud model** — Karpenter uses the same core `NodePool` and `NodeClaim` APIs and operational model across AWS, Azure, and GCP. Provider-specific settings remain in each `NodeClass`, while shared policies, automation, and tooling can follow the same pattern. This reduces friction for multi-cloud platforms and future cloud migrations.
+* **Direct, workload-aware provisioning** — Karpenter evaluates native pod requests and scheduling constraints, bin-packs pending workloads, and directly creates the best-fitting GCE VM for each decision. This removes the managed node pool as a provisioning layer and avoids maintaining a node pool for every capacity shape.
+
+GKE ComputeClasses are a good fit when fully managed GKE integration, especially Autopilot, is the primary goal. For platform teams that expect to customize autoscaling, operate across clouds, or retain deeper control over infrastructure decisions, Karpenter provides the more adaptable foundation. Karpenter Provider for GCP currently targets GKE Standard clusters.
+
 
 ## Managed optimization for production Kubernetes
 


### PR DESCRIPTION
## Summary

- compare Karpenter Provider for GCP with GKE custom ComputeClasses
- highlight Karpenter extensibility and its consistent multi-cloud operating model
- explain direct, workload-aware GCE VM provisioning without a managed node pool layer
- clarify when GKE ComputeClasses remain a good fit

## Testing

- `make ci`

## Review notes

- Full golangci-lint reports an existing complexity warning in `pkg/providers/instance/metadata_bootstrap.go`; this documentation-only change does not modify that code.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62189576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/karpenter-provider-gcp/-/pull-requests/cloudpilot-ai/karpenter-provider-gcp/599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The documentation-only PR appears safe to merge.

<details><summary><h3>Summary</h3></summary>

- Describes Karpenter’s extensibility and common multi-cloud API model.
- Explains direct, workload-aware GCE VM provisioning.
- Positions ComputeClasses for managed GKE use cases and clearly limits this provider to GKE Standard clusters.
</details>

<!-- /greptile_comment -->